### PR TITLE
Gracefully handle missing prompt slug column

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -279,10 +279,12 @@
               <div class="field-group">
                 <label for="promptEditorSlug">Slug (optional)</label>
                 <input id="promptEditorSlug" name="slug" placeholder="deep-research" />
+                <p class="muted-small" id="promptEditorSlugHelp">Short identifier with letters, numbers or dashes. Leave blank to auto-generate.</p>
               </div>
               <div class="field-group">
                 <label for="promptEditorSortOrder">Sort order</label>
                 <input id="promptEditorSortOrder" name="sort_order" type="number" min="0" step="1" placeholder="100" />
+                <p class="muted-small">Lower numbers appear higher in the picker. Leave blank for default ordering.</p>
               </div>
             </div>
             <div class="field-group">
@@ -298,6 +300,7 @@
               <label class="prompt-editor__toggle"><input type="checkbox" id="promptEditorDefault" name="is_default" /> Default prompt</label>
               <label class="prompt-editor__toggle"><input type="checkbox" id="promptEditorArchived" name="archived" /> Archived</label>
             </div>
+            <p class="muted-small">Set "Default" to auto-select this template. Archive a prompt to hide it from the picker without deleting it.</p>
             <p id="promptEditorStatus" class="muted-small prompt-editor__status"></p>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- allow prompt templates to save even when the Supabase table is missing the slug column by retrying without it and disabling the slug field
- add helper copy that explains slug, sort order, default, and archived fields in the prompt editor

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6acf4352c832d9740b2bb0cf74eeb