### PR TITLE
Adjust light theme nav and strategy buttons

### DIFF
--- a/assets/strategy.css
+++ b/assets/strategy.css
@@ -56,8 +56,8 @@ body.page-strategy .hero p{
   margin-right:auto;
 }
 
-/* Buttons – override site buttons only on this page */
-body.page-strategy .btn{
+/* Buttons – override site buttons only within page content */
+body.page-strategy main .btn{
   appearance:none;
   border:1px solid var(--line);
   background:var(--panel);
@@ -68,12 +68,12 @@ body.page-strategy .btn{
   box-shadow:var(--shadow);
   transition:.15s transform,.15s box-shadow;
 }
-body.page-strategy .btn:hover{ transform:translateY(-1px); }
-body.page-strategy .btn.primary{
+body.page-strategy main .btn:hover{ transform:translateY(-1px); }
+body.page-strategy main .btn.primary{
   background:linear-gradient(135deg,var(--accent),var(--accent-2));
   color:#001024; border:0;
 }
-body.page-strategy .btn.ghost{ background:transparent; border-color:var(--line); color:var(--ink); }
+body.page-strategy main .btn.ghost{ background:transparent; border-color:var(--line); color:var(--ink); }
 
 /* Metrics row (center the four chips) */
 body.page-strategy .tag{

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -361,6 +361,22 @@ body.theme-light .site-footer {
   border-color: var(--border);
 }
 
+/* Light theme navigation readability */
+body.theme-light .nav a {
+  color: var(--text);
+}
+
+body.theme-light .nav a:hover,
+body.theme-light .nav a:focus-visible {
+  color: color-mix(in srgb, var(--text) 85%, var(--accent) 15%);
+}
+
+body.theme-light .nav a.active,
+body.theme-light .nav a.active:hover,
+body.theme-light .nav a.active:focus-visible {
+  color: var(--danger);
+}
+
 /* Default buttons look like soft pills in light mode */
 body.theme-light .btn:not(.primary):not(.ghost):not(.danger) {
   background: var(--card);


### PR DESCRIPTION
## Summary
- ensure light theme navigation links use body text color with a red active state for better contrast
- scope strategy page button overrides to main content so header buttons keep the global styling

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68cd4ab84280832db108d82bdc136f0e