### PR TITLE
Update coverage helper text for Buyback Extreme

### DIFF
--- a/assets/editor.js
+++ b/assets/editor.js
@@ -1089,7 +1089,7 @@ async function initEditor() {
     if (activeState) {
       activeState.name = value;
     }
-    const defaultDisplay = taskTitleDefault || 'What can I help you with?';
+    const defaultDisplay = taskTitleDefault || 'Buyback Extreme';
     const display = value ? `${defaultDisplay} - ${value}` : defaultDisplay;
     if (taskTitle) {
       taskTitle.textContent = display;

--- a/editor.html
+++ b/editor.html
@@ -406,6 +406,7 @@
                   </div>
                 </div>
                 <p class="coverage-meta__hint">Only the company name is required to run a prompt.</p>
+                <p class="coverage-meta__hint">What can I help you with?</p>
               </div>
             </div>
             <aside class="coverage-meta__aside" aria-label="Automation workspace launcher">
@@ -475,7 +476,7 @@
     <div class="editor-summary-grid editor-summary-grid--full" aria-label="Workflow console">
       <article class="summary-card summary-card--combined summary-card--task" aria-label="Task overview">
         <header class="summary-card__head">
-          <h2 class="summary-card__title">What can I help you with?</h2>
+          <h2 class="summary-card__title">Buyback Extreme</h2>
         </header>
         <div class="summary-card__sections">
           <section class="summary-subcard" aria-label="Process progress">


### PR DESCRIPTION
## Summary
- rename the workflow summary card title to "Buyback Extreme"
- add helper text under the coverage target guidance
- align the default task title fallback in the editor script with the new name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc10a58428832d84b3e7fbcfb23880