### PR TITLE
feat: add equity analyst blueprint page and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ universe, and internal tooling.
 
 - [Supabase database reference](docs/supabase-schema.md) — canonical contract for the
   tables, policies, and triggers the frontend expects.
+- [Automated equity analyst roadmap](docs/equity-analyst-roadmap.md) — phased build plan for the
+  multi-stage research system and associated UI.

--- a/docs/equity-analyst-roadmap.md
+++ b/docs/equity-analyst-roadmap.md
@@ -1,0 +1,97 @@
+# Automated Equity Analyst Development Roadmap
+
+This roadmap translates the analyst automation conversation into an actionable, PR-by-PR delivery
+plan. Treat each phase as a small, reviewable milestone so the Codex workflow can ship improvements
+incrementally.
+
+## 0. Foundations (Week 0)
+- [ ] **Repository scaffolding** – confirm `/web`, `/api`, `/sql`, `/docs` folders exist and add
+      `.env.example` with `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `OPENAI_API_KEY`.
+- [ ] **Dependencies** – ensure Supabase and OpenAI SDKs installed where server code will run.
+- [ ] **Design brief** – circulate this roadmap + equity_analyst.html overview with stakeholders.
+
+## 1. Data Contract & Seed (Week 1)
+- [ ] `sql/001_core.sql` – create `tickers`, `runs`, `run_items`, `answers`, `cost_ledger`,
+      `sector_prompts`, and `doc_chunks` tables.
+- [ ] `sql/002_seed.sql` – seed 10 flagship tickers across sectors.
+- [ ] Add Supabase migration scripts / npm tasks to run migrations locally and in staging.
+
+## 2. Planner Experience (Week 1–2)
+- [ ] Build `web/admin/planner.html` with live cost estimator (universe slider, survival sliders,
+      per-stage token inputs, model selectors, total cost output).
+- [ ] Persist planner state to `localStorage` and surface a **Start Run** CTA.
+- [ ] Implement `/api/runs/create` endpoint to insert a run row and queue `run_items`.
+
+## 3. Stage 1 – Cheap Triage (Week 2)
+- [ ] `/api/stage1/consume` worker: pull pending items, call GPT-4o-mini, store JSON label + usage
+      in `answers` and `cost_ledger`, update `run_items`.
+- [ ] Planner UI: add **Process Stage 1 batch** control and progress stats (processed / total /
+      remaining).
+- [ ] Add retry/backoff (429, 5xx) and structured error logging for failed items.
+
+## 4. Stage 2 – Thematic Scoring (Week 3)
+- [ ] Survivor filter: only `label` in (`consider`, `borderline`).
+- [ ] `/api/stage2/consume`: gather sector notes, Stage 1 output, retrieved snippets; call GPT-5-mini
+      with JSON schema covering profitability, reinvestment, leverage, moat, timing.
+- [ ] Persist `go_deep` boolean to `run_items` and show Stage 2 progress in planner.
+
+## 5. Sector Intelligence CMS (Week 3)
+- [ ] `web/admin/sectors.html`: CRUD editor for `sector_prompts` with autosave + version tag.
+- [ ] Surface sector notes summary inside planner to remind analysts what heuristics are in play.
+
+## 6. Stage 3 – Deep Dive Reports (Week 4)
+- [ ] `/api/stage3/consume`: for tickers with `go_deep=true`, orchestrate 4–6 grouped prompts using
+      GPT-5, injecting retrieved RAG facts (from `doc_chunks`).
+- [ ] Store each grouped response in `answers`; synthesise a long-form narrative into
+      `answer_text`.
+- [ ] Planner UI: **Process Stage 3 batch** and highlight total deep-dive spend.
+
+## 7. Universe & Report Views (Week 4–5)
+- [ ] `web/universe.html`: searchable table summarising ticker, stage, label, scores, spend.
+- [ ] `web/ticker/{ticker}.html`: render Stage 1–3 outputs, sector notes, and allow CSV / JSON
+      export.
+- [ ] Add shareable permalink for members (respect Supabase Auth).
+
+## 8. Cost Governance (Week 5)
+- [ ] Store `runs.budget_usd` and show in planner alongside actual cost-to-date.
+- [ ] Auto-stop runs when spend >= budget or when `stop_requested` is true.
+- [ ] Add sparkline / bar chart for stage-level spend (client-side or lightweight chart lib).
+
+## 9. Automation Loop (Week 6)
+- [ ] `/api/runs/continue` endpoint to sequentially trigger Stage 1 → 3 until batch limit / stop.
+- [ ] Planner toggle for **Auto continue** that polls the endpoint every N seconds.
+- [ ] Optional: schedule nightly cron (Supabase Edge) to run small watchlists.
+
+## 10. Retrieval Augmentation (Week 6–7)
+- [ ] `docs` uploader UI to add filings, transcripts, letters; chunk + embed into `doc_chunks`.
+- [ ] Retrieval helper RPC (e.g., `match_doc_chunks`) returning top-k snippets per query.
+- [ ] Integrate retrieved snippets into Stage 2 & 3 prompts with citation metadata.
+
+## 11. Member Experience & Auth (Week 7)
+- [ ] Gate analyst pages behind Supabase Auth; provide onboarding flow for new members.
+- [ ] Track per-user quotas (e.g., runs per day) using Supabase policies or server logic.
+- [ ] Post-run feedback widget so members can trigger manual follow-up questions (optional).
+
+## 12. Observability & Safety (Week 8)
+- [ ] `/api/health` endpoint (DB + OpenAI status) for uptime monitors.
+- [ ] `error_logs` table + viewer UI capturing payloads, prompt ids, retry counts.
+- [ ] Automated regression tests for prompt output schemas and JSON validators.
+
+## 13. Prompt & Model Registry (Week 8–9)
+- [ ] Store prompt templates as markdown files with interpolation tokens.
+- [ ] Central config (e.g., `config/models.json`) containing price per model, default temperature,
+      cache policy, retry settings.
+- [ ] Loader utility to compose prompts per sector & stage and to map usage -> cost ledger.
+
+## 14. Stretch Enhancements (Backlog)
+- [ ] Cached context via OpenAI Responses API to reuse deterministic summaries.
+- [ ] Advanced scoring ensembles (blend LLM output with deterministic factors).
+- [ ] User-triggered “Focus questions” appended post Stage 3.
+- [ ] Automated notification system (email / Slack) when high-conviction names found.
+
+---
+
+### Working style notes
+- Ship in small PRs; keep each milestone isolated (DB, API, UI) to simplify QA.
+- Document prompts and schema updates in `/docs/changelog.md` for future analysts.
+- Reference `equity_analyst.html` during design reviews to keep UI & DX aligned.

--- a/equity_analyst.html
+++ b/equity_analyst.html
@@ -1,0 +1,246 @@
+<!doctype html>
+<html lang="en" data-lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>FutureFunds — Automated Equity Analyst Blueprint</title>
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <style>
+    .editor-wrap{max-width:960px;margin:32px auto;padding:0 16px}
+    .analyst-header{display:grid;gap:18px;margin-bottom:28px}
+    .analyst-header__info{display:grid;gap:8px}
+    .analyst-header__info .editor-title{margin:0}
+    .analyst-header__info .editor-intro{margin:0}
+    .analyst-header__panel{border:1px solid var(--border,#e5e7eb);border-radius:22px;background:var(--panel,#fff);box-shadow:0 14px 28px rgba(15,23,42,.08);padding:20px;display:grid;gap:20px}
+    .analyst-badge{justify-self:center;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px;padding:16px;border:1px solid var(--border,#e5e7eb);border-radius:18px;background:var(--panel,#fff);box-shadow:0 12px 24px rgba(15,23,42,.06);width:100%;max-width:320px;min-height:164px;text-align:center}
+    .analyst-badge__photo{width:68px;height:68px;border-radius:14px;overflow:hidden;background:var(--panel-muted,#f8fafc);display:flex;align-items:center;justify-content:center;border:1px solid var(--border,#e5e7eb)}
+    .analyst-badge__photo img{width:100%;height:100%;object-fit:cover}
+    .analyst-badge__name{font-size:1.05rem;font-weight:600;color:var(--text,#0f172a);margin:0}
+    .analyst-badge__role{font-size:.78rem;color:var(--muted,#64748b);margin:0}
+    .analyst-badge__stamp{font-size:.75rem;color:var(--muted,#64748b);margin:0}
+    .analyst-badge__status{font-size:.78rem;color:var(--muted,#64748b);margin:0}
+    .analyst-badge__status strong{color:var(--text,#0f172a)}
+    .analyst-badge__actions{display:flex;flex-wrap:wrap;justify-content:center;gap:8px}
+    .analyst-header__panel .coverage-meta{margin:0;height:100%}
+    .analyst-header__panel .coverage-meta--compact{padding:0;border:none;box-shadow:none;background:transparent;gap:16px}
+    .analyst-header__panel .coverage-meta__layout{height:100%}
+    .analyst-header__panel .analyst-badge{justify-self:stretch;max-width:none;height:100%}
+    @media (min-width:768px){
+      .analyst-header__panel{grid-template-columns:minmax(0,.7fr) minmax(0,.3fr);align-items:stretch}
+    }
+    .editor-title{font-size:1.9rem;margin:0;color:var(--text,#0f172a);font-weight:700}
+    .editor-intro{margin:0;color:var(--muted,#64748b)}
+    .coverage-meta{margin:32px 0;padding:20px;border:1px solid var(--border,#e5e7eb);border-radius:18px;background:var(--panel,#fff);box-shadow:0 12px 24px rgba(15,23,42,.06);display:grid;gap:16px}
+    .coverage-meta--compact{margin:0;padding:20px;gap:18px;box-shadow:0 10px 20px rgba(15,23,42,.05);height:100%}
+    .coverage-meta__title{margin:0;font-size:1.15rem;font-weight:600;color:var(--text,#0f172a)}
+    .coverage-meta__layout{display:grid;gap:18px}
+    @media (min-width:768px){.coverage-meta__layout{grid-template-columns:minmax(0,1.2fr) minmax(0,.8fr);align-items:start}}
+    .coverage-meta__fields{display:grid;gap:18px;grid-template-columns:1fr;height:100%}
+    .coverage-meta__form-card{display:grid;gap:16px;padding:18px;border:1px solid var(--border,#e5e7eb);border-radius:14px;background:var(--panel-muted,#f8fafc);height:100%;transition:box-shadow .2s ease,border-color .2s ease}
+    .coverage-meta__counter-card{display:flex;align-items:center;justify-content:space-between;gap:18px;width:100%;padding:14px 16px;border:1px dashed rgba(37,99,235,.35);border-radius:14px;background:rgba(37,99,235,.08);color:var(--text,#0f172a);text-align:left;cursor:pointer;transition:transform .15s ease,box-shadow .15s ease,border-color .15s ease}
+    .coverage-meta__counter-info{display:grid;gap:4px}
+    .coverage-meta__counter-label{margin:0;font-size:.85rem;font-weight:600;color:var(--accent,#2563eb)}
+    .coverage-meta__counter-description{margin:0;font-size:.82rem;color:var(--muted,#475569)}
+    .coverage-meta__counter-value{font-size:1.4rem;font-weight:700;color:var(--text,#0f172a)}
+    .summary-card{border:1px solid var(--border,#e5e7eb);border-radius:18px;background:var(--panel,#fff);padding:18px;display:grid;gap:12px;box-shadow:0 10px 22px rgba(15,23,42,.05)}
+    .summary-card__title{margin:0;font-size:1.05rem;font-weight:600;color:var(--text,#0f172a)}
+    .summary-card__content{font-size:.92rem;color:var(--muted,#64748b);display:grid;gap:8px}
+    .editor-summary-grid{display:grid;gap:18px;margin-bottom:28px}
+    @media (min-width:768px){.editor-summary-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+    .editor-summary-grid--full{grid-template-columns:1fr}
+    .process-steps{list-style:none;margin:0;padding:0;display:grid;gap:8px}
+    .process-step{display:flex;align-items:center;gap:12px;padding:8px 12px;border-radius:14px;border:1px solid var(--border,#e5e7eb);background:var(--panel-muted,#f8fafc);transition:background .2s ease,border-color .2s ease,box-shadow .2s ease}
+    .process-step__icon{position:relative;flex-shrink:0;width:30px;height:30px;border-radius:999px;display:inline-flex;align-items:center;justify-content:center;color:var(--muted,#64748b)}
+    .process-step__icon::after{content:attr(data-step);display:flex;align-items:center;justify-content:center;width:100%;height:100%;border-radius:inherit;background:#fff;border:2px solid currentColor;font-size:.85rem;font-weight:600;box-sizing:border-box;transition:background .2s ease,color .2s ease,border-color .2s ease}
+    .process-step__body{flex:1}
+    .process-step__title{font-weight:600;color:var(--text,#0f172a);font-size:.9rem;margin:0}
+    .process-step__meta{color:var(--muted,#64748b);font-size:.82rem;margin:0}
+    .task-launch-card{display:grid;gap:4px;padding:16px;border:1px solid var(--border,#e5e7eb);border-radius:14px;background:var(--panel,#fff);text-align:left;cursor:pointer;transition:transform .15s ease,box-shadow .15s ease,border-color .15s ease;color:inherit;font:inherit;width:100%}
+    .task-launch-card:hover{border-color:var(--accent,#2563eb);box-shadow:0 14px 26px rgba(37,99,235,.15);transform:translateY(-2px)}
+    .task-launch-card__title{font-size:1.05rem;font-weight:600;color:var(--text,#0f172a)}
+    .task-launch-card__subtitle{font-size:.85rem;color:var(--muted,#64748b)}
+    .ai-settings-list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
+    .ai-settings-list strong{font-size:.9rem;color:var(--text,#0f172a)}
+    .ai-settings-list span{font-size:.85rem;color:var(--muted,#64748b)}
+    .analysis-export{display:grid;gap:18px}
+    .analysis-export__title{margin:0;font-size:1.15rem;font-weight:600;color:var(--text,#0f172a)}
+    .analysis-export__fields{display:grid;gap:18px}
+    .analysis-export__actions{display:flex;gap:12px;flex-wrap:wrap;align-items:center}
+  </style>
+</head>
+<body>
+  <main class="editor-wrap">
+    <header class="analyst-header">
+      <div class="analyst-header__info">
+        <h1 class="editor-title">Automated Equity Analyst Command Center</h1>
+        <p class="editor-intro">A next-generation workspace for orchestrating the multi-stage research robot, cost guardrails, and knowledge graph that power FutureFunds equity coverage.</p>
+      </div>
+      <section class="analyst-header__panel">
+        <article class="coverage-meta coverage-meta--compact">
+          <div class="coverage-meta__layout">
+            <div class="coverage-meta__fields">
+              <div class="coverage-meta__form-card">
+                <h2 class="coverage-meta__title">Run Planner Snapshot</h2>
+                <p class="muted-small">Track universe size, survival rates, and token budgets before hitting “go”. Sync these parameters with the live cost estimator widget.</p>
+                <div class="coverage-meta__counter-card" role="presentation">
+                  <div class="coverage-meta__counter-info">
+                    <p class="coverage-meta__counter-label">Current focus</p>
+                    <p class="coverage-meta__counter-description">Universe → Stage 1 → Stage 2 → Stage 3</p>
+                  </div>
+                  <p class="coverage-meta__counter-value">40,000 → 6,000 → 720 → 90</p>
+                </div>
+                <ul class="ai-settings-list">
+                  <li><strong>Stage 1:</strong> GPT-4o-mini · 3k in / 600 out tokens target · JSON triage</li>
+                  <li><strong>Stage 2:</strong> GPT-5-mini · 30k in / 6k out tokens target · thematic batches</li>
+                  <li><strong>Stage 3:</strong> GPT-5 · 5 x deep prompts w/ RAG · 100k in / 20k out tokens target</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </article>
+        <aside class="analyst-badge">
+          <div class="analyst-badge__photo">
+            <img src="/images/logo.png" alt="FutureFunds badge" />
+          </div>
+          <p class="analyst-badge__name">Mr. ValueBot</p>
+          <p class="analyst-badge__role">Autonomous Lead Analyst</p>
+          <p class="analyst-badge__stamp">Revision 2 · Oct 2025 pricing baseline</p>
+          <p class="analyst-badge__status"><strong>Status:</strong> Stage 2 build in progress</p>
+          <div class="analyst-badge__actions">
+            <button class="task-launch-card" type="button">
+              <span class="task-launch-card__title">Open Planner UI</span>
+              <span class="task-launch-card__subtitle">Launch the live calculator embedded in the app</span>
+            </button>
+          </div>
+        </aside>
+      </section>
+    </header>
+
+    <section class="editor-summary-grid">
+      <article class="summary-card">
+        <h2 class="summary-card__title">Pipeline Architecture</h2>
+        <div class="summary-card__content">
+          <ul class="process-steps">
+            <li class="process-step" data-status="complete">
+              <span class="process-step__icon" data-step="0"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Stage 0 · Deterministic screen</p>
+                <p class="process-step__meta">Universe filters (exchange, float, liquidity, sector guardrails)</p>
+              </div>
+            </li>
+            <li class="process-step" data-status="active">
+              <span class="process-step__icon" data-step="1"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Stage 1 · GPT-4o-mini triage</p>
+                <p class="process-step__meta">Return label + risk flags + data freshness check</p>
+              </div>
+            </li>
+            <li class="process-step" data-status="upcoming">
+              <span class="process-step__icon" data-step="2"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Stage 2 · GPT-5-mini thematic scoring</p>
+                <p class="process-step__meta">Batch 20 Q across profitability, reinvestment, leverage, moat, timing</p>
+              </div>
+            </li>
+            <li class="process-step" data-status="upcoming">
+              <span class="process-step__icon" data-step="3"></span>
+              <div class="process-step__body">
+                <p class="process-step__title">Stage 3 · GPT-5 deep dive</p>
+                <p class="process-step__meta">4–6 grouped prompts with RAG citations + final brief</p>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </article>
+      <article class="summary-card">
+        <h2 class="summary-card__title">Cost Control Toolkit</h2>
+        <div class="summary-card__content">
+          <p>Embed the live estimator widget to simulate spend scenarios before launching runs. Persist chosen parameters to Supabase so the worker functions can enforce limits.</p>
+          <ul class="ai-settings-list">
+            <li><strong>Budget guardrail:</strong> runs.budget_usd with auto-stop toggle</li>
+            <li><strong>Usage telemetry:</strong> cost_ledger rollups + per-stage sparkline</li>
+            <li><strong>Caching:</strong> GPT Responses API to reuse 10-K summaries</li>
+          </ul>
+        </div>
+      </article>
+    </section>
+
+    <section class="summary-card summary-card--task">
+      <div class="summary-card__head">
+        <h2 class="summary-card__title">Implementation Tracks</h2>
+      </div>
+      <div class="summary-card__content">
+        <p>Work through the three parallel tracks below. Each stage can ship independently and is mapped to the development roadmap README.</p>
+        <div class="editor-summary-grid editor-summary-grid--full">
+          <article class="summary-card">
+            <h3 class="summary-card__title">Data &amp; Retrieval</h3>
+            <div class="summary-card__content">
+              <ul class="ai-settings-list">
+                <li><strong>Universe ingestion:</strong> Load tickers &amp; sector tags via Supabase cron.</li>
+                <li><strong>Feature hub:</strong> Harmonise price feeds + fundamentals with provenance metadata.</li>
+                <li><strong>Doc lake:</strong> Parse filings / transcripts into chunked embeddings for RAG.</li>
+                <li><strong>Quality gates:</strong> Flag stale fundamentals &amp; missing prices before model calls.</li>
+              </ul>
+            </div>
+          </article>
+          <article class="summary-card">
+            <h3 class="summary-card__title">Prompt &amp; Model Orchestration</h3>
+            <div class="summary-card__content">
+              <ul class="ai-settings-list">
+                <li><strong>Prompt registry:</strong> Versioned markdown templates per stage &amp; sector.</li>
+                <li><strong>Dynamic context:</strong> Stage 2/3 fetch sector notes + retrieved facts + prior answers.</li>
+                <li><strong>Batch execution:</strong> Worker API endpoints process 10–25 tickers per invocation.</li>
+                <li><strong>Safety net:</strong> Auto retry + anomaly detection on inconsistent JSON.</li>
+              </ul>
+            </div>
+          </article>
+          <article class="summary-card">
+            <h3 class="summary-card__title">Experience Layer</h3>
+            <div class="summary-card__content">
+              <ul class="ai-settings-list">
+                <li><strong>Planner UI:</strong> Slider-based estimator + “Start run” + run monitor dashboard.</li>
+                <li><strong>Universe view:</strong> Filter by label, sector, stage, recency, cost spent.</li>
+                <li><strong>Ticker drilldown:</strong> Render structured answers, stage transitions, and citations.</li>
+                <li><strong>Member sandbox:</strong> Allow manual follow-up questions post-automation (phase 2).</li>
+              </ul>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="analysis-export">
+      <h2 class="analysis-export__title">Operational Checklist</h2>
+      <div class="analysis-export__fields">
+        <article class="summary-card">
+          <h3 class="summary-card__title">Readiness</h3>
+          <div class="summary-card__content">
+            <ul class="ai-settings-list">
+              <li><strong>✅ Environment:</strong> Supabase, OpenAI keys, and storage buckets configured.</li>
+              <li><strong>✅ Logging:</strong> errors, cost ledger, and run metadata stored per ticker.</li>
+              <li><strong>🔄 Upcoming:</strong> Integrate scheduler to cycle Stage 1 → Stage 3 automatically.</li>
+            </ul>
+          </div>
+        </article>
+        <article class="summary-card">
+          <h3 class="summary-card__title">Next sprint focus</h3>
+          <div class="summary-card__content">
+            <ul class="ai-settings-list">
+              <li><strong>Stage 1 worker:</strong> finish streaming pipeline &amp; UI progress counters.</li>
+              <li><strong>Sector CMS:</strong> capture analyst heuristics per vertical.</li>
+              <li><strong>Cost guardrails:</strong> enforce run.budget_usd + warnings in planner UI.</li>
+            </ul>
+          </div>
+        </article>
+      </div>
+      <div class="analysis-export__actions">
+        <a class="task-launch-card" href="docs/equity-analyst-roadmap.md">
+          <span class="task-launch-card__title">Open development roadmap</span>
+          <span class="task-launch-card__subtitle">View checklist &amp; PR-by-PR plan</span>
+        </a>
+        <p class="muted-small">Use this hub as the staging ground for stakeholder reviews while the build advances.</p>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated equity_analyst.html page that presents the multi-stage automation vision and operational checklist for the research robot
- document a phased delivery plan in docs/equity-analyst-roadmap.md and link it from the new page and main README

## Testing
- no automated tests were run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68e15c8f4f04832d9ade0a7cb73884a3