### PR TITLE
Fix prompt preview overflow in editor

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -13,7 +13,7 @@
       width:100%;padding:12px 14px;border:1px solid var(--border,#e5e7eb);border-radius:12px;background:var(--panel,#fff);
       color:var(--text,#0f172a);
     }
-    .editor-grid textarea{min-height:120px;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace}
+    .editor-grid textarea{min-height:120px;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;resize:vertical;box-sizing:border-box}
     .field-row{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
     .muted-small{color:var(--muted,#64748b);font-size:.9rem;margin:4px 0 0}
     .recent-list{margin-top:22px;display:grid;gap:12px}
@@ -47,7 +47,7 @@
     .prompt-menu button.active{background:var(--accent,#2563eb);color:#fff}
     .prompt-menu button.active span{color:rgba(255,255,255,.85)}
     .prompt-details{margin-top:8px;border:1px solid var(--border,#e5e7eb);border-radius:12px;padding:12px;background:rgba(148,163,184,.1);font-size:.85rem;color:var(--muted,#64748b)}
-    .prompt-preview{margin-top:6px;padding:12px;border:1px solid var(--border,#e5e7eb);border-radius:12px;background:var(--panel,#fff);max-height:220px;overflow:auto;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:.78rem;line-height:1.4;color:var(--text,#0f172a)}
+    .prompt-preview{margin-top:6px;padding:12px;border:1px solid var(--border,#e5e7eb);border-radius:12px;background:var(--panel,#fff);max-height:220px;overflow:auto;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:.78rem;line-height:1.4;color:var(--text,#0f172a);width:100%;max-width:100%;box-sizing:border-box}
     .select-edit{display:flex;align-items:center;gap:8px}
     .select-edit select{flex:1 1 auto}
     .model-editor{margin-top:10px;border:1px dashed var(--border,#e5e7eb);border-radius:12px;padding:12px;display:grid;gap:10px;background:rgba(148,163,184,.08)}
@@ -77,7 +77,7 @@
     .prompt-editor__form .field-group{display:grid;gap:6px}
     .prompt-editor__form label{font-weight:600;font-size:.9rem}
     .prompt-editor__form input,.prompt-editor__form textarea{padding:10px 12px;border:1px solid var(--border,#e5e7eb);border-radius:10px;background:var(--panel,#fff);color:var(--text,#0f172a)}
-    .prompt-editor__form textarea{min-height:220px;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace}
+    .prompt-editor__form textarea{min-height:220px;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;width:100%;max-width:100%;box-sizing:border-box;overflow:auto}
     .prompt-editor__row{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(160px,1fr))}
     .prompt-editor__toggles{display:flex;gap:18px;flex-wrap:wrap;align-items:center}
     .prompt-editor__toggle{display:flex;gap:8px;align-items:center;font-size:.9rem;color:var(--muted,#64748b)}


### PR DESCRIPTION
## Summary
- ensure editor text areas keep their width and only resize vertically
- constrain the prompt preview panel so long prompts scroll instead of stretching the layout

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6abd10d40832d8e3ee1b18e27c9d5