### PR TITLE
Limit public universe and portfolio access

### DIFF
--- a/assets/portfolio.css
+++ b/assets/portfolio.css
@@ -71,6 +71,7 @@ body.page-portfolio .pill{
 }
 body.page-portfolio .pill.live{ color: var(--ok); border-color: color-mix(in oklab, var(--ok) 50%, var(--line)); }
 body.page-portfolio .pill.experimental{ color: var(--warn); border-color: color-mix(in oklab, var(--warn) 50%, var(--line)); }
+body.page-portfolio .pill.patreon{ color: var(--accent); border-color: color-mix(in oklab, var(--accent) 45%, var(--line)); }
 
 body.page-portfolio .mini-chart{
   width:100%; height:120px; display:block;
@@ -107,6 +108,31 @@ body.page-portfolio table.preview td{
   font-size: 14px;
 }
 body.page-portfolio table.preview tr:last-child td{ border-bottom:none; }
+
+body.page-portfolio .p-card.paywall-card{
+  display:grid;
+  gap:12px;
+  cursor:default;
+}
+body.page-portfolio .p-card.paywall-card .paywall-copy{
+  margin:0;
+  color:var(--muted-local);
+}
+body.page-portfolio .p-card.paywall-card .paywall-note{
+  margin:0;
+  font-size:13px;
+  color:var(--muted-local);
+}
+body.page-portfolio .p-card.paywall-card .paywall-list{
+  margin:0;
+  padding-left:18px;
+  color:var(--muted-local);
+}
+body.page-portfolio .p-card.paywall-card .paywall-actions{
+  display:flex;
+  gap:10px;
+  flex-wrap:wrap;
+}
 
 /* ===== Modal ===== */
 body.page-portfolio .pf-modal{

--- a/portfolio.html
+++ b/portfolio.html
@@ -152,6 +152,23 @@
           <tbody></tbody>
         </table>
       </article>
+
+      <article id="portfolioPaywall" class="p-card paywall-card" hidden>
+        <header class="p-head">
+          <h3>Unlock the full portfolio suite</h3>
+          <span class="pill patreon">Membership</span>
+        </header>
+        <p id="portfolioPaywallMsg" class="paywall-copy">Join FutureFunds.ai to unlock every live portfolio, performance chart, and holdings table.</p>
+        <p id="portfolioPaywallPreview" class="paywall-note">Preview shows 0 of 0 portfolios.</p>
+        <ul class="paywall-list">
+          <li>Access automated performance tracking and drawdown stats.</li>
+          <li>See every holding, weight, and trade note in real time.</li>
+        </ul>
+        <div class="paywall-actions">
+          <a class="btn primary" href="/membership.html">View membership plans</a>
+          <button class="btn" type="button" data-lock-secondary data-open-auth="signup">Sign up</button>
+        </div>
+      </article>
     </section>
   </main>
 

--- a/universe.html
+++ b/universe.html
@@ -33,6 +33,12 @@
 
   .empty{padding:32px;text-align:center;color:var(--muted,#64748b)}
 
+  .locked-row td{background:color-mix(in srgb, var(--bg,#f6f7fb) 85%, var(--panel,#fff) 15%);padding:28px 16px;text-align:center}
+  .locked-paywall{display:grid;gap:12px;justify-items:center}
+  .locked-paywall p{margin:0;color:var(--muted,#64748b);max-width:520px}
+  .locked-paywall .actions{display:flex;gap:10px;flex-wrap:wrap;justify-content:center}
+  .locked-note{font-size:13px;color:var(--muted,#64748b)}
+
   /* Modal */
   .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.4);display:none;align-items:center;justify-content:center;padding:16px}
   .modal{max-width:900px;width:100%;background:var(--panel,#fff);border-radius:18px;box-shadow:var(--shadow,0 12px 34px rgba(0,0,0,.18));border:1px solid var(--border,#e5e7eb)}


### PR DESCRIPTION
## Summary
- gate the Universe table to a 20% preview when the visitor is not an authenticated member and surface a membership CTA row
- hide locked portfolio cards behind a paywall card while keeping a small preview visible for non-members
- hook both pages into the shared auth state so exports and buttons react to membership/ sign-in status

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cda0b29de4832d885a099ec60645d7