### PR TITLE
Move AI configuration into task workspace

### DIFF
--- a/assets/editor.js
+++ b/assets/editor.js
@@ -260,6 +260,8 @@ async function initEditor() {
   const aiKeyPreview = document.getElementById('aiKeyPreview');
   const aiKeyPreviewValue = document.getElementById('aiKeyPreviewValue');
   const aiModel = document.getElementById('aiModel');
+  const taskNameInput = document.getElementById('taskName');
+  const taskTitle = document.getElementById('analysisTaskTitle');
   const promptSelectBtn = document.getElementById('promptSelectBtn');
   const promptSelectLabel = document.getElementById('promptSelectLabel');
   const promptMenu = document.getElementById('promptMenu');
@@ -320,6 +322,7 @@ async function initEditor() {
   const aiSettingsModelDefault = (aiSettingsModel?.textContent || '').trim();
   const aiSettingsPromptDefault = (aiSettingsPrompt?.textContent || '').trim();
   const aiSettingsKeyDefault = (aiSettingsKey?.textContent || '').trim();
+  const taskTitleDefault = (taskTitle?.textContent || '').trim();
 
   if (!form || !locked) return;
 
@@ -361,6 +364,12 @@ async function initEditor() {
     const displayName = optionLabel || storedPreference;
     if (analystLastName) analystLastName.textContent = displayName || 'Model';
     if (aiSettingsModel) aiSettingsModel.textContent = displayName || aiSettingsModelDefault || 'Pending selection';
+  };
+
+  const updateTaskTitle = () => {
+    if (!taskTitle) return;
+    const value = (taskNameInput?.value || '').trim();
+    taskTitle.textContent = value ? `Task - ${value}` : taskTitleDefault || 'Task';
   };
 
   const updatePromptSettingsSummary = () => {
@@ -1396,6 +1405,7 @@ async function initEditor() {
 
   switchAnalysisMode('manual');
   await loadAiConfig({ includeRemote: true });
+  updateTaskTitle();
 
   modeButtons.forEach((btn) => {
     btn.addEventListener('click', () => {
@@ -1412,6 +1422,10 @@ async function initEditor() {
       persistAiConfig();
       updateAnalystIdentity();
     });
+  }
+
+  if (taskNameInput) {
+    ['input', 'change'].forEach((evt) => taskNameInput.addEventListener(evt, updateTaskTitle));
   }
 
   if (promptSelectBtn) {

--- a/editor.html
+++ b/editor.html
@@ -112,6 +112,8 @@
     .analysis-task__panel{border:1px solid var(--border,#e5e7eb);border-radius:16px;padding:20px;background:var(--panel-muted,#f8fafc);display:grid;gap:16px}
     .analysis-task__panel .muted-small{margin:4px 0 0}
     .analysis-task__panel textarea{background:var(--panel,#fff)}
+    .analysis-task__config{gap:20px}
+    .task-name-field{display:grid;gap:8px}
     .analysis-source{display:grid;gap:14px}
     .analysis-source__head{display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:space-between}
     .analysis-source__modes{display:flex;gap:8px;flex-wrap:wrap}
@@ -421,28 +423,6 @@
           <section class="summary-subcard" aria-label="Tasks">
             <h3 class="summary-subcard__title">Tasks</h3>
             <div class="summary-subcard__content">
-              <div class="ai-structures">
-                <div class="field-row">
-                  <div>
-                    <label for="aiModel">Model</label>
-                    <div class="select-edit">
-                      <select id="aiModel"></select>
-                      <button type="button" class="btn small ghost" id="editModelList">Edit list</button>
-                    </div>
-                    <p class="muted-small">Select from saved OpenRouter models or edit the list for this workspace.</p>
-                  </div>
-                  <div>
-                    <label for="aiKey">AI API key</label>
-                    <input id="aiKey" type="password" placeholder="Paste your OpenRouter key" autocomplete="off" />
-                    <div class="ai-key-actions">
-                      <button type="button" class="btn small ghost" id="refreshAiKey">Refresh from Supabase</button>
-                      <span class="muted-small" id="aiKeyStatus" role="status" aria-live="polite"></span>
-                    </div>
-                    <p class="muted-small">Stored locally in this browser. Admins can refresh to sync the server key used for AI calls.</p>
-                    <p class="ai-key-preview" id="aiKeyPreview" hidden>Active key: <code id="aiKeyPreviewValue"></code></p>
-                  </div>
-                </div>
-              </div>
               <ul class="ai-settings-list">
                 <li>
                   <strong>Primary model</strong>
@@ -472,8 +452,37 @@
     <form id="analysisForm" class="editor-grid" hidden>
       <section class="analysis-task" aria-label="Task workspace">
         <header class="analysis-task__head">
-          <h2 class="analysis-task__title">Task</h2>
+          <h2 class="analysis-task__title" id="analysisTaskTitle">Task</h2>
         </header>
+        <section class="analysis-task__panel analysis-task__config" aria-label="Task setup">
+          <div class="task-name-field">
+            <label for="taskName">Task name</label>
+            <input id="taskName" type="text" placeholder="Name this task" autocomplete="off" />
+            <p class="muted-small">Appears in the task header below.</p>
+          </div>
+          <div class="ai-structures">
+            <div class="field-row">
+              <div>
+                <label for="aiModel">Model</label>
+                <div class="select-edit">
+                  <select id="aiModel"></select>
+                  <button type="button" class="btn small ghost" id="editModelList">Edit list</button>
+                </div>
+                <p class="muted-small">Select from saved OpenRouter models or edit the list for this workspace.</p>
+              </div>
+              <div>
+                <label for="aiKey">AI API key</label>
+                <input id="aiKey" type="password" placeholder="Paste your OpenRouter key" autocomplete="off" />
+                <div class="ai-key-actions">
+                  <button type="button" class="btn small ghost" id="refreshAiKey">Refresh from Supabase</button>
+                  <span class="muted-small" id="aiKeyStatus" role="status" aria-live="polite"></span>
+                </div>
+                <p class="muted-small">Stored locally in this browser. Admins can refresh to sync the server key used for AI calls.</p>
+                <p class="ai-key-preview" id="aiKeyPreview" hidden>Active key: <code id="aiKeyPreviewValue"></code></p>
+              </div>
+            </div>
+          </div>
+        </section>
         <div class="analysis-task__grid">
           <section class="analysis-source analysis-task__panel" aria-label="Analysis input">
             <div class="analysis-source__head">


### PR DESCRIPTION
## Summary
- move the model and API key controls into the Task workspace card and add a Task name input that populates the card header
- tune the Task workspace styles to accommodate the new setup panel
- update the editor logic so the header stays in sync with the Task name field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dae9d91364832d9528d1106b42cfad