### PR TITLE
Update team page with robotic roster

### DIFF
--- a/team.html
+++ b/team.html
@@ -39,9 +39,8 @@
       <p class="hero-eyebrow"><em>Who ships FutureFunds.ai?</em></p>
       <h1>Meet the team building the FutureFunds.ai experiment</h1>
       <p>
-        We are a small crew pairing human judgment with AI copilots to explore how autonomous research and
-        portfolio management can work in the open. Our roles stretch across data engineering, analysis,
-        storytelling, and member experience so the entire loop stays tight.
+        Our goal is to prototype autonomous finance copilots that analyze markets, execute research, and share
+        transparent updates with members.
       </p>
       <div class="team-subnav" aria-label="Team quick links">
         <a href="#team-members">👥 Team roster</a>
@@ -58,7 +57,7 @@
       <div class="team-grid">
         <article class="panel team-card">
           <div class="team-card__head">
-            <h3 class="team-card__name">Lena Ortiz</h3>
+            <h3 class="team-card__name">DataSynth-01</h3>
             <span class="team-card__version">Power v1.8</span>
           </div>
           <p class="team-card__role">Head of Research Automation</p>
@@ -84,7 +83,7 @@
 
         <article class="panel team-card">
           <div class="team-card__head">
-            <h3 class="team-card__name">Noah Chen</h3>
+            <h3 class="team-card__name">ValueBot</h3>
             <span class="team-card__version">Power v1.5</span>
           </div>
           <p class="team-card__role">Lead Portfolio Engineer</p>
@@ -110,7 +109,7 @@
 
         <article class="panel team-card">
           <div class="team-card__head">
-            <h3 class="team-card__name">Maya Patel</h3>
+            <h3 class="team-card__name">EchoWeaver</h3>
             <span class="team-card__version">Power v1.3</span>
           </div>
           <p class="team-card__role">Member Operations &amp; Narrative</p>
@@ -136,7 +135,7 @@
 
         <article class="panel team-card">
           <div class="team-card__head">
-            <h3 class="team-card__name">Atlas</h3>
+            <h3 class="team-card__name">Atlas-Prime</h3>
             <span class="team-card__version">Power v0.9</span>
           </div>
           <p class="team-card__role">Strategy Copilot (AI)</p>
@@ -156,7 +155,7 @@
               </ul>
             </dd>
             <dt>Currently shipping</dt>
-            <dd>Pairing with Lena on a structured note generator that references filings, transcripts, and quant outputs.</dd>
+            <dd>Pairing with DataSynth-01 on a structured note generator that references filings, transcripts, and quant outputs.</dd>
           </dl>
         </article>
       </div>


### PR DESCRIPTION
## Summary
- replace the hero description with a concise statement of the project goal
- rename the team roster with robotic personas including ValueBot and adjust references

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d94dcd04c4832db5f776e1e88e1634