### PR TITLE
Build sequential process progress timeline

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -21,9 +21,30 @@
     .summary-card{border:1px solid var(--border,#e5e7eb);border-radius:18px;background:var(--panel,#fff);padding:18px;display:grid;gap:12px;box-shadow:0 10px 22px rgba(15,23,42,.05)}
     .summary-card__title{margin:0;font-size:1.05rem;font-weight:600;color:var(--text,#0f172a)}
     .summary-card__content{font-size:.92rem;color:var(--muted,#64748b);display:grid;gap:8px}
-    .process-steps{list-style:none;margin:0;padding:0;display:grid;gap:6px}
-    .process-steps li{display:flex;align-items:center;gap:8px;padding:8px 10px;border-radius:12px;background:rgba(37,99,235,.08);color:var(--text,#0f172a);font-weight:500}
-    .process-steps li span{font-size:.8rem;color:var(--muted,#64748b);font-weight:400}
+    .process-steps{list-style:none;margin:0;padding:0;display:grid;gap:10px}
+    .process-step{display:flex;align-items:flex-start;gap:12px;padding:10px 12px;border-radius:14px;border:1px solid var(--border,#e5e7eb);background:var(--panel-muted,#f8fafc);transition:background .2s ease,border-color .2s ease,box-shadow .2s ease}
+    .process-step__icon{position:relative;flex-shrink:0;width:32px;height:32px;border-radius:999px;display:inline-flex;align-items:center;justify-content:center;color:var(--muted,#64748b)}
+    .process-step__icon::after{content:attr(data-step);display:flex;align-items:center;justify-content:center;width:100%;height:100%;border-radius:inherit;background:#fff;border:2px solid currentColor;font-size:.85rem;font-weight:600;box-sizing:border-box;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .process-step__icon::before{content:"";position:absolute;inset:6px;border-radius:inherit;border:2px solid transparent;opacity:0}
+    .process-step__body{display:grid;gap:4px}
+    .process-step__title{margin:0;font-weight:600;color:var(--text,#0f172a);font-size:.93rem}
+    .process-step__meta{margin:0;color:var(--muted,#64748b);font-size:.82rem;line-height:1.4}
+    .process-step[data-status="complete"]{background:rgba(49,208,163,.12);border-color:rgba(49,208,163,.32)}
+    .process-step[data-status="complete"] .process-step__icon{color:var(--ok,#31d0a3)}
+    .process-step[data-status="complete"] .process-step__icon::after{content:"✓";background:var(--ok,#31d0a3);color:#fff;border-color:var(--ok,#31d0a3)}
+    .process-step[data-status="complete"] .process-step__title{color:var(--ok,#0f766e)}
+    .process-step[data-status="complete"] .process-step__meta{color:rgba(15,118,110,.85)}
+    .process-step[data-status="active"]{border-color:var(--accent,#2563eb);background:rgba(37,99,235,.12);box-shadow:0 0 0 1px rgba(37,99,235,.16)}
+    .process-step[data-status="active"] .process-step__icon{color:var(--accent,#2563eb)}
+    .process-step[data-status="active"] .process-step__icon::after{content:"";background:transparent;border-color:rgba(37,99,235,.32)}
+    .process-step[data-status="active"] .process-step__icon::before{opacity:1;border-top-color:var(--accent,#2563eb);border-right-color:var(--accent,#2563eb);animation:processSpin .85s linear infinite}
+    .process-step[data-status="active"] .process-step__title{color:var(--accent,#2563eb)}
+    .process-step[data-status="active"] .process-step__meta{color:rgba(37,99,235,.85)}
+    .process-step[data-status="upcoming"] .process-step__icon{color:var(--muted,#94a3b8)}
+    .process-step[data-status="upcoming"] .process-step__icon::after{background:#fff;border-style:dashed;color:var(--muted,#94a3b8)}
+    .process-step[data-status="upcoming"] .process-step__title{color:var(--text,#0f172a)}
+    .process-step[data-status="upcoming"] .process-step__meta{color:var(--muted,#94a3b8)}
+    @keyframes processSpin{to{transform:rotate(360deg)}}
     .ai-settings-list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
     .ai-settings-list li{display:flex;flex-direction:column;gap:2px}
     .ai-settings-list strong{font-size:.9rem;color:var(--text,#0f172a)}
@@ -152,10 +173,77 @@
       <article class="summary-card">
         <h2 class="summary-card__title">Process Progress</h2>
         <div class="summary-card__content">
-          <ul class="process-steps">
-            <li>1. Discovery <span>Capture new tickers and catalysts</span></li>
-            <li>2. Analysis <span>Validate thesis and key scenarios</span></li>
-            <li>3. Publication <span>Send approved insights to the Universe</span></li>
+          <ul class="process-steps" id="analysisProgress" data-auto-cycle="true" data-demo-interval="2600">
+            <li class="process-step" data-step-id="round-1" data-status="active">
+              <span class="process-step__icon" data-step="1" aria-hidden="true"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Round 1 — Discovery kickoff question</p>
+                <p class="process-step__meta">Capture new tickers and catalysts for the desk.</p>
+              </div>
+            </li>
+            <li class="process-step" data-step-id="round-2" data-status="upcoming">
+              <span class="process-step__icon" data-step="2" aria-hidden="true"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Round 2 — Market context question</p>
+                <p class="process-step__meta">Sync macro signals and the universe list to prioritise coverage.</p>
+              </div>
+            </li>
+            <li class="process-step" data-step-id="round-3" data-status="upcoming">
+              <span class="process-step__icon" data-step="3" aria-hidden="true"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Round 3 — Hypothesis framing question</p>
+                <p class="process-step__meta">Translate discovery notes into the thesis we need to test.</p>
+              </div>
+            </li>
+            <li class="process-step" data-step-id="round-4" data-status="upcoming">
+              <span class="process-step__icon" data-step="4" aria-hidden="true"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Round 4 — Evidence gathering question</p>
+                <p class="process-step__meta">Pull filings, transcripts and KPI references for validation.</p>
+              </div>
+            </li>
+            <li class="process-step" data-step-id="round-5" data-status="upcoming">
+              <span class="process-step__icon" data-step="5" aria-hidden="true"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Round 5 — Model wiring question</p>
+                <p class="process-step__meta">Draft the valuation scaffolding and anchor the inputs.</p>
+              </div>
+            </li>
+            <li class="process-step" data-step-id="round-6" data-status="upcoming">
+              <span class="process-step__icon" data-step="6" aria-hidden="true"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Round 6 — Thesis validation question</p>
+                <p class="process-step__meta">Pressure-test assumptions versus the collected data quality.</p>
+              </div>
+            </li>
+            <li class="process-step" data-step-id="round-7" data-status="upcoming">
+              <span class="process-step__icon" data-step="7" aria-hidden="true"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Round 7 — Risk audit question</p>
+                <p class="process-step__meta">Score downside scenarios and mitigation paths.</p>
+              </div>
+            </li>
+            <li class="process-step" data-step-id="round-8" data-status="upcoming">
+              <span class="process-step__icon" data-step="8" aria-hidden="true"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Round 8 — Timing window question</p>
+                <p class="process-step__meta">Review catalysts, liquidity and market timing cues.</p>
+              </div>
+            </li>
+            <li class="process-step" data-step-id="round-9" data-status="upcoming">
+              <span class="process-step__icon" data-step="9" aria-hidden="true"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Round 9 — Publication assembly question</p>
+                <p class="process-step__meta">Compose the research narrative and compliance checklist.</p>
+              </div>
+            </li>
+            <li class="process-step" data-step-id="round-10" data-status="upcoming">
+              <span class="process-step__icon" data-step="10" aria-hidden="true"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Round 10 — Share-out &amp; next questions</p>
+                <p class="process-step__meta">Publish to the Universe and push follow-up questions to the team.</p>
+              </div>
+            </li>
           </ul>
         </div>
       </article>


### PR DESCRIPTION
## Summary
- restyle the editor "Process Progress" card into a 10-round workflow with contextual copy and status icons
- add live status styling for complete, active, and upcoming states including spinner animation
- introduce a progress controller in the editor script to manage status changes and demo auto-cycling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d95294c34c832da888df9e0663311f