### PR TITLE
Fix editor task modal launch when locked

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -89,6 +89,9 @@
     .task-launch-card:hover:not(:disabled){border-color:var(--accent,#2563eb);box-shadow:0 14px 26px rgba(37,99,235,.15);transform:translateY(-2px)}
     .task-launch-card:focus-visible{outline:3px solid rgba(37,99,235,.35);outline-offset:2px;border-color:var(--accent,#2563eb);box-shadow:0 14px 26px rgba(37,99,235,.15);transform:translateY(-2px)}
     .task-launch-card:disabled{cursor:not-allowed;opacity:.6;box-shadow:none;transform:none}
+    .task-launch-card[data-state="locked"]{border-style:dashed;opacity:.78;cursor:pointer;box-shadow:none;transform:none}
+    .task-launch-card[data-state="locked"]:hover{border-color:var(--border,#e5e7eb);box-shadow:none;transform:none}
+    .task-launch-card[data-state="locked"] .task-launch-card__subtitle{color:var(--warn,#f6b73c);font-weight:600}
     .task-launch-card__title{font-size:1.05rem;font-weight:600;color:var(--text,#0f172a)}
     .task-launch-card__subtitle{font-size:.85rem;color:var(--muted,#64748b)}
     .editor-grid{display:grid;gap:18px}


### PR DESCRIPTION
## Summary
- keep the editor task launch button interactive even when the workspace is locked
- update the task card styling and messaging to communicate the admin sign-in requirement

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68db116b34cc832d8989a89283688f2b