### PR TITLE
Redesign universe view with dynamic table modes

### DIFF
--- a/universe.html
+++ b/universe.html
@@ -11,29 +11,33 @@
 <style>
   /* Page-local styles (keeps your global tokens) */
   .wrap{max-width:1200px;margin:32px auto;padding:0 16px}
-  .hero h1{margin:.2rem 0 .5rem}
+  .hero{padding:32px 0 12px;text-align:left;background:none}
+  .hero h1{margin:.2rem 0 .35rem}
   .hero p{margin:0;color:var(--muted,#64748b)}
 
-  .controls{display:flex;flex-wrap:wrap;gap:10px;margin:16px 0 18px}
-  .controls input,.controls select{padding:10px 12px;border:1px solid var(--border,#e5e7eb);border-radius:12px;background:var(--panel,#fff)}
-  .controls .btn{padding:10px 12px;border:1px solid var(--border,#e5e7eb);border-radius:12px;background:var(--panel,#fff);cursor:pointer}
-  .controls .btn:hover{border-color:var(--accent,#1a73e8)}
-  .chips{display:flex;gap:8px;flex-wrap:wrap;margin:4px 0 16px}
-  .chip{font-size:12px;padding:6px 10px;border:1px solid var(--border,#e5e7eb);border-radius:999px;background:var(--panel,#fff);cursor:pointer}
-  .chip.active{border-color:var(--accent,#1a73e8)}
+  .universe-toolbar{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin:8px 0 16px}
+  .universe-search{flex:1 1 260px}
+  .universe-search input{width:100%;padding:10px 14px;border:1px solid var(--border,#e5e7eb);border-radius:999px;background:var(--panel,#fff);box-shadow:inset 0 0 0 1px transparent;transition:border .2s ease,box-shadow .2s ease}
+  .universe-search input:focus{outline:none;border-color:var(--accent,#1a73e8);box-shadow:0 0 0 3px color-mix(in srgb, var(--accent,#1a73e8) 18%, transparent)}
+  .universe-actions{display:flex;gap:8px;flex-wrap:wrap}
+  .universe-actions .btn{padding:8px 12px;border:1px solid var(--border,#e5e7eb);border-radius:999px;background:var(--panel,#fff);cursor:pointer;font-size:.85rem}
+  .universe-actions .btn:hover{border-color:var(--accent,#1a73e8)}
+
+  .view-switcher{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 18px}
+  .view-switcher button{padding:8px 14px;border:1px solid var(--border,#e5e7eb);border-radius:999px;background:var(--panel,#fff);color:var(--text,#1f2937);font-size:.9rem;font-weight:500;cursor:pointer;transition:border .2s ease,background .2s ease,color .2s ease}
+  .view-switcher button.active{border-color:var(--accent,#1a73e8);background:color-mix(in srgb, var(--accent,#1a73e8) 12%, var(--panel,#fff) 88%);color:var(--accent-contrast,#0f172a)}
+  .view-switcher button:focus{outline:none;border-color:var(--accent,#1a73e8)}
 
   .table-wrap{background:var(--panel,#fff);border:1px solid var(--border,#e5e7eb);border-radius:16px;box-shadow:var(--shadow,0 12px 34px rgba(0,0,0,.06));overflow:hidden}
   table.grid{width:100%;border-collapse:collapse}
   .grid th,.grid td{padding:12px 14px;border-bottom:1px solid var(--border,#e5e7eb);vertical-align:top}
-  .grid thead th{position:sticky;top:62px;background:var(--bg,#f6f7fb);z-index:5;text-align:left}
-  .grid tbody tr{cursor:pointer}
+  .grid thead th{position:sticky;top:62px;background:var(--bg,#f6f7fb);z-index:5;text-align:left;font-size:.85rem;text-transform:uppercase;letter-spacing:.05em;color:var(--muted,#64748b)}
   .grid tbody tr:hover{background:#f8fafc}
-  .tags{display:flex;gap:6px;flex-wrap:wrap}
-  .tag{font-size:12px;padding:3px 8px;border:1px solid var(--border,#e5e7eb);border-radius:999px}
-  .topic-cell{display:flex;flex-direction:column;gap:6px}
-  .topic-cell__title{font-weight:600;line-height:1.4}
-  .link-btn{background:none;border:none;padding:0;color:var(--accent,#1a73e8);font-size:.85rem;text-decoration:underline;cursor:pointer;align-self:flex-start}
+  .company-cell{font-weight:600;line-height:1.35}
+  .metric-cell{font-variant-numeric:tabular-nums}
+  .link-btn{background:none;border:none;padding:0;color:var(--accent,#1a73e8);font-size:.85rem;text-decoration:underline;cursor:pointer}
   .link-btn:hover{color:#0b4dd8}
+  .link-btn:focus{outline:none;text-decoration:none;color:#0b4dd8}
   .modal-actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:8px}
   .analysis-full{display:grid;gap:14px}
   .analysis-full__meta{color:var(--muted,#64748b);font-size:.9rem}
@@ -56,8 +60,7 @@
 
   /* Small screens */
   @media (max-width: 740px){
-    .grid th:nth-child(4), .grid td:nth-child(4){display:none} /* hide Visual/Table on mobile */
-    .grid th:nth-child(5), .grid td:nth-child(5){display:none} /* hide Conclusion on mobile */
+    .grid th:nth-child(n+5), .grid td:nth-child(n+5){display:none}
   }
 </style>
 </head>
@@ -96,32 +99,29 @@
 
 <!-- Controls -->
 <main class="wrap">
-  <div class="controls">
-    <input id="q" placeholder="Search topic, findings, conclusion…" aria-label="Search"/>
-    <select id="tagSel" aria-label="Filter by tag">
-      <option value="">All tags</option>
-    </select>
-    <input id="from" type="date" aria-label="From date"/>
-    <input id="to" type="date" aria-label="To date"/>
-    <button id="btnExportCsv" class="btn" title="Export current view to CSV">Export CSV</button>
-    <button id="btnCopyJson" class="btn" title="Copy current view as JSON">Copy JSON</button>
-    <button id="btnRefresh" class="btn" title="Reload data">Refresh</button>
+  <div class="universe-toolbar">
+    <div class="universe-search">
+      <input id="q" type="search" placeholder="Search the universe…" aria-label="Search the universe" />
+    </div>
+    <div class="universe-actions">
+      <button id="btnExportCsv" class="btn" type="button" title="Export current view to CSV">Export CSV</button>
+      <button id="btnCopyJson" class="btn" type="button" title="Copy current view as JSON">Copy JSON</button>
+      <button id="btnRefresh" class="btn" type="button" title="Reload data">Refresh</button>
+    </div>
   </div>
 
-  <!-- Tag chips (top 12) -->
-  <div id="chips" class="chips"></div>
+  <div class="view-switcher" role="tablist" aria-label="Universe view modes">
+    <button type="button" class="toggle active" data-mode="tags" aria-pressed="true">Tags</button>
+    <button type="button" class="toggle" data-mode="strategies" aria-pressed="false">Strategies</button>
+    <button type="button" class="toggle" data-mode="metrics" aria-pressed="false">Metrics</button>
+    <button type="button" class="toggle" data-mode="placeholder1" aria-pressed="false">Placeholder1</button>
+    <button type="button" class="toggle" data-mode="placeholder2" aria-pressed="false">Placeholder2</button>
+  </div>
 
   <div class="table-wrap">
     <table class="grid" id="grid">
       <thead>
-        <tr>
-          <th style="width:110px">Date</th>
-          <th style="width:300px">Topic</th>
-          <th>Key Findings</th>
-          <th style="width:320px">Visual/Table</th>
-          <th style="width:280px">Conclusion</th>
-          <th style="width:160px">Tags</th>
-        </tr>
+        <tr id="headerRow"></tr>
       </thead>
       <tbody id="tbody">
         <tr><td class="empty" colspan="6">Loading…</td></tr>


### PR DESCRIPTION
## Summary
- Restyle the Universe hero to remove the purple background and add a new search/actions toolbar with mode toggles.
- Replace the legacy table with fixed company columns plus dynamic headers that respond to the selected Tags/Strategies/Metrics/Placeholder modes.
- Rebuild the Universe page script with view-mode state, dynamic header rendering, updated modals for analysis/financials, and refreshed CSV export helpers.

## Testing
- Not run (not requested).

------
https://chatgpt.com/codex/tasks/task_e_68d6dfdc3880832db67117239b8adc39