### PR TITLE
Fix prompt editor modal parsing error

### DIFF
--- a/assets/editor.js
+++ b/assets/editor.js
@@ -757,8 +757,7 @@ async function initEditor() {
   const parseModelListInput = () => {
     if (!modelEditorInput) return [];
     const lines = (modelEditorInput.value || '')
-      .split('
-')
+      .split('\n')
       .map((line) => line.trim())
       .filter(Boolean);
     if (!lines.length) throw new Error('Add at least one model option.');


### PR DESCRIPTION
## Summary
- fix the model list parser to split on newline characters without introducing syntax errors
- ensure the prompt editor modal script executes so the dialog opens correctly

## Testing
- node --check assets/editor.js

------
https://chatgpt.com/codex/tasks/task_e_68d562748644832dbee609c434adf598