### PR TITLE
Improve task modal handling when editor is locked

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1313,3 +1313,37 @@ body.theme-light table.grid pre{
 .auth-profile-actions{display:flex;gap:10px;flex-wrap:wrap}
 .auth-profile .btn{width:auto}
 
+.task-launch-card[aria-disabled="true"]{
+  cursor:not-allowed;
+  opacity:.55;
+}
+
+.task-launch-card[aria-disabled="true"]:focus-visible{
+  outline-color:var(--muted,#64748b);
+}
+
+.task-locked-message{
+  border:1px solid color-mix(in srgb,var(--border,#1a2147) 70%,#5af 30%);
+  border-radius:14px;
+  padding:1.4rem;
+  margin-bottom:1.5rem;
+  background:color-mix(in srgb,var(--card,#121733) 90%,#1b2b6a 10%);
+  display:grid;
+  gap:.75rem;
+  box-shadow:0 12px 30px rgba(15,23,42,.45);
+}
+
+.task-locked-message h3{
+  margin:0;
+  font-size:1.05rem;
+}
+
+.task-locked-message p{
+  margin:0;
+  color:color-mix(in srgb,var(--muted,#94a3b8) 70%,#fff 30%);
+}
+
+.task-locked-message .btn{
+  justify-self:start;
+}
+

--- a/editor.html
+++ b/editor.html
@@ -471,6 +471,11 @@
           <button type="button" class="btn small ghost" id="closeTaskModal">Close</button>
         </header>
         <div class="modal__body modal__body--task">
+          <div id="taskLockedMessage" class="task-locked-message" hidden tabindex="-1" role="alert">
+            <h3>Task workspace locked</h3>
+            <p id="taskLockedMessageText">Sign in with an admin account to open the task workspace.</p>
+            <button class="btn small" type="button" id="taskLockedAction" data-open-auth="signin">Sign in</button>
+          </div>
           <form id="analysisForm" class="editor-grid" hidden>
             <section class="analysis-task" aria-label="Task workspace">
               <section class="analysis-task__panel analysis-task__config" aria-label="Task setup">


### PR DESCRIPTION
## Summary
- allow the task launch button to surface a lock notice instead of silently doing nothing when admin access is missing
- style the disabled task launcher and locked-state messaging within the modal for better clarity
- keep the locked notice in sync with existing auth actions when access state changes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68daf61ca130832dabc80c64887e4a43