### PR TITLE
Allow admin accounts to bypass membership gating

### DIFF
--- a/assets/auth.js
+++ b/assets/auth.js
@@ -236,7 +236,10 @@ function applyStateToUI() {
   updateGatedElements();
   updateProfileView();
   document.body?.classList.toggle('is-authed', !!state.user);
-  document.body?.classList.toggle('is-member', isMembershipActive(state.membership));
+  document.body?.classList.toggle(
+    'is-member',
+    isMembershipActive(state.membership, { profile: state.profile, user: state.user })
+  );
   if (els.modal?.classList.contains('open')) {
     const currentView = els.modal.getAttribute('data-view');
     if (currentView === 'signin' && state.user) showView('profile');
@@ -253,7 +256,8 @@ function updateHeaderButton() {
     btn.textContent = btn.dataset.originalLabel;
     btn.setAttribute('data-open-auth', 'signin');
   } else {
-    btn.textContent = isMembershipActive(state.membership) ? 'Members Area' : 'Account';
+    const membershipActive = isMembershipActive(state.membership, { profile: state.profile, user: state.user });
+    btn.textContent = membershipActive ? 'Members Area' : 'Account';
     btn.setAttribute('data-open-auth', 'profile');
   }
 }
@@ -264,7 +268,7 @@ function updateGatedElements() {
     const requirement = (block.dataset.gated || 'auth').toLowerCase();
     let locked = false;
     if (requirement === 'member') {
-      locked = !isMembershipActive(state.membership);
+      locked = !isMembershipActive(state.membership, { profile: state.profile, user: state.user });
     } else {
       locked = !state.user;
     }
@@ -281,7 +285,7 @@ function updateProfileView() {
   }
   const email = state.user.email || '';
   els.profileEmail.innerHTML = `Signed in as <strong>${escapeHtml(email)}</strong>`;
-  const membershipActive = isMembershipActive(state.membership);
+  const membershipActive = isMembershipActive(state.membership, { profile: state.profile, user: state.user });
   if (membershipActive) {
     const until = state.membership?.current_period_end
       ? new Date(state.membership.current_period_end).toLocaleString()

--- a/assets/paywall.js
+++ b/assets/paywall.js
@@ -73,7 +73,8 @@ async function ensureMemberAccess(context={}){
   const account = (typeof auth.getAccount === 'function') ? auth.getAccount() : null;
   const user = account?.user || null;
   const membership = account?.membership || null;
-  if (user && membershipIsActive(membership)) {
+  const isAdmin = accountHasAdminRole(account);
+  if (user && (membershipIsActive(membership) || isAdmin)) {
     return { allowed:true };
   }
   const signedIn = !!user;
@@ -92,6 +93,66 @@ function membershipIsActive(record){
     if (!Number.isNaN(expiry) && expiry < Date.now()) return false;
   }
   return true;
+}
+
+function normalizeRole(value){
+  if (value == null) return [];
+  if (Array.isArray(value)) return value.flatMap((entry)=>normalizeRole(entry));
+  if (typeof value === 'object') return Object.values(value).flatMap((entry)=>normalizeRole(entry));
+  return String(value ?? '')
+    .split(/[\s,]+/)
+    .map((part)=>part.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function accountHasAdminRole(account){
+  if (!account) return false;
+  const profile = account.profile || {};
+  const membership = account.membership || {};
+  const user = account.user || {};
+  const appMeta = user.app_metadata || {};
+  const userMeta = user.user_metadata || {};
+
+  const buckets = new Set();
+  const collect = (value) => {
+    normalizeRole(value).forEach((role) => buckets.add(role));
+  };
+
+  collect(profile.role);
+  collect(profile.role_name);
+  collect(profile.user_role);
+  collect(profile.access_level);
+  collect(profile.roles);
+  collect(profile.role_tags);
+
+  collect(appMeta.role);
+  collect(appMeta.roles);
+  collect(appMeta.access_level);
+  collect(appMeta.permissions);
+
+  collect(userMeta.role);
+  collect(userMeta.roles);
+  collect(userMeta.access_level);
+
+  collect(membership.role);
+  collect(membership.roles);
+  collect(membership.access_level);
+  collect(membership.plan);
+  collect(membership.plan_name);
+
+  const flagSources = [profile, membership, appMeta, userMeta];
+  const flagKeys = ['is_admin', 'admin', 'isAdmin', 'is_superadmin', 'superuser', 'staff', 'is_staff'];
+  if (flagSources.some((source) => flagKeys.some((key) => Boolean(source?.[key])))) {
+    return true;
+  }
+
+  const elevated = new Set(['admin', 'administrator', 'superadmin', 'owner', 'editor', 'staff']);
+  for (const role of buckets) {
+    if (role === 'admin' || elevated.has(role)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function membershipLockedHTML({ title, subtitle, backHref, signedIn }){

--- a/assets/supabase.js
+++ b/assets/supabase.js
@@ -56,13 +56,87 @@ export async function getMembership() {
   return data ?? null;
 }
 
-export function isMembershipActive(record) {
-  if (!record) return false;
-  const status = (record.status || '').toLowerCase();
-  if (status && status !== 'active') return false;
-  if (record.current_period_end) {
-    const expiry = new Date(record.current_period_end).getTime();
-    if (!Number.isNaN(expiry) && expiry < Date.now()) return false;
+function normalizeRole(value) {
+  if (value == null) return [];
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => normalizeRole(entry));
   }
-  return true;
+  if (typeof value === 'object') {
+    return Object.values(value).flatMap((entry) => normalizeRole(entry));
+  }
+  return String(value ?? '')
+    .split(/[\s,]+/)
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
 }
+
+function hasAdminMarker(source = {}) {
+  const flagKeys = ['is_admin', 'admin', 'isAdmin', 'is_superadmin', 'superuser', 'staff', 'is_staff'];
+  return flagKeys.some((key) => Boolean(source?.[key]));
+}
+
+function hasAdminRole(context = {}) {
+  const profile = context.profile || {};
+  const membership = context.membership || {};
+  const user = context.user || {};
+  const appMeta = user.app_metadata || {};
+  const userMeta = user.user_metadata || {};
+
+  const buckets = new Set();
+  const collect = (value) => {
+    normalizeRole(value).forEach((role) => buckets.add(role));
+  };
+
+  collect(profile.role);
+  collect(profile.role_name);
+  collect(profile.user_role);
+  collect(profile.access_level);
+  collect(profile.roles);
+  collect(profile.role_tags);
+
+  collect(appMeta.role);
+  collect(appMeta.roles);
+  collect(appMeta.access_level);
+  collect(appMeta.permissions);
+
+  collect(userMeta.role);
+  collect(userMeta.roles);
+  collect(userMeta.access_level);
+
+  collect(membership.role);
+  collect(membership.roles);
+  collect(membership.access_level);
+  collect(membership.plan);
+  collect(membership.plan_name);
+
+  if (hasAdminMarker(profile) || hasAdminMarker(appMeta) || hasAdminMarker(userMeta) || hasAdminMarker(membership)) {
+    return true;
+  }
+
+  const elevated = new Set(['admin', 'administrator', 'superadmin', 'owner', 'editor', 'staff']);
+  for (const role of buckets) {
+    if (role === 'admin' || elevated.has(role)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function isMembershipActive(record, context = {}) {
+  if (record) {
+    const status = (record.status || '').toLowerCase();
+    if (status && status !== 'active') {
+      return hasAdminRole({ ...context, membership: record });
+    }
+    if (record.current_period_end) {
+      const expiry = new Date(record.current_period_end).getTime();
+      if (!Number.isNaN(expiry) && expiry < Date.now()) {
+        return hasAdminRole({ ...context, membership: record });
+      }
+    }
+    return true;
+  }
+  return hasAdminRole(context);
+}
+
+export { hasAdminRole };

--- a/assets/universe.js
+++ b/assets/universe.js
@@ -664,7 +664,9 @@ async function UniversePage() {
         ? payload
         : payload.detail || {};
       const membership = account?.membership || null;
-      const isMember = isMembershipActive ? isMembershipActive(membership) : false;
+      const isMember = isMembershipActive
+        ? isMembershipActive(membership, { profile: account?.profile, user: account?.user })
+        : false;
       const isSignedIn = !!account?.user;
       const changed = isMember !== state.isMember || isSignedIn !== state.isSignedIn || !state.authReady;
       state.isMember = isMember;


### PR DESCRIPTION
## Summary
- recognise admin role markers when determining active membership status
- allow admin accounts to skip portfolio paywall messaging and preview limits
- propagate the enhanced membership check through the shared auth helpers

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7c111cd5c832db61b933e54b7a20f