### PR TITLE
Add prompt deletion flow in editor

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -306,6 +306,7 @@
         </div>
       </div>
       <footer class="modal__footer">
+        <button type="button" class="btn danger" id="deletePromptEditor" disabled>Delete prompt</button>
         <button type="button" class="btn ghost" id="cancelPromptEditor">Cancel</button>
         <button type="submit" class="btn primary" form="promptEditorForm" id="savePromptEditor">Save prompt</button>
       </footer>


### PR DESCRIPTION
## Summary
- add a Delete prompt action to the prompt library modal
- call Supabase to remove saved prompts and refresh the selector state when a template is deleted

## Testing
- node --test tests/editor-support.test.mjs
- node --test tests/supabase-connection.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d6b0ddd5d8832d81a7d3c989828015