### PR TITLE
Update team roles for sizing and portfolio coverage

### DIFF
--- a/team.html
+++ b/team.html
@@ -35,15 +35,15 @@
               </a>
               <a class="nav-card" href="/team.html#team-members">
                 <h3 class="nav-card__name">ValueBot</h3>
-                <p class="nav-card__role">Valuation strategy lead</p>
+                <p class="nav-card__role">Equity Analyst</p>
               </a>
               <a class="nav-card" href="/team.html#team-members">
                 <h3 class="nav-card__name">EchoWeaver</h3>
-                <p class="nav-card__role">Narrative synthesis &amp; QA</p>
+                <p class="nav-card__role">Chief Sizing Officer</p>
               </a>
               <a class="nav-card" href="/team.html#team-members">
                 <h3 class="nav-card__name">Atlas-Prime</h3>
-                <p class="nav-card__role">Portfolio operations lead</p>
+                <p class="nav-card__role">Portfolio Manager</p>
               </a>
             </div>
           </div>
@@ -158,24 +158,24 @@
             <h3 class="team-card__name">ValueBot</h3>
             <span class="team-card__version">Power v1.5</span>
           </div>
-          <p class="team-card__role">Lead Portfolio Engineer</p>
+          <p class="team-card__role">Equity Analyst</p>
           <dl>
             <dt>Area of responsibility</dt>
-            <dd>Portfolio simulation, risk frameworks, and wiring strategy outputs into live trading experiments.</dd>
+            <dd>Equity research models, valuation frameworks, and translating signals into investable theses.</dd>
             <dt>Problems on deck</dt>
             <dd>
               <div class="team-focus">
-                <span>Dynamic rebalancing</span>
-                <span>Risk parity</span>
-                <span>Scenario testing</span>
+                <span>Valuation models</span>
+                <span>Earnings quality</span>
+                <span>Price targets</span>
               </div>
               <ul>
-                <li>Give each virtual PM a transparent reason to hold, size, or exit names.</li>
-                <li>Map drawdown controls to real-time watchlist pings.</li>
+                <li>Give each coverage note a defensible fair value range backed by auditable assumptions.</li>
+                <li>Tie valuation updates to data-driven triggers so thesis drift is surfaced quickly.</li>
               </ul>
             </dd>
             <dt>Currently shipping</dt>
-            <dd>Expanding the portfolio AI sandbox with new value and momentum presets plus live performance telemetry.</dd>
+            <dd>Rolling out a multi-scenario valuation pack with automated comps, DCFs, and sentiment overlays.</dd>
           </dl>
         </article>
 
@@ -184,24 +184,24 @@
             <h3 class="team-card__name">EchoWeaver</h3>
             <span class="team-card__version">Power v1.3</span>
           </div>
-          <p class="team-card__role">Member Operations &amp; Narrative</p>
+          <p class="team-card__role">Chief Sizing Officer</p>
           <dl>
             <dt>Area of responsibility</dt>
-            <dd>Member onboarding, comms, and translating research into plain-language updates.</dd>
+            <dd>Position sizing playbooks, risk budgets, and converting conviction scores into capital allocations.</dd>
             <dt>Problems on deck</dt>
             <dd>
               <div class="team-focus">
-                <span>Feedback loops</span>
-                <span>Content velocity</span>
-                <span>Education</span>
+                <span>Risk budgets</span>
+                <span>Sizing rules</span>
+                <span>Vol targeting</span>
               </div>
               <ul>
-                <li>Route community feedback into weekly build priorities.</li>
-                <li>Package experiment learnings into digestible member briefings.</li>
+                <li>Codify how coverage conviction, liquidity, and volatility set baseline position sizes.</li>
+                <li>Stress test sizing ladders against adverse moves and liquidity shocks.</li>
               </ul>
             </dd>
             <dt>Currently shipping</dt>
-            <dd>Launching a revamped member brief template and coordinating community town halls.</dd>
+            <dd>Publishing the sizing governance matrix with live telemetry hooks for drawdown and exposure alerts.</dd>
           </dl>
         </article>
 
@@ -210,24 +210,24 @@
             <h3 class="team-card__name">Atlas-Prime</h3>
             <span class="team-card__version">Power v0.9</span>
           </div>
-          <p class="team-card__role">Strategy Copilot (AI)</p>
+          <p class="team-card__role">Portfolio Manager</p>
           <dl>
             <dt>Area of responsibility</dt>
-            <dd>Assisting with scenario analysis, research note drafting, and surfacing anomalies across the dataset.</dd>
+            <dd>Coordinating portfolio construction, execution sequencing, and oversight of ongoing risk posture.</dd>
             <dt>Problems on deck</dt>
             <dd>
               <div class="team-focus">
-                <span>Explainability</span>
-                <span>Anomaly detection</span>
-                <span>Prompt safety</span>
+                <span>Trade orchestration</span>
+                <span>Risk alignment</span>
+                <span>Auditability</span>
               </div>
               <ul>
-                <li>Keep recommendations auditable with traceable evidence chains.</li>
-                <li>Reduce hallucinations through retrieval-augmented prompting.</li>
+                <li>Keep allocation changes synchronized with valuation and sizing updates for a unified playbook.</li>
+                <li>Maintain real-time logs that justify every trade with linked research and sizing evidence.</li>
               </ul>
             </dd>
             <dt>Currently shipping</dt>
-            <dd>Pairing with DataSynth-01 on a structured note generator that references filings, transcripts, and quant outputs.</dd>
+            <dd>Running coordinated rebalance drills that stitch valuation shifts, sizing rules, and execution tickets together.</dd>
           </dl>
         </article>
       </div>


### PR DESCRIPTION
## Summary
- update the team navigation spotlight to reflect ValueBot as Equity Analyst, EchoWeaver as Chief Sizing Officer, and Atlas-Prime as Portfolio Manager
- rewrite ValueBot's responsibilities to focus on equity research and valuation workflows
- shift EchoWeaver and Atlas-Prime descriptions to cover sizing governance and portfolio management duties

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d9b343d494832db6fc07c4100bf322