### PR TITLE
Add label to theme toggle

### DIFF
--- a/ai-article.html
+++ b/ai-article.html
@@ -23,7 +23,10 @@
       <a href="/portfolio.html" data-i18n="nav.portfolios">Portfolios</a>
       <a href="/universe.html" data-i18n="nav.universe">Universe</a>
       <button id="langBtn" class="btn small">EN ▾</button>
-      <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+      <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+        <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+        <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+      </button>
       <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
     </nav>
   </header>

--- a/ai-economy.html
+++ b/ai-economy.html
@@ -23,7 +23,10 @@
       <a href="/portfolio.html" data-i18n="nav.portfolios">Portfolios</a>
       <a href="/universe.html" data-i18n="nav.universe">Universe</a>
       <button id="langBtn" class="btn small">EN ▾</button>
-      <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+      <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+        <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+        <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+      </button>
       <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
     </nav>
   </header>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -113,6 +113,18 @@ body.nav-open .nav-toggle__bar::after{top:0;transform:rotate(-45deg);}
   border:none
 }
 .btn.ghost{background:transparent}
+.btn.theme-toggle{
+  display:inline-flex;
+  align-items:center;
+  gap:.35rem;
+}
+.btn.theme-toggle .theme-toggle__icon{
+  font-size:1.05em;
+  line-height:1;
+}
+.btn.theme-toggle .theme-toggle__label{
+  font-size:.85em;
+}
 
 /* Hero (base) */
 .hero{

--- a/blog.html
+++ b/blog.html
@@ -24,7 +24,10 @@
       <a href="/portfolio.html" data-i18n="nav.portfolios">Portfolios</a>
       <a href="/universe.html" data-i18n="nav.universe">Universe</a>
       <button id="langBtn" class="btn small">EN ▾</button>
-      <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+      <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+        <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+        <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+      </button>
       <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
     </nav>
   </header>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -23,7 +23,10 @@
       <a href="/portfolio.html" data-i18n="nav.portfolios">Portfolios</a>
       <a href="/universe.html" data-i18n="nav.universe">Universe</a>
       <button id="langBtn" class="btn small">EN ▾</button>
-      <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+      <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+        <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+        <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+      </button>
       <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
     </nav>
   </header>

--- a/editor.html
+++ b/editor.html
@@ -40,7 +40,10 @@
       <a href="/portfolio.html" data-i18n="nav.portfolios">Portfolios</a>
       <a href="/universe.html" data-i18n="nav.universe">Universe</a>
       <button id="langBtn" class="btn small">EN ▾</button>
-      <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+      <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+        <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+        <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+      </button>
       <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
     </nav>
   </header>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,6 +4,7 @@
   "nav.aiEconomy": "The AI Economy",
   "nav.portfolios": "Portfolios",
   "nav.universe": "Universe",
+  "nav.themeToggle": "Theme",
   "nav.tools": "Tools",
   "nav.disclaimer": "Disclaimer",
   "cta.connectPatreon": "Connect Patreon",

--- a/index.html
+++ b/index.html
@@ -40,7 +40,10 @@
     <a href="/portfolio.html" data-i18n="nav.portfolios">Portfolios</a>
     <a href="/universe.html" data-i18n="nav.universe">Universe</a>
     <button id="langBtn" class="btn small">EN ▾</button>
-    <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+    <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+      <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+      <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+    </button>
     <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
 
   </nav>

--- a/login.html
+++ b/login.html
@@ -37,7 +37,10 @@
       <a href="/portfolio.html" data-i18n="nav.portfolios">Portfolios</a>
       <a href="/universe.html" data-i18n="nav.universe">Universe</a>
       <button id="langBtn" class="btn small">EN ▾</button>
-      <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+      <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+        <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+        <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+      </button>
       <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
     </nav>
   </header>

--- a/portfolio.html
+++ b/portfolio.html
@@ -26,7 +26,10 @@
       <a href="/portfolio.html" class="active" data-i18n="nav.portfolios">Portfolios</a>
       <a href="/universe.html" data-i18n="nav.universe">Universe</a>
       <button id="langBtn" class="btn small">EN ▾</button>
-      <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+      <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+        <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+        <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+      </button>
       <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
     </nav>
   </header>

--- a/posts/example-post.html
+++ b/posts/example-post.html
@@ -23,7 +23,10 @@
       <a href="/portfolio.html" data-i18n="nav.portfolios">Portfolios</a>
       <a href="/universe.html" data-i18n="nav.universe">Universe</a>
       <button id="langBtn" class="btn small">EN ▾</button>
-      <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+      <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+        <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+        <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+      </button>
       <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
     </nav>
   </header>

--- a/strategy.html
+++ b/strategy.html
@@ -26,7 +26,10 @@
       <a href="/portfolio.html" data-i18n="nav.portfolios">Portfolios</a>
       <a href="/universe.html" data-i18n="nav.universe">Universe</a>
       <button id="langBtn" class="btn small">EN ▾</button>
-      <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+      <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+        <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+        <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+      </button>
       <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
     </nav>
   </header>

--- a/tool.html
+++ b/tool.html
@@ -23,7 +23,10 @@
     <a href="/portfolio.html" data-i18n="nav.portfolios">Portfolios</a>
     <a href="/universe.html" data-i18n="nav.universe">Universe</a>
     <button id="langBtn" class="btn small">EN ▾</button>
-    <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+    <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+      <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+      <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+    </button>
     <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
   </nav>
 </header>

--- a/tools.html
+++ b/tools.html
@@ -23,7 +23,10 @@
     <a href="/portfolio.html" data-i18n="nav.portfolios">Portfolios</a>
     <a href="/universe.html" data-i18n="nav.universe">Universe</a>
     <button id="langBtn" class="btn small">EN ▾</button>
-    <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+    <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+      <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+      <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+    </button>
     <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
   </nav>
 </header>

--- a/universe.html
+++ b/universe.html
@@ -72,7 +72,10 @@
     <a href="/portfolio.html" data-i18n="nav.portfolios">Portfolios</a>
     <a href="/universe.html" class="active" data-i18n="nav.universe">Universe</a>
     <button id="langBtn" class="btn small">EN ▾</button>
-    <button id="themeToggle" class="btn small ghost" aria-label="Toggle theme">🌗</button>
+    <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+      <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+      <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+    </button>
     <a id="patreonLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
   </nav>
 </header>


### PR DESCRIPTION
## Summary
- add a text label next to the theme toggle icon on each page header for clarity
- style the toggle button to align the icon and label and expose the label for localization

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d193582654832da497b6b60936ec9b