### PR TITLE
feat: add universe explorer and ticker report pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ universe, and internal tooling.
 
 - [Supabase database reference](docs/supabase-schema.md) — canonical contract for the
   tables, policies, and triggers the frontend expects.
+- [Automated equity analyst roadmap](docs/equity-analyst-roadmap.md) — phased build plan for the
+  multi-stage research system and associated UI.
+- [Sector prompt library](sectors.html) — admin console to curate Stage 2 heuristics synced to the planner.
+- [Universe cockpit](universe.html) — requires the helper functions from `sql/003_dashboard_helpers.sql`
+  and `sql/005_universe_snapshot.sql` to surface run outputs and ticker dossiers.
+- Database migrations live under `/sql` (apply them with `supabase db push` or your preferred
+  migration runner).

--- a/assets/equity-analyst.js
+++ b/assets/equity-analyst.js
@@ -1,0 +1,713 @@
+import {
+  supabase,
+  ensureProfile,
+  hasAdminRole,
+  isMembershipActive,
+  getUser,
+  getProfile,
+  getMembership
+} from './supabase.js';
+
+const RUN_STORAGE_KEY = 'ff-analyst-active-run';
+const REFRESH_INTERVAL_MS = 30000;
+
+const selectors = {
+  runSelect: document.getElementById('runSelect'),
+  refreshRunsBtn: document.getElementById('refreshRunsBtn'),
+  accessNotice: document.getElementById('accessNotice'),
+  dashboardStatus: document.getElementById('dashboardStatus'),
+  runStatus: document.getElementById('runStatus'),
+  runCreated: document.getElementById('runCreated'),
+  runStage1Pending: document.getElementById('runStage1Pending'),
+  runFailures: document.getElementById('runFailures'),
+  runStopRequested: document.getElementById('runStopRequested'),
+  runNotes: document.getElementById('runNotes'),
+  costBreakdownList: document.getElementById('costBreakdownList'),
+  metricTotalTickers: document.getElementById('metricTotalTickers'),
+  metricStage1Complete: document.getElementById('metricStage1Complete'),
+  metricStage2Queue: document.getElementById('metricStage2Queue'),
+  metricStage3Queue: document.getElementById('metricStage3Queue'),
+  metricSpend: document.getElementById('metricSpend'),
+  metricTokens: document.getElementById('metricTokens'),
+  metricStage1Pending: document.getElementById('metricStage1Pending'),
+  metricStage1Done: document.getElementById('metricStage1Done'),
+  metricStage2Done: document.getElementById('metricStage2Done'),
+  metricStage3Done: document.getElementById('metricStage3Done'),
+  metricFailures: document.getElementById('metricFailures'),
+  stage1Percent: document.getElementById('stage1Percent'),
+  stage1Progress: document.getElementById('stage1Progress'),
+  stage1CompletedCount: document.getElementById('stage1CompletedCount'),
+  stage1PendingCount: document.getElementById('stage1PendingCount'),
+  stage1FailedCount: document.getElementById('stage1FailedCount'),
+  stage1LabelList: document.getElementById('stage1LabelList'),
+  stage2Percent: document.getElementById('stage2Percent'),
+  stage2Progress: document.getElementById('stage2Progress'),
+  stage2CompletedCount: document.getElementById('stage2CompletedCount'),
+  stage2QueueCount: document.getElementById('stage2QueueCount'),
+  stage2FailedCount: document.getElementById('stage2FailedCount'),
+  stage3Percent: document.getElementById('stage3Percent'),
+  stage3Progress: document.getElementById('stage3Progress'),
+  stage3CompletedCount: document.getElementById('stage3CompletedCount'),
+  stage3QueueCount: document.getElementById('stage3QueueCount'),
+  stage3FailedCount: document.getElementById('stage3FailedCount'),
+  activityBody: document.getElementById('activityBody'),
+  activityEmpty: document.getElementById('activityEmpty'),
+  pipelineUpdated: document.getElementById('pipelineUpdated')
+};
+
+const stageNames = new Map([
+  [0, 'Queued'],
+  [1, 'Stage 1'],
+  [2, 'Stage 2'],
+  [3, 'Stage 3']
+]);
+
+const state = {
+  runs: [],
+  activeRunId: null,
+  pollTimer: null,
+  auth: {
+    ready: false,
+    admin: false,
+    membershipActive: false,
+    userEmail: null
+  }
+};
+
+function formatNumber(value) {
+  if (value == null || Number.isNaN(value)) return '—';
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function formatCompactNumber(value) {
+  if (value == null || Number.isNaN(value)) return '—';
+  return new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 }).format(value);
+}
+
+function formatCurrency(value) {
+  if (value == null || Number.isNaN(value)) return '—';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 }).format(value);
+}
+
+function formatTokens(inTokens, outTokens) {
+  if ((inTokens == null || Number.isNaN(inTokens)) && (outTokens == null || Number.isNaN(outTokens))) {
+    return '—';
+  }
+  const inbound = formatCompactNumber(inTokens ?? 0);
+  const outbound = formatCompactNumber(outTokens ?? 0);
+  return `${inbound} in / ${outbound} out`;
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    }).format(new Date(value));
+  } catch (error) {
+    console.warn('Unable to format date', value, error);
+    return '—';
+  }
+}
+
+function formatFullDate(value) {
+  if (!value) return '—';
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit'
+    }).format(new Date(value));
+  } catch (error) {
+    return '—';
+  }
+}
+
+function setText(element, value) {
+  if (!element) return;
+  element.textContent = value;
+}
+
+function setStatus(message, isError = false) {
+  const el = selectors.dashboardStatus;
+  if (!el) return;
+  if (!message) {
+    el.hidden = true;
+    el.textContent = '';
+    el.classList.remove('notice--warning');
+    return;
+  }
+  el.hidden = false;
+  el.textContent = message;
+  if (isError) {
+    el.classList.add('notice--warning');
+  } else {
+    el.classList.remove('notice--warning');
+  }
+}
+
+function updateAccessNotice(message, isError = false) {
+  const el = selectors.accessNotice;
+  if (!el) return;
+  el.textContent = message;
+  if (isError) {
+    el.classList.add('notice--warning');
+  } else {
+    el.classList.remove('notice--warning');
+  }
+}
+
+function disableControls() {
+  if (selectors.runSelect) selectors.runSelect.disabled = true;
+  if (selectors.refreshRunsBtn) selectors.refreshRunsBtn.disabled = true;
+}
+
+function enableControls() {
+  if (selectors.runSelect) selectors.runSelect.disabled = false;
+  if (selectors.refreshRunsBtn) selectors.refreshRunsBtn.disabled = false;
+}
+
+function stageLabel(stage) {
+  return stageNames.get(Number(stage)) ?? `Stage ${stage}`;
+}
+
+function setProgressBar(bar, percent) {
+  if (!bar) return;
+  const clamped = Math.max(0, Math.min(100, Number(percent) || 0));
+  bar.style.width = `${clamped}%`;
+  const parent = bar.parentElement;
+  if (parent) {
+    parent.setAttribute('aria-valuenow', String(clamped));
+  }
+}
+
+function clearList(listEl, emptyMessage) {
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  if (emptyMessage) {
+    const li = document.createElement('li');
+    li.textContent = emptyMessage;
+    listEl.appendChild(li);
+  }
+}
+
+function clearDashboard() {
+  setText(selectors.runStatus, '—');
+  setText(selectors.runCreated, '—');
+  setText(selectors.runStage1Pending, '—');
+  setText(selectors.runFailures, '—');
+  setText(selectors.runStopRequested, '—');
+  if (selectors.runNotes) {
+    selectors.runNotes.textContent = '';
+    selectors.runNotes.classList.remove('run-notes--visible');
+  }
+
+  setText(selectors.metricTotalTickers, '—');
+  setText(selectors.metricStage1Complete, '—');
+  setText(selectors.metricStage2Queue, '—');
+  setText(selectors.metricStage3Queue, '—');
+  setText(selectors.metricSpend, '—');
+  setText(selectors.metricTokens, '—');
+  setText(selectors.metricStage1Pending, '—');
+  setText(selectors.metricStage1Done, '—');
+  setText(selectors.metricStage2Done, '—');
+  setText(selectors.metricStage3Done, '—');
+  setText(selectors.metricFailures, '—');
+
+  setText(selectors.stage1Percent, '0%');
+  setText(selectors.stage2Percent, '0%');
+  setText(selectors.stage3Percent, '0%');
+  setProgressBar(selectors.stage1Progress, 0);
+  setProgressBar(selectors.stage2Progress, 0);
+  setProgressBar(selectors.stage3Progress, 0);
+  setText(selectors.stage1CompletedCount, '—');
+  setText(selectors.stage1PendingCount, '—');
+  setText(selectors.stage1FailedCount, '—');
+  setText(selectors.stage2CompletedCount, '—');
+  setText(selectors.stage2QueueCount, '—');
+  setText(selectors.stage2FailedCount, '—');
+  setText(selectors.stage3CompletedCount, '—');
+  setText(selectors.stage3QueueCount, '—');
+  setText(selectors.stage3FailedCount, '—');
+  clearList(selectors.stage1LabelList, 'No Stage 1 verdicts yet.');
+  clearList(selectors.costBreakdownList, 'No spend recorded yet.');
+  if (selectors.pipelineUpdated) setText(selectors.pipelineUpdated, '—');
+
+  if (selectors.activityBody) selectors.activityBody.innerHTML = '';
+  if (selectors.activityEmpty) selectors.activityEmpty.hidden = false;
+}
+
+function buildStageMetrics(rows = []) {
+  const stageMap = new Map();
+  let totalFailures = 0;
+
+  rows.forEach((row) => {
+    const stage = Number(row.stage ?? 0);
+    const status = String(row.status ?? '').toLowerCase() || 'pending';
+    const total = Number(row.total ?? 0);
+
+    if (!stageMap.has(stage)) {
+      stageMap.set(stage, { total: 0, statuses: {} });
+    }
+    const bucket = stageMap.get(stage);
+    bucket.total += total;
+    bucket.statuses[status] = (bucket.statuses[status] ?? 0) + total;
+
+    if (status === 'failed') {
+      totalFailures += total;
+    }
+  });
+
+  const totalTickers = Array.from(stageMap.values()).reduce((sum, bucket) => sum + bucket.total, 0);
+  const stage1Pending = stageMap.get(0)?.statuses?.pending ?? 0;
+  const stage1Failed = stageMap.get(0)?.statuses?.failed ?? 0;
+  const stage1Skipped = stageMap.get(0)?.statuses?.skipped ?? 0;
+
+  let stage1Completed = 0;
+  let stage2Completed = 0;
+  let stage3Completed = 0;
+  let stage2Failed = 0;
+  let stage3Failed = 0;
+
+  for (const [stage, bucket] of stageMap.entries()) {
+    const ok = bucket.statuses.ok ?? 0;
+    const failed = bucket.statuses.failed ?? 0;
+
+    if (stage >= 1) stage1Completed += ok;
+    if (stage >= 2) stage2Completed += ok;
+    if (stage >= 3) stage3Completed += ok;
+
+    if (stage === 1) stage2Failed += failed;
+    if (stage >= 2) stage3Failed += failed;
+  }
+
+  const stage2Queue = stageMap.get(1)?.statuses?.ok ?? 0;
+  const stage3Queue = stageMap.get(2)?.statuses?.ok ?? 0;
+
+  return {
+    stageMap,
+    totalTickers,
+    stage1Pending,
+    stage1Completed,
+    stage2Completed,
+    stage3Completed,
+    stage2Queue,
+    stage3Queue,
+    totalFailures,
+    stage1Failed,
+    stage2Failed,
+    stage3Failed,
+    stage1Skipped
+  };
+}
+
+function populateRunSelect() {
+  const select = selectors.runSelect;
+  if (!select) return;
+  const previousValue = select.value;
+  select.innerHTML = '';
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Select a run…';
+  select.appendChild(placeholder);
+
+  state.runs.forEach((run) => {
+    const option = document.createElement('option');
+    option.value = run.id;
+    const status = (run.status ?? 'queued').toUpperCase();
+    option.textContent = `${formatDate(run.created_at)} · ${status}`;
+    select.appendChild(option);
+  });
+
+  if (state.activeRunId) {
+    select.value = state.activeRunId;
+  } else if (previousValue && state.runs.some((run) => run.id === previousValue)) {
+    select.value = previousValue;
+  }
+}
+
+function renderLabelList(labels = [], totalCompleted = 0) {
+  const list = selectors.stage1LabelList;
+  if (!list) return;
+  list.innerHTML = '';
+  if (!labels.length) {
+    const li = document.createElement('li');
+    li.textContent = 'No Stage 1 verdicts yet.';
+    list.appendChild(li);
+    return;
+  }
+  labels.forEach((row) => {
+    const li = document.createElement('li');
+    const label = (row.label ?? 'Unlabeled').toString();
+    const total = Number(row.total ?? 0);
+    const percent = totalCompleted > 0 ? Math.round((total / totalCompleted) * 100) : 0;
+    li.innerHTML = `<strong>${label}</strong> — ${formatNumber(total)} (${percent}%)`;
+    list.appendChild(li);
+  });
+}
+
+function renderCostBreakdown(rows = []) {
+  const list = selectors.costBreakdownList;
+  if (!list) return;
+  list.innerHTML = '';
+  if (!rows.length) {
+    const li = document.createElement('li');
+    li.textContent = 'No spend recorded yet.';
+    list.appendChild(li);
+    return;
+  }
+  rows.forEach((row) => {
+    const li = document.createElement('li');
+    const stage = stageLabel(row.stage);
+    const model = row.model ?? 'unknown model';
+    const cost = formatCurrency(row.cost_usd ?? 0);
+    const tokens = formatTokens(row.tokens_in ?? 0, row.tokens_out ?? 0);
+    li.innerHTML = `<strong>${stage}</strong> · ${model} — ${cost} (${tokens})`;
+    list.appendChild(li);
+  });
+}
+
+function renderActivity(rows = []) {
+  const tbody = selectors.activityBody;
+  const empty = selectors.activityEmpty;
+  if (!tbody) return;
+  tbody.innerHTML = '';
+
+  if (!rows.length) {
+    if (empty) empty.hidden = false;
+    return;
+  }
+
+  rows.forEach((row) => {
+    const tr = document.createElement('tr');
+
+    const createdCell = document.createElement('td');
+    createdCell.textContent = formatDate(row.created_at);
+    createdCell.title = formatFullDate(row.created_at);
+    tr.appendChild(createdCell);
+
+    const tickerCell = document.createElement('td');
+    tickerCell.textContent = row.ticker ?? '—';
+    tr.appendChild(tickerCell);
+
+    const stageCell = document.createElement('td');
+    stageCell.textContent = stageLabel(row.stage);
+    tr.appendChild(stageCell);
+
+    const labelCell = document.createElement('td');
+    labelCell.textContent = row.label ?? '—';
+    tr.appendChild(labelCell);
+
+    const summaryCell = document.createElement('td');
+    const summary = row.summary ?? '—';
+    summaryCell.textContent = summary;
+    tr.appendChild(summaryCell);
+
+    tbody.appendChild(tr);
+  });
+
+  if (empty) empty.hidden = true;
+}
+
+function updateRunMeta(run, metrics) {
+  setText(selectors.runStatus, (run?.status ?? '—').toUpperCase());
+  setText(selectors.runCreated, formatFullDate(run?.created_at));
+  setText(selectors.runStage1Pending, formatNumber(metrics.stage1Pending));
+  setText(selectors.runFailures, formatNumber(metrics.totalFailures));
+  setText(selectors.runStopRequested, run?.stop_requested ? 'Yes' : 'No');
+
+  if (selectors.runNotes) {
+    const notes = (run?.notes ?? '').trim();
+    if (notes) {
+      selectors.runNotes.textContent = notes;
+      selectors.runNotes.classList.add('run-notes--visible');
+    } else {
+      selectors.runNotes.textContent = '';
+      selectors.runNotes.classList.remove('run-notes--visible');
+    }
+  }
+}
+
+function updateHero(metrics, costSummary) {
+  setText(selectors.metricTotalTickers, formatNumber(metrics.totalTickers));
+  setText(selectors.metricStage1Complete, formatNumber(metrics.stage1Completed));
+  setText(selectors.metricStage2Queue, formatNumber(metrics.stage2Queue));
+  setText(selectors.metricStage3Queue, formatNumber(metrics.stage3Queue));
+
+  const totalCost = costSummary?.[0]?.total_cost ?? 0;
+  const totalTokensIn = costSummary?.[0]?.total_tokens_in ?? 0;
+  const totalTokensOut = costSummary?.[0]?.total_tokens_out ?? 0;
+
+  setText(selectors.metricSpend, formatCurrency(totalCost));
+  setText(selectors.metricTokens, formatTokens(totalTokensIn, totalTokensOut));
+
+  setText(selectors.metricStage1Pending, formatNumber(metrics.stage1Pending));
+  setText(selectors.metricStage1Done, formatNumber(metrics.stage1Completed));
+  setText(selectors.metricStage2Done, formatNumber(metrics.stage2Completed));
+  setText(selectors.metricStage3Done, formatNumber(metrics.stage3Completed));
+  setText(selectors.metricFailures, formatNumber(metrics.totalFailures));
+}
+
+function updateStageCards(metrics) {
+  const stage1PercentVal = metrics.totalTickers > 0
+    ? Math.round((metrics.stage1Completed / metrics.totalTickers) * 100)
+    : 0;
+  const stage2PercentVal = metrics.stage1Completed > 0
+    ? Math.round((metrics.stage2Completed / metrics.stage1Completed) * 100)
+    : 0;
+  const stage3PercentVal = metrics.stage2Completed > 0
+    ? Math.round((metrics.stage3Completed / metrics.stage2Completed) * 100)
+    : 0;
+
+  setText(selectors.stage1Percent, `${stage1PercentVal}%`);
+  setText(selectors.stage2Percent, `${stage2PercentVal}%`);
+  setText(selectors.stage3Percent, `${stage3PercentVal}%`);
+  setProgressBar(selectors.stage1Progress, stage1PercentVal);
+  setProgressBar(selectors.stage2Progress, stage2PercentVal);
+  setProgressBar(selectors.stage3Progress, stage3PercentVal);
+
+  setText(selectors.stage1CompletedCount, formatNumber(metrics.stage1Completed));
+  setText(selectors.stage1PendingCount, formatNumber(metrics.stage1Pending));
+  setText(selectors.stage1FailedCount, formatNumber(metrics.stage1Failed));
+  setText(selectors.stage2CompletedCount, formatNumber(metrics.stage2Completed));
+  setText(selectors.stage2QueueCount, formatNumber(metrics.stage2Queue));
+  setText(selectors.stage2FailedCount, formatNumber(metrics.stage2Failed));
+  setText(selectors.stage3CompletedCount, formatNumber(metrics.stage3Completed));
+  setText(selectors.stage3QueueCount, formatNumber(metrics.stage3Queue));
+  setText(selectors.stage3FailedCount, formatNumber(metrics.stage3Failed));
+}
+
+async function loadRuns() {
+  if (!state.auth.admin) return;
+  setStatus('Loading runs…');
+  const { data, error } = await supabase
+    .from('runs')
+    .select('id, created_at, status, stop_requested, notes')
+    .order('created_at', { ascending: false })
+    .limit(30);
+
+  if (error) {
+    console.error('Failed to load runs', error);
+    setStatus(`Failed to load runs: ${error.message}`, true);
+    state.runs = [];
+    populateRunSelect();
+    return;
+  }
+
+  state.runs = data ?? [];
+  populateRunSelect();
+
+  if (!state.runs.length) {
+    setStatus('No runs found. Launch a run from the planner to populate telemetry.');
+  } else {
+    setStatus('');
+  }
+}
+
+async function loadRunDashboard(runId, { silent = false } = {}) {
+  if (!state.auth.admin || !runId) {
+    clearDashboard();
+    return;
+  }
+
+  if (!silent) {
+    setStatus('Fetching telemetry…');
+  }
+
+  const [{ data: run, error: runError }, statusCounts, labelCounts, costBreakdown, costSummary, latest] = await Promise.all([
+    supabase.from('runs').select('id, created_at, status, stop_requested, notes').eq('id', runId).maybeSingle(),
+    supabase.rpc('run_stage_status_counts', { p_run_id: runId }),
+    supabase.rpc('run_stage1_labels', { p_run_id: runId }),
+    supabase.rpc('run_cost_breakdown', { p_run_id: runId }),
+    supabase.rpc('run_cost_summary', { p_run_id: runId }),
+    supabase.rpc('run_latest_activity', { p_run_id: runId, p_limit: 12 })
+  ]);
+
+  if (runError) {
+    console.error('Failed to load run metadata', runError);
+    setStatus(`Unable to load run ${runId}: ${runError.message}`, true);
+    clearDashboard();
+    return;
+  }
+
+  const statusRows = statusCounts.error ? [] : statusCounts.data ?? [];
+  const labelRows = labelCounts.error ? [] : labelCounts.data ?? [];
+  const costRows = costBreakdown.error ? [] : costBreakdown.data ?? [];
+  const costSummaryRows = costSummary.error ? [] : costSummary.data ?? [];
+  const activityRows = latest.error ? [] : latest.data ?? [];
+
+  if (statusCounts.error) {
+    console.error('Stage status query failed', statusCounts.error);
+  }
+  if (labelCounts.error) {
+    console.error('Label distribution query failed', labelCounts.error);
+  }
+  if (costBreakdown.error) {
+    console.error('Cost breakdown query failed', costBreakdown.error);
+  }
+  if (costSummary.error) {
+    console.error('Cost summary query failed', costSummary.error);
+  }
+  if (latest.error) {
+    console.error('Latest activity query failed', latest.error);
+  }
+
+  const metrics = buildStageMetrics(statusRows);
+  updateRunMeta(run, metrics);
+  updateHero(metrics, costSummaryRows);
+  updateStageCards(metrics);
+  renderLabelList(labelRows, metrics.stage1Completed);
+  renderCostBreakdown(costRows);
+  renderActivity(activityRows);
+
+  if (selectors.pipelineUpdated) {
+    const timestamp = new Date();
+    selectors.pipelineUpdated.textContent = `Last updated ${formatDate(timestamp)}`;
+  }
+
+  setStatus('');
+}
+
+function applySavedRun() {
+  const savedId = localStorage.getItem(RUN_STORAGE_KEY);
+  if (!savedId) return;
+  if (state.runs.some((run) => run.id === savedId)) {
+    state.activeRunId = savedId;
+    if (selectors.runSelect) selectors.runSelect.value = savedId;
+    loadRunDashboard(savedId, { silent: true }).catch((error) => {
+      console.error('Failed to load saved run', error);
+    });
+  }
+}
+
+function attachListeners() {
+  if (selectors.runSelect) {
+    selectors.runSelect.addEventListener('change', (event) => {
+      const value = event.target.value || null;
+      state.activeRunId = value;
+      if (value) {
+        localStorage.setItem(RUN_STORAGE_KEY, value);
+        loadRunDashboard(value).catch((error) => {
+          console.error('Failed to load run dashboard', error);
+          setStatus(`Unable to load run: ${error.message}`, true);
+        });
+      } else {
+        localStorage.removeItem(RUN_STORAGE_KEY);
+        clearDashboard();
+      }
+    });
+  }
+
+  if (selectors.refreshRunsBtn) {
+    selectors.refreshRunsBtn.addEventListener('click', () => {
+      loadRuns()
+        .then(() => {
+          if (state.activeRunId && state.runs.some((run) => run.id === state.activeRunId)) {
+            loadRunDashboard(state.activeRunId, { silent: true }).catch((error) => {
+              console.error('Dashboard refresh failed', error);
+            });
+          } else {
+            applySavedRun();
+          }
+        })
+        .catch((error) => {
+          console.error('Run refresh failed', error);
+        });
+    });
+  }
+
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden && state.activeRunId) {
+      loadRunDashboard(state.activeRunId, { silent: true }).catch((error) => {
+        console.error('Failed to refresh on focus', error);
+      });
+    }
+  });
+}
+
+function startPolling() {
+  if (state.pollTimer) {
+    clearInterval(state.pollTimer);
+  }
+  state.pollTimer = setInterval(() => {
+    if (document.hidden) return;
+    if (!state.activeRunId) return;
+    loadRunDashboard(state.activeRunId, { silent: true }).catch((error) => {
+      console.error('Polling refresh failed', error);
+    });
+  }, REFRESH_INTERVAL_MS);
+}
+
+async function bootstrapAuth() {
+  const user = await getUser();
+  if (!user) {
+    updateAccessNotice('Sign in with analyst access to load run telemetry.', true);
+    disableControls();
+    return;
+  }
+
+  await ensureProfile(user).catch((error) => {
+    console.warn('ensureProfile failed', error);
+  });
+
+  const [profile, membership] = await Promise.all([getProfile(), getMembership()]);
+  const admin = hasAdminRole({ user, profile, membership });
+  const membershipActive = isMembershipActive(membership, { user, profile, membership });
+
+  state.auth = {
+    ready: true,
+    admin,
+    membershipActive,
+    userEmail: user.email ?? null
+  };
+
+  if (!admin) {
+    updateAccessNotice('Analyst permissions required. Ask an admin to grant access.', true);
+    disableControls();
+    return;
+  }
+
+  if (!membershipActive) {
+    updateAccessNotice('Membership inactive. Renew access to view live telemetry.', true);
+    disableControls();
+    return;
+  }
+
+  updateAccessNotice(`Signed in as ${user.email ?? 'analyst'} · access granted.`);
+  enableControls();
+}
+
+async function init() {
+  clearDashboard();
+  disableControls();
+  await bootstrapAuth();
+  attachListeners();
+  if (!state.auth.admin) {
+    return;
+  }
+  await loadRuns();
+  if (state.runs.length) {
+    applySavedRun();
+    if (!state.activeRunId) {
+      const [first] = state.runs;
+      if (first) {
+        state.activeRunId = first.id;
+        if (selectors.runSelect) selectors.runSelect.value = first.id;
+        localStorage.setItem(RUN_STORAGE_KEY, first.id);
+        await loadRunDashboard(first.id, { silent: true });
+      }
+    }
+  }
+  startPolling();
+}
+
+init().catch((error) => {
+  console.error('Failed to initialise analyst dashboard', error);
+  setStatus(`Unable to initialise dashboard: ${error.message}`, true);
+});

--- a/assets/planner.js
+++ b/assets/planner.js
@@ -1,0 +1,1613 @@
+import { supabase, ensureProfile, hasAdminRole, isMembershipActive, SUPABASE_URL } from './supabase.js';
+
+const STORAGE_KEY = 'ff-planner-settings-v1';
+const PRICES = {
+  '5': { in: 1.25, out: 10.0 },
+  '5-mini': { in: 0.25, out: 2.0 },
+  '4o-mini': { in: 0.15, out: 0.60 }
+};
+
+const defaults = {
+  universe: 40000,
+  surviveStage2: 15,
+  surviveStage3: 12,
+  stage1: { model: '4o-mini', inTokens: 3000, outTokens: 600 },
+  stage2: { model: '5-mini', inTokens: 30000, outTokens: 6000 },
+  stage3: { model: '5', inTokens: 100000, outTokens: 20000 }
+};
+
+const $ = (id) => document.getElementById(id);
+
+const inputs = {
+  universe: $('universeInput'),
+  stage2Slider: $('stage2Slider'),
+  stage3Slider: $('stage3Slider'),
+  stage1Model: $('modelStage1'),
+  stage2Model: $('modelStage2'),
+  stage3Model: $('modelStage3'),
+  stage1In: $('stage1InputTokens'),
+  stage1Out: $('stage1OutputTokens'),
+  stage2In: $('stage2InputTokens'),
+  stage2Out: $('stage2OutputTokens'),
+  stage3In: $('stage3InputTokens'),
+  stage3Out: $('stage3OutputTokens'),
+  status: $('startRunStatus'),
+  log: $('statusLog'),
+  costOut: $('costOutput'),
+  totalCost: $('totalCost'),
+  survivorSummary: $('survivorSummary'),
+  stage2Value: $('stage2Value'),
+  stage3Value: $('stage3Value'),
+  startBtn: $('startRunBtn'),
+  resetBtn: $('resetDefaultsBtn'),
+  runIdInput: $('runIdInput'),
+  applyRunIdBtn: $('applyRunIdBtn'),
+  clearRunIdBtn: $('clearRunIdBtn'),
+  runIdDisplay: $('runIdDisplay'),
+  runStatusText: $('runStatusText'),
+  runStopText: $('runStopText'),
+  runMetaStatus: $('runMetaStatus'),
+  stopRunBtn: $('stopRunBtn'),
+  resumeRunBtn: $('resumeRunBtn'),
+  stage1Btn: $('processStage1Btn'),
+  stage1RefreshBtn: $('refreshStage1Btn'),
+  stage1Status: $('stage1Status'),
+  stage1Total: $('stage1Total'),
+  stage1Pending: $('stage1Pending'),
+  stage1Completed: $('stage1Completed'),
+  stage1Failed: $('stage1Failed'),
+  stage1RecentBody: $('stage1RecentBody'),
+  stage2Btn: $('processStage2Btn'),
+  stage2RefreshBtn: $('refreshStage2Btn'),
+  stage2Status: $('stage2Status'),
+  stage2Total: $('stage2Total'),
+  stage2Pending: $('stage2Pending'),
+  stage2Completed: $('stage2Completed'),
+  stage2Failed: $('stage2Failed'),
+  stage2GoDeep: $('stage2GoDeep'),
+  stage2RecentBody: $('stage2RecentBody'),
+  stage3Btn: $('processStage3Btn'),
+  stage3RefreshBtn: $('refreshStage3Btn'),
+  stage3Status: $('stage3Status'),
+  stage3Finalists: $('stage3Finalists'),
+  stage3Pending: $('stage3Pending'),
+  stage3Completed: $('stage3Completed'),
+  stage3Spend: $('stage3Spend'),
+  stage3Failed: $('stage3Failed'),
+  stage3RecentBody: $('stage3RecentBody'),
+  sectorNotesList: $('sectorNotesList'),
+  sectorNotesEmpty: $('sectorNotesEmpty')
+};
+
+const FUNCTIONS_BASE = SUPABASE_URL.replace(/\.supabase\.co$/, '.functions.supabase.co');
+const RUNS_CREATE_ENDPOINT = `${FUNCTIONS_BASE}/runs-create`;
+const STAGE1_CONSUME_ENDPOINT = `${FUNCTIONS_BASE}/stage1-consume`;
+const STAGE2_CONSUME_ENDPOINT = `${FUNCTIONS_BASE}/stage2-consume`;
+const STAGE3_CONSUME_ENDPOINT = `${FUNCTIONS_BASE}/stage3-consume`;
+const RUNS_STOP_ENDPOINT = `${FUNCTIONS_BASE}/runs-stop`;
+const RUN_STORAGE_KEY = 'ff-active-run-id';
+
+let authContext = {
+  user: null,
+  profile: null,
+  membership: null,
+  token: null,
+  isAdmin: false,
+  membershipActive: false
+};
+let lastAccessState = 'unknown';
+let activeRunId = null;
+let currentRunMeta = null;
+let runChannel = null;
+let stage1RefreshTimer = null;
+let stage2RefreshTimer = null;
+let stage3RefreshTimer = null;
+let sectorNotesChannel = null;
+let sectorNotesReady = false;
+
+function loadSettings() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    if (!saved) return { ...defaults };
+    return {
+      universe: Number(saved.universe) || defaults.universe,
+      surviveStage2: Number(saved.surviveStage2) || defaults.surviveStage2,
+      surviveStage3: Number(saved.surviveStage3) || defaults.surviveStage3,
+      stage1: { ...defaults.stage1, ...saved.stage1 },
+      stage2: { ...defaults.stage2, ...saved.stage2 },
+      stage3: { ...defaults.stage3, ...saved.stage3 }
+    };
+  } catch (error) {
+    console.warn('Unable to parse saved planner settings', error);
+    return { ...defaults };
+  }
+}
+
+function persistSettings(settings) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+}
+
+function getSettingsFromInputs() {
+  return {
+    universe: Number(inputs.universe?.value) || 0,
+    surviveStage2: Number(inputs.stage2Slider?.value) || 0,
+    surviveStage3: Number(inputs.stage3Slider?.value) || 0,
+    stage1: {
+      model: inputs.stage1Model?.value || defaults.stage1.model,
+      inTokens: Number(inputs.stage1In?.value) || 0,
+      outTokens: Number(inputs.stage1Out?.value) || 0
+    },
+    stage2: {
+      model: inputs.stage2Model?.value || defaults.stage2.model,
+      inTokens: Number(inputs.stage2In?.value) || 0,
+      outTokens: Number(inputs.stage2Out?.value) || 0
+    },
+    stage3: {
+      model: inputs.stage3Model?.value || defaults.stage3.model,
+      inTokens: Number(inputs.stage3In?.value) || 0,
+      outTokens: Number(inputs.stage3Out?.value) || 0
+    }
+  };
+}
+
+function applySettings(settings) {
+  if (!inputs.startBtn) return;
+  inputs.universe.value = settings.universe;
+  inputs.stage2Slider.value = settings.surviveStage2;
+  inputs.stage3Slider.value = settings.surviveStage3;
+  inputs.stage2Value.textContent = `${settings.surviveStage2}%`;
+  inputs.stage3Value.textContent = `${settings.surviveStage3}%`;
+  inputs.stage1Model.value = settings.stage1.model;
+  inputs.stage1In.value = settings.stage1.inTokens;
+  inputs.stage1Out.value = settings.stage1.outTokens;
+  inputs.stage2Model.value = settings.stage2.model;
+  inputs.stage2In.value = settings.stage2.inTokens;
+  inputs.stage2Out.value = settings.stage2.outTokens;
+  inputs.stage3Model.value = settings.stage3.model;
+  inputs.stage3In.value = settings.stage3.inTokens;
+  inputs.stage3Out.value = settings.stage3.outTokens;
+}
+
+function isValidUuid(value) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+function updateRunDisplay() {
+  if (inputs.runIdDisplay) {
+    inputs.runIdDisplay.textContent = activeRunId ?? '—';
+  }
+
+  if (inputs.runIdInput && document.activeElement !== inputs.runIdInput) {
+    inputs.runIdInput.value = activeRunId ?? '';
+  }
+}
+
+function updateRunMeta(meta = null, { message } = {}) {
+  currentRunMeta = meta ?? null;
+
+  const statusText = meta?.status ? String(meta.status).replace(/_/g, ' ') : null;
+  const stopText = meta ? (meta.stop_requested ? 'Yes' : 'No') : null;
+
+  if (inputs.runStatusText) {
+    inputs.runStatusText.textContent = statusText ? statusText : '—';
+  }
+
+  if (inputs.runStopText) {
+    inputs.runStopText.textContent = stopText ?? '—';
+  }
+
+  const defaultMessage = !activeRunId
+    ? 'Select a run to manage stop requests.'
+    : meta
+      ? meta.stop_requested
+        ? 'Run flagged to stop. Workers finish the active batch and halt new processing.'
+        : 'Run active. Flag a stop request to pause new work after current batches.'
+      : 'Loading run details…';
+
+  if (inputs.runMetaStatus) {
+    inputs.runMetaStatus.textContent = message || defaultMessage;
+  }
+
+  applyAccessState({ preserveStatus: true });
+}
+
+function clearStage1RefreshTimer() {
+  if (stage1RefreshTimer) {
+    clearTimeout(stage1RefreshTimer);
+    stage1RefreshTimer = null;
+  }
+}
+
+function scheduleStage1Refresh({ immediate = false } = {}) {
+  clearStage1RefreshTimer();
+  if (!activeRunId) return;
+  if (immediate) {
+    fetchStage1Summary({ silent: true }).catch((error) => {
+      console.error('Auto refresh failed', error);
+    });
+    return;
+  }
+
+  stage1RefreshTimer = window.setTimeout(() => {
+    stage1RefreshTimer = null;
+    fetchStage1Summary({ silent: true }).catch((error) => {
+      console.error('Auto refresh failed', error);
+    });
+  }, 400);
+}
+
+function clearStage2RefreshTimer() {
+  if (stage2RefreshTimer) {
+    clearTimeout(stage2RefreshTimer);
+    stage2RefreshTimer = null;
+  }
+}
+
+function scheduleStage2Refresh({ immediate = false } = {}) {
+  clearStage2RefreshTimer();
+  if (!activeRunId) return;
+  if (immediate) {
+    fetchStage2Summary({ silent: true }).catch((error) => {
+      console.error('Stage 2 auto refresh failed', error);
+    });
+    return;
+  }
+
+  stage2RefreshTimer = window.setTimeout(() => {
+    stage2RefreshTimer = null;
+    fetchStage2Summary({ silent: true }).catch((error) => {
+      console.error('Stage 2 auto refresh failed', error);
+    });
+  }, 500);
+}
+
+function clearStage3RefreshTimer() {
+  if (stage3RefreshTimer) {
+    clearTimeout(stage3RefreshTimer);
+    stage3RefreshTimer = null;
+  }
+}
+
+function scheduleStage3Refresh({ immediate = false } = {}) {
+  clearStage3RefreshTimer();
+  if (!activeRunId) return;
+  if (immediate) {
+    fetchStage3Summary({ silent: true }).catch((error) => {
+      console.error('Stage 3 auto refresh failed', error);
+    });
+    return;
+  }
+
+  stage3RefreshTimer = window.setTimeout(() => {
+    stage3RefreshTimer = null;
+    fetchStage3Summary({ silent: true }).catch((error) => {
+      console.error('Stage 3 auto refresh failed', error);
+    });
+  }, 650);
+}
+
+function unsubscribeFromRunChannel() {
+  clearStage1RefreshTimer();
+  clearStage2RefreshTimer();
+  clearStage3RefreshTimer();
+  if (runChannel) {
+    try {
+      supabase.removeChannel(runChannel);
+    } catch (error) {
+      console.warn('Failed to remove previous realtime channel', error);
+    }
+    runChannel = null;
+  }
+}
+
+function subscribeToRunChannel(runId) {
+  unsubscribeFromRunChannel();
+  if (!runId) return;
+
+  runChannel = supabase
+    .channel(`planner-run-${runId}`)
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'run_items', filter: `run_id=eq.${runId}` }, () => {
+      scheduleStage1Refresh();
+      scheduleStage2Refresh();
+      scheduleStage3Refresh();
+    })
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'answers', filter: `run_id=eq.${runId}` }, () => {
+      scheduleStage1Refresh();
+      scheduleStage2Refresh();
+      scheduleStage3Refresh();
+    })
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'runs', filter: `id=eq.${runId}` }, () => {
+      fetchRunMeta({ silent: true }).catch((error) => {
+        console.error('Realtime run meta refresh failed', error);
+      });
+    })
+    .subscribe((status) => {
+      if (status === 'SUBSCRIBED') {
+        scheduleStage1Refresh({ immediate: true });
+        scheduleStage2Refresh({ immediate: true });
+        scheduleStage3Refresh({ immediate: true });
+        fetchRunMeta({ silent: true }).catch((error) => {
+          console.error('Initial run meta load failed', error);
+        });
+      }
+    });
+}
+
+async function fetchRunMeta({ silent = false } = {}) {
+  if (!activeRunId) {
+    updateRunMeta(null);
+    return null;
+  }
+
+  if (!silent && inputs.runMetaStatus) {
+    inputs.runMetaStatus.textContent = 'Loading run details…';
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('runs')
+      .select('id, created_at, status, stop_requested, notes')
+      .eq('id', activeRunId)
+      .maybeSingle();
+
+    if (error) throw error;
+
+    updateRunMeta(data ?? null);
+    return data ?? null;
+  } catch (error) {
+    console.error('Failed to load run details', error);
+    updateRunMeta(null, { message: 'Unable to load run details. Try refreshing.' });
+    return null;
+  }
+}
+
+async function toggleRunStop(stopRequested) {
+  if (!activeRunId) {
+    if (inputs.runMetaStatus) inputs.runMetaStatus.textContent = 'Select a run before toggling stop requests.';
+    return;
+  }
+
+  await syncAccess({ preserveStatus: true });
+
+  if (!authContext.user) {
+    if (inputs.runMetaStatus) inputs.runMetaStatus.textContent = 'Sign in required to manage runs.';
+    return;
+  }
+
+  if (!authContext.isAdmin) {
+    if (inputs.runMetaStatus) inputs.runMetaStatus.textContent = 'Admin access required to toggle stop requests.';
+    return;
+  }
+
+  if (!authContext.token) {
+    if (inputs.runMetaStatus) inputs.runMetaStatus.textContent = 'Session expired. Sign in again to continue.';
+    await syncAccess();
+    return;
+  }
+
+  const primaryBtn = stopRequested ? inputs.stopRunBtn : inputs.resumeRunBtn;
+  const secondaryBtn = stopRequested ? inputs.resumeRunBtn : inputs.stopRunBtn;
+
+  if (primaryBtn) primaryBtn.disabled = true;
+  if (secondaryBtn) secondaryBtn.disabled = true;
+
+  if (inputs.runMetaStatus) {
+    inputs.runMetaStatus.textContent = stopRequested
+      ? 'Flagging run to stop…'
+      : 'Clearing stop request…';
+  }
+
+  try {
+    const response = await fetch(RUNS_STOP_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authContext.token}`
+      },
+      body: JSON.stringify({
+        run_id: activeRunId,
+        stop_requested: Boolean(stopRequested),
+        client_meta: {
+          origin: window.location.origin,
+          triggered_at: new Date().toISOString()
+        }
+      })
+    });
+
+    const raw = await response.text();
+    let payload = {};
+    if (raw) {
+      try {
+        payload = JSON.parse(raw);
+      } catch (error) {
+        console.warn('Unable to parse runs-stop response JSON', error);
+      }
+    }
+
+    if (!response.ok) {
+      const message = payload?.error || `runs-stop endpoint responded ${response.status}`;
+      throw new Error(message);
+    }
+
+    const run = payload?.run ?? null;
+    updateRunMeta(run ?? currentRunMeta, {
+      message: stopRequested
+        ? 'Stop request recorded. Workers will finish the active batch and halt.'
+        : 'Stop request cleared. Workers may resume new batches.'
+    });
+
+    const logMessage = stopRequested ? 'Stop requested for active run.' : 'Stop request cleared for active run.';
+    logStatus(logMessage);
+    scheduleStage1Refresh({ immediate: true });
+    scheduleStage2Refresh({ immediate: true });
+  } catch (error) {
+    console.error('Failed to toggle stop request', error);
+    if (inputs.runMetaStatus) {
+      inputs.runMetaStatus.textContent = `Failed to update run: ${error.message}`;
+    }
+    logStatus(`Stop toggle failed: ${error.message}`);
+  } finally {
+    if (secondaryBtn) secondaryBtn.disabled = false;
+    if (primaryBtn) primaryBtn.disabled = false;
+    applyAccessState({ preserveStatus: true });
+  }
+}
+
+function updateStage1Metrics(metrics = null) {
+  const formatter = (value) => {
+    if (value == null || Number.isNaN(value)) return '—';
+    return Number(value).toLocaleString();
+  };
+
+  if (inputs.stage1Total) inputs.stage1Total.textContent = formatter(metrics?.total);
+  if (inputs.stage1Pending) inputs.stage1Pending.textContent = formatter(metrics?.pending);
+  if (inputs.stage1Completed) inputs.stage1Completed.textContent = formatter(metrics?.completed);
+  if (inputs.stage1Failed) inputs.stage1Failed.textContent = formatter(metrics?.failed);
+}
+
+function renderRecentClassifications(entries = []) {
+  const body = inputs.stage1RecentBody;
+  if (!body) return;
+
+  body.innerHTML = '';
+
+  if (!entries.length) {
+    const row = document.createElement('tr');
+    row.innerHTML = '<td colspan="4" class="recent-empty">No classifications yet.</td>';
+    body.appendChild(row);
+    return;
+  }
+
+  entries.forEach((entry) => {
+    const row = document.createElement('tr');
+    const safeSummary = entry.summary ? String(entry.summary) : '—';
+    const updated = entry.updated_at
+      ? new Date(entry.updated_at).toLocaleString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+      : '—';
+    row.innerHTML = `
+      <td>${entry.ticker ?? '—'}</td>
+      <td data-label>${entry.label ?? '—'}</td>
+      <td>${safeSummary}</td>
+      <td>${updated}</td>
+    `;
+    body.appendChild(row);
+  });
+}
+
+function updateStage2Metrics(metrics = null) {
+  const formatter = (value) => {
+    if (value == null || Number.isNaN(value)) return '—';
+    return Number(value).toLocaleString();
+  };
+
+  if (inputs.stage2Total) inputs.stage2Total.textContent = formatter(metrics?.total);
+  if (inputs.stage2Pending) inputs.stage2Pending.textContent = formatter(metrics?.pending);
+  if (inputs.stage2Completed) inputs.stage2Completed.textContent = formatter(metrics?.completed);
+  if (inputs.stage2Failed) inputs.stage2Failed.textContent = formatter(metrics?.failed);
+  if (inputs.stage2GoDeep) inputs.stage2GoDeep.textContent = formatter(metrics?.goDeep);
+}
+
+function renderStage2Insights(entries = []) {
+  const body = inputs.stage2RecentBody;
+  if (!body) return;
+
+  body.innerHTML = '';
+
+  if (!entries.length) {
+    const row = document.createElement('tr');
+    row.innerHTML = '<td colspan="4" class="recent-empty">No Stage 2 calls yet.</td>';
+    body.appendChild(row);
+    return;
+  }
+
+  entries.forEach((entry) => {
+    const row = document.createElement('tr');
+    const goDeep = entry.go_deep ? 'Yes' : entry.status === 'failed' ? 'Failed' : 'No';
+    const updated = entry.updated_at
+      ? new Date(entry.updated_at).toLocaleString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+      : '—';
+    row.innerHTML = `
+      <td>${entry.ticker ?? '—'}</td>
+      <td data-label>${goDeep}</td>
+      <td>${entry.summary ?? '—'}</td>
+      <td>${updated}</td>
+    `;
+    body.appendChild(row);
+  });
+}
+
+function updateStage3Metrics(metrics = null) {
+  const formatter = (value) => {
+    if (value == null || Number.isNaN(value)) return '—';
+    return Number(value).toLocaleString();
+  };
+
+  if (inputs.stage3Finalists) inputs.stage3Finalists.textContent = formatter(metrics?.finalists);
+  if (inputs.stage3Pending) inputs.stage3Pending.textContent = formatter(metrics?.pending);
+  if (inputs.stage3Completed) inputs.stage3Completed.textContent = formatter(metrics?.completed);
+  if (inputs.stage3Spend) {
+    const spend = metrics?.spend;
+    inputs.stage3Spend.textContent = spend == null || Number.isNaN(spend) ? '—' : formatCurrency(Number(spend));
+  }
+  if (inputs.stage3Failed) inputs.stage3Failed.textContent = formatter(metrics?.failed);
+}
+
+function renderStage3Reports(entries = []) {
+  const body = inputs.stage3RecentBody;
+  if (!body) return;
+
+  body.innerHTML = '';
+
+  if (!entries.length) {
+    const row = document.createElement('tr');
+    row.innerHTML = '<td colspan="4" class="recent-empty">No deep-dive reports yet.</td>';
+    body.appendChild(row);
+    return;
+  }
+
+  entries.forEach((entry) => {
+    const row = document.createElement('tr');
+    const verdict = entry.verdict ? String(entry.verdict) : '—';
+    const thesis = entry.summary ?? entry.answer_text ?? '—';
+    const updated = entry.updated_at
+      ? new Date(entry.updated_at).toLocaleString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+      : '—';
+    row.innerHTML = `
+      <td>${entry.ticker ?? '—'}</td>
+      <td data-label>${verdict}</td>
+      <td>${thesis}</td>
+      <td>${updated}</td>
+    `;
+    body.appendChild(row);
+  });
+}
+
+async function fetchStage1Summary({ silent = false } = {}) {
+  if (!inputs.stage1Status) return;
+
+  if (!activeRunId) {
+    updateStage1Metrics();
+    renderRecentClassifications([]);
+    if (!silent) inputs.stage1Status.textContent = 'Set a run ID to monitor triage progress.';
+    return;
+  }
+
+  if (!silent) inputs.stage1Status.textContent = 'Fetching Stage 1 progress…';
+
+  try {
+    const [totalRes, pendingRes, completedRes, failedRes, answersRes] = await Promise.all([
+      supabase
+        .from('run_items')
+        .select('*', { count: 'exact', head: true })
+        .eq('run_id', activeRunId),
+      supabase
+        .from('run_items')
+        .select('*', { count: 'exact', head: true })
+        .eq('run_id', activeRunId)
+        .eq('status', 'pending')
+        .eq('stage', 0),
+      supabase
+        .from('run_items')
+        .select('*', { count: 'exact', head: true })
+        .eq('run_id', activeRunId)
+        .eq('status', 'ok')
+        .gte('stage', 1),
+      supabase
+        .from('run_items')
+        .select('*', { count: 'exact', head: true })
+        .eq('run_id', activeRunId)
+        .eq('status', 'failed'),
+      supabase
+        .from('answers')
+        .select('ticker, answer_json, created_at')
+        .eq('run_id', activeRunId)
+        .eq('stage', 1)
+        .order('created_at', { ascending: false })
+        .limit(8)
+    ]);
+
+    if (totalRes.error) throw totalRes.error;
+    if (pendingRes.error) throw pendingRes.error;
+    if (completedRes.error) throw completedRes.error;
+    if (failedRes.error) throw failedRes.error;
+    if (answersRes.error) throw answersRes.error;
+
+    const metrics = {
+      total: totalRes.count ?? 0,
+      pending: pendingRes.count ?? 0,
+      completed: completedRes.count ?? 0,
+      failed: failedRes.count ?? 0
+    };
+
+    updateStage1Metrics(metrics);
+
+    const recent = (answersRes.data ?? []).map((row) => {
+      const answer = row.answer_json ?? {};
+      let summary = '';
+      if (Array.isArray(answer.reasons) && answer.reasons.length) {
+        summary = answer.reasons[0];
+      } else if (typeof answer.summary === 'string') {
+        summary = answer.summary;
+      } else if (typeof answer.reason === 'string') {
+        summary = answer.reason;
+      }
+
+      return {
+        ticker: row.ticker,
+        label: answer.label ?? answer.classification ?? null,
+        summary: summary || '—',
+        updated_at: row.created_at
+      };
+    });
+
+    renderRecentClassifications(recent);
+
+    const timestamp = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    inputs.stage1Status.textContent = `Last updated ${timestamp}`;
+  } catch (error) {
+    console.error('Failed to load Stage 1 summary', error);
+    inputs.stage1Status.textContent = 'Failed to load Stage 1 progress.';
+  }
+}
+
+async function fetchStage2Summary({ silent = false } = {}) {
+  if (!inputs.stage2Status) return;
+
+  if (!activeRunId) {
+    updateStage2Metrics();
+    renderStage2Insights([]);
+    if (!silent) inputs.stage2Status.textContent = 'Set a run ID to monitor Stage 2 progress.';
+    return;
+  }
+
+  if (!silent) inputs.stage2Status.textContent = 'Fetching Stage 2 progress…';
+
+  try {
+    const [summaryResult, answersResult] = await Promise.all([
+      supabase.rpc('run_stage2_summary', { p_run_id: activeRunId }).maybeSingle(),
+      supabase
+        .from('answers')
+        .select('ticker, answer_json, created_at')
+        .eq('run_id', activeRunId)
+        .eq('stage', 2)
+        .order('created_at', { ascending: false })
+        .limit(8)
+    ]);
+
+    if (summaryResult.error) throw summaryResult.error;
+    if (answersResult.error) throw answersResult.error;
+
+    const summary = summaryResult.data ?? null;
+    const metrics = {
+      total: summary ? Number(summary.total_survivors ?? 0) : 0,
+      pending: summary ? Number(summary.pending ?? 0) : 0,
+      completed: summary ? Number(summary.completed ?? 0) : 0,
+      failed: summary ? Number(summary.failed ?? 0) : 0,
+      goDeep: summary ? Number(summary.go_deep ?? 0) : 0
+    };
+
+    updateStage2Metrics(metrics);
+
+    const recent = (answersResult.data ?? []).map((row) => {
+      const answer = row.answer_json ?? {};
+      const verdict = answer?.verdict ?? {};
+      const rawGoDeep = verdict?.go_deep;
+      const goDeep = typeof rawGoDeep === 'boolean'
+        ? rawGoDeep
+        : typeof rawGoDeep === 'string'
+          ? rawGoDeep.toLowerCase() === 'true'
+          : false;
+      let summaryText = typeof verdict?.summary === 'string' ? verdict.summary : '';
+      if (!summaryText && Array.isArray(answer?.next_steps) && answer.next_steps.length) {
+        summaryText = String(answer.next_steps[0]);
+      }
+      return {
+        ticker: row.ticker,
+        go_deep: goDeep,
+        summary: summaryText || '—',
+        updated_at: row.created_at,
+        status: 'ok'
+      };
+    });
+
+    renderStage2Insights(recent);
+
+    const timestamp = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    inputs.stage2Status.textContent = `Last updated ${timestamp}`;
+  } catch (error) {
+    console.error('Failed to load Stage 2 summary', error);
+    inputs.stage2Status.textContent = 'Failed to load Stage 2 progress.';
+  }
+}
+
+async function fetchStage3Summary({ silent = false } = {}) {
+  if (!inputs.stage3Status) return;
+
+  if (!activeRunId) {
+    updateStage3Metrics();
+    renderStage3Reports([]);
+    if (!silent) inputs.stage3Status.textContent = 'Set a run ID to monitor Stage 3 deep dives.';
+    return;
+  }
+
+  if (!silent) inputs.stage3Status.textContent = 'Fetching Stage 3 progress…';
+
+  try {
+    const [summaryResult, answersResult, costResult] = await Promise.all([
+      supabase.rpc('run_stage3_summary', { p_run_id: activeRunId }).maybeSingle(),
+      supabase
+        .from('answers')
+        .select('ticker, answer_json, answer_text, question_group, created_at')
+        .eq('run_id', activeRunId)
+        .eq('stage', 3)
+        .order('created_at', { ascending: false })
+        .limit(10),
+      supabase.rpc('run_cost_breakdown', { p_run_id: activeRunId })
+    ]);
+
+    if (summaryResult.error) throw summaryResult.error;
+    if (answersResult.error) throw answersResult.error;
+    if (costResult.error) throw costResult.error;
+
+    const summary = summaryResult.data ?? null;
+    const metrics = {
+      finalists: summary ? Number(summary.total_finalists ?? summary.finalists ?? 0) : 0,
+      pending: summary ? Number(summary.pending ?? 0) : 0,
+      completed: summary ? Number(summary.completed ?? 0) : 0,
+      failed: summary ? Number(summary.failed ?? 0) : 0,
+      spend: 0
+    };
+
+    const breakdown = Array.isArray(costResult.data) ? costResult.data : [];
+    const stage3Spend = breakdown
+      .filter((row) => Number(row.stage) === 3)
+      .reduce((acc, row) => acc + Number(row.cost_usd ?? 0), 0);
+    metrics.spend = stage3Spend;
+
+    updateStage3Metrics(metrics);
+
+    const reports = (answersResult.data ?? [])
+      .filter((row) => (row.question_group ?? '').toLowerCase() === 'summary')
+      .map((row) => {
+        const answer = row.answer_json ?? {};
+        const verdict = answer.verdict ?? answer.rating ?? answer.recommendation ?? null;
+        const summaryText =
+          answer.thesis ??
+          answer.summary ??
+          answer.narrative ??
+          (Array.isArray(answer.takeaways) && answer.takeaways.length ? answer.takeaways[0] : null) ??
+          row.answer_text ??
+          '—';
+        return {
+          ticker: row.ticker,
+          verdict,
+          summary: summaryText,
+          answer_text: row.answer_text ?? null,
+          updated_at: row.created_at
+        };
+      });
+
+    renderStage3Reports(reports);
+
+    const timestamp = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    inputs.stage3Status.textContent = `Last updated ${timestamp}`;
+  } catch (error) {
+    console.error('Failed to load Stage 3 summary', error);
+    inputs.stage3Status.textContent = 'Failed to load Stage 3 progress.';
+  }
+}
+
+function setActiveRunId(value, { announce = true, silent = false } = {}) {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  if (normalized && !isValidUuid(normalized)) {
+    if (inputs.stage1Status) inputs.stage1Status.textContent = 'Run ID must be a valid UUID.';
+    return false;
+  }
+
+  const previous = activeRunId;
+  activeRunId = normalized || null;
+  const changed = previous !== activeRunId;
+
+  if (activeRunId) {
+    localStorage.setItem(RUN_STORAGE_KEY, activeRunId);
+  } else {
+    localStorage.removeItem(RUN_STORAGE_KEY);
+  }
+
+  updateRunDisplay();
+  applyAccessState({ preserveStatus: true });
+
+  if (!activeRunId) {
+    unsubscribeFromRunChannel();
+    updateRunMeta(null);
+    updateStage1Metrics();
+    renderRecentClassifications([]);
+    updateStage2Metrics();
+    renderStage2Insights([]);
+    updateStage3Metrics();
+    renderStage3Reports([]);
+    if (announce && inputs.stage1Status) inputs.stage1Status.textContent = 'Active run cleared. Set a run ID to continue.';
+    if (announce) logStatus('Active run cleared.');
+    if (inputs.stage2Status) inputs.stage2Status.textContent = 'Active run cleared.';
+    if (inputs.stage3Status) inputs.stage3Status.textContent = 'Active run cleared.';
+    return changed;
+  }
+
+  subscribeToRunChannel(activeRunId);
+
+  fetchRunMeta({ silent }).catch((error) => {
+    console.error('Failed to refresh run details', error);
+  });
+
+  if (announce) {
+    const message = `Active run set to ${activeRunId}`;
+    if (inputs.stage1Status) inputs.stage1Status.textContent = message;
+    if (inputs.stage2Status) inputs.stage2Status.textContent = 'Loading Stage 2 progress…';
+    if (inputs.stage3Status) inputs.stage3Status.textContent = 'Loading Stage 3 progress…';
+    logStatus(message);
+  }
+
+  fetchStage1Summary({ silent }).catch((error) => {
+    console.error('Failed to refresh Stage 1 summary', error);
+    if (inputs.stage1Status) inputs.stage1Status.textContent = 'Failed to load Stage 1 progress.';
+  });
+
+  fetchStage2Summary({ silent }).catch((error) => {
+    console.error('Failed to refresh Stage 2 summary', error);
+    if (inputs.stage2Status) inputs.stage2Status.textContent = 'Failed to load Stage 2 progress.';
+  });
+
+  fetchStage3Summary({ silent }).catch((error) => {
+    console.error('Failed to refresh Stage 3 summary', error);
+    if (inputs.stage3Status) inputs.stage3Status.textContent = 'Failed to load Stage 3 progress.';
+  });
+
+  return changed;
+}
+
+async function processStage1Batch() {
+  if (!inputs.stage1Btn) return;
+
+  if (!activeRunId) {
+    if (inputs.stage1Status) inputs.stage1Status.textContent = 'Assign a run ID before processing.';
+    return;
+  }
+
+  if (currentRunMeta?.stop_requested) {
+    if (inputs.stage1Status) inputs.stage1Status.textContent = 'Run flagged to stop. Clear the stop request to continue processing.';
+    return;
+  }
+
+  await syncAccess({ preserveStatus: true });
+
+  if (!authContext.user) {
+    if (inputs.stage1Status) inputs.stage1Status.textContent = 'Sign in required.';
+    return;
+  }
+
+  if (!authContext.isAdmin) {
+    if (inputs.stage1Status) inputs.stage1Status.textContent = 'Admin access required.';
+    return;
+  }
+
+  if (!authContext.token) {
+    if (inputs.stage1Status) inputs.stage1Status.textContent = 'Session expired. Sign in again to continue.';
+    await syncAccess();
+    return;
+  }
+
+  inputs.stage1Btn.disabled = true;
+  if (inputs.stage1Status) inputs.stage1Status.textContent = 'Processing Stage 1 batch…';
+
+  try {
+    const response = await fetch(STAGE1_CONSUME_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authContext.token}`
+      },
+      body: JSON.stringify({
+        run_id: activeRunId,
+        limit: 8,
+        client_meta: {
+          origin: window.location.origin,
+          triggered_at: new Date().toISOString()
+        }
+      })
+    });
+
+    const raw = await response.text();
+    let payload = {};
+    if (raw) {
+      try {
+        payload = JSON.parse(raw);
+      } catch (error) {
+        console.warn('Unable to parse Stage 1 response JSON', error);
+      }
+    }
+
+    if (!response.ok) {
+      const message = payload?.error || `Stage 1 endpoint responded ${response.status}`;
+      throw new Error(message);
+    }
+
+    const results = Array.isArray(payload.results) ? payload.results : [];
+    if (results.length) {
+      renderRecentClassifications(results);
+    }
+
+    const message = payload.message || `Processed ${results.length} ticker${results.length === 1 ? '' : 's'}.`;
+    if (inputs.stage1Status) inputs.stage1Status.textContent = message;
+    logStatus(`[Stage 1] ${message}`);
+  } catch (error) {
+    console.error('Stage 1 batch error', error);
+    if (inputs.stage1Status) inputs.stage1Status.textContent = `Stage 1 failed: ${error.message}`;
+    logStatus(`Stage 1 batch failed: ${error.message}`);
+  } finally {
+    try {
+      await fetchStage1Summary({ silent: true });
+    } catch (error) {
+      console.error('Failed to refresh Stage 1 summary after batch', error);
+    }
+    try {
+      await fetchStage2Summary({ silent: true });
+    } catch (error) {
+      console.error('Failed to refresh Stage 2 summary after Stage 1 batch', error);
+    }
+    applyAccessState({ preserveStatus: true });
+  }
+}
+
+async function processStage2Batch() {
+  if (!inputs.stage2Btn) return;
+
+  if (!activeRunId) {
+    if (inputs.stage2Status) inputs.stage2Status.textContent = 'Assign a run ID before processing.';
+    return;
+  }
+
+  if (currentRunMeta?.stop_requested) {
+    if (inputs.stage2Status) inputs.stage2Status.textContent = 'Run flagged to stop. Clear the stop request to continue processing.';
+    return;
+  }
+
+  await syncAccess({ preserveStatus: true });
+  if (!authContext.isAdmin) {
+    if (inputs.stage2Status) inputs.stage2Status.textContent = 'Admin access required for Stage 2.';
+    return;
+  }
+  if (!authContext.token) {
+    if (inputs.stage2Status) inputs.stage2Status.textContent = 'Session expired. Refresh and try again.';
+    return;
+  }
+
+  inputs.stage2Btn.disabled = true;
+  if (inputs.stage2Status) inputs.stage2Status.textContent = 'Processing Stage 2 batch…';
+
+  try {
+    const response = await fetch(STAGE2_CONSUME_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authContext.token}`
+      },
+      body: JSON.stringify({
+        run_id: activeRunId,
+        limit: 4,
+        client_meta: {
+          origin: window.location.origin,
+          triggered_at: new Date().toISOString()
+        }
+      })
+    });
+
+    const raw = await response.text();
+    let payload = {};
+    if (raw) {
+      try {
+        payload = JSON.parse(raw);
+      } catch (error) {
+        console.warn('Unable to parse Stage 2 response JSON', error);
+      }
+    }
+
+    if (!response.ok) {
+      const message = payload?.error || `Stage 2 endpoint responded ${response.status}`;
+      throw new Error(message);
+    }
+
+    const results = Array.isArray(payload.results) ? payload.results : [];
+    if (results.length) {
+      renderStage2Insights(results);
+    }
+
+    if (payload.metrics) {
+      updateStage2Metrics({
+        total: Number(payload.metrics.total_survivors ?? payload.metrics.total ?? 0),
+        pending: Number(payload.metrics.pending ?? 0),
+        completed: Number(payload.metrics.completed ?? 0),
+        failed: Number(payload.metrics.failed ?? 0),
+        goDeep: Number(payload.metrics.go_deep ?? payload.metrics.goDeep ?? 0)
+      });
+    }
+
+    const message = payload.message || `Processed ${results.length} ticker${results.length === 1 ? '' : 's'}.`;
+    if (inputs.stage2Status) inputs.stage2Status.textContent = message;
+    logStatus(`[Stage 2] ${message}`);
+  } catch (error) {
+    console.error('Stage 2 batch error', error);
+    if (inputs.stage2Status) inputs.stage2Status.textContent = `Stage 2 failed: ${error.message}`;
+    logStatus(`Stage 2 batch failed: ${error.message}`);
+  } finally {
+    try {
+      await fetchStage2Summary({ silent: true });
+    } catch (error) {
+      console.error('Failed to refresh Stage 2 summary after batch', error);
+    }
+    applyAccessState({ preserveStatus: true });
+  }
+}
+
+async function processStage3Batch() {
+  if (!inputs.stage3Btn) return;
+
+  if (!activeRunId) {
+    if (inputs.stage3Status) inputs.stage3Status.textContent = 'Assign a run ID before processing deep dives.';
+    return;
+  }
+
+  if (currentRunMeta?.stop_requested) {
+    if (inputs.stage3Status) inputs.stage3Status.textContent = 'Run flagged to stop. Clear the stop request to continue.';
+    return;
+  }
+
+  await syncAccess({ preserveStatus: true });
+  if (!authContext.isAdmin) {
+    if (inputs.stage3Status) inputs.stage3Status.textContent = 'Admin access required for Stage 3.';
+    return;
+  }
+  if (!authContext.token) {
+    if (inputs.stage3Status) inputs.stage3Status.textContent = 'Session expired. Refresh and try again.';
+    return;
+  }
+
+  inputs.stage3Btn.disabled = true;
+  if (inputs.stage3Status) inputs.stage3Status.textContent = 'Processing Stage 3 batch…';
+
+  try {
+    const response = await fetch(STAGE3_CONSUME_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authContext.token}`
+      },
+      body: JSON.stringify({
+        run_id: activeRunId,
+        limit: 2,
+        client_meta: {
+          origin: window.location.origin,
+          triggered_at: new Date().toISOString()
+        }
+      })
+    });
+
+    const raw = await response.text();
+    let payload = {};
+    if (raw) {
+      try {
+        payload = JSON.parse(raw);
+      } catch (error) {
+        console.warn('Unable to parse Stage 3 response JSON', error);
+      }
+    }
+
+    if (!response.ok) {
+      const message = payload?.error || `Stage 3 endpoint responded ${response.status}`;
+      throw new Error(message);
+    }
+
+    const reports = Array.isArray(payload.results) ? payload.results : [];
+    if (reports.length) {
+      renderStage3Reports(reports);
+    }
+
+    if (payload.metrics) {
+      updateStage3Metrics({
+        finalists: Number(payload.metrics.total_finalists ?? payload.metrics.finalists ?? payload.metrics.total ?? 0),
+        pending: Number(payload.metrics.pending ?? 0),
+        completed: Number(payload.metrics.completed ?? 0),
+        failed: Number(payload.metrics.failed ?? 0),
+        spend: Number(payload.metrics.spend ?? payload.metrics.total_spend ?? 0)
+      });
+    }
+
+    const message = payload.message || `Processed ${reports.length} finalist${reports.length === 1 ? '' : 's'}.`;
+    if (inputs.stage3Status) inputs.stage3Status.textContent = message;
+    logStatus(`[Stage 3] ${message}`);
+  } catch (error) {
+    console.error('Stage 3 batch error', error);
+    if (inputs.stage3Status) inputs.stage3Status.textContent = `Stage 3 failed: ${error.message}`;
+    logStatus(`Stage 3 batch failed: ${error.message}`);
+  } finally {
+    try {
+      await fetchStage3Summary({ silent: true });
+    } catch (error) {
+      console.error('Failed to refresh Stage 3 summary after batch', error);
+    }
+    applyAccessState({ preserveStatus: true });
+  }
+}
+
+function stageCost(n, inTok, outTok, modelKey) {
+  const model = PRICES[modelKey];
+  if (!model || !n) return { total: 0, inCost: 0, outCost: 0 };
+  const inCost = (n * inTok / 1_000_000) * model.in;
+  const outCost = (n * outTok / 1_000_000) * model.out;
+  return { total: inCost + outCost, inCost, outCost };
+}
+
+function formatCurrency(amount) {
+  return `$${amount.toFixed(2)}`;
+}
+
+function updateCostOutput() {
+  if (!inputs.costOut) return;
+  const settings = getSettingsFromInputs();
+  persistSettings(settings);
+
+  const survivorsStage2 = Math.round(settings.universe * (settings.surviveStage2 / 100));
+  const survivorsStage3 = Math.round(survivorsStage2 * (settings.surviveStage3 / 100));
+
+  const s1 = stageCost(settings.universe, settings.stage1.inTokens, settings.stage1.outTokens, settings.stage1.model);
+  const s2 = stageCost(survivorsStage2, settings.stage2.inTokens, settings.stage2.outTokens, settings.stage2.model);
+  const s3 = stageCost(survivorsStage3, settings.stage3.inTokens, settings.stage3.outTokens, settings.stage3.model);
+
+  const total = s1.total + s2.total + s3.total;
+
+  const rows = inputs.costOut.querySelectorAll('li');
+  if (rows[0]) rows[0].lastElementChild.textContent = formatCurrency(s1.total);
+  if (rows[1]) rows[1].lastElementChild.textContent = formatCurrency(s2.total);
+  if (rows[2]) rows[2].lastElementChild.textContent = formatCurrency(s3.total);
+  inputs.totalCost.textContent = formatCurrency(total);
+  inputs.survivorSummary.textContent = `Stage 2 survivors: ${survivorsStage2.toLocaleString()} • Stage 3 finalists: ${survivorsStage3.toLocaleString()}`;
+}
+
+function logStatus(message) {
+  if (!inputs.log) return;
+  const now = new Date();
+  const timestamp = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  inputs.log.textContent = `[${timestamp}] ${message}\n\n${inputs.log.textContent}`.trim();
+}
+
+const defaultSectorEmptyText = inputs.sectorNotesEmpty?.textContent ??
+  'No sector notes yet. Add heuristics to customise Stage 2 scoring.';
+
+function truncateNotes(text, limit = 180) {
+  if (!text) return '';
+  const normalized = String(text).replace(/\s+/g, ' ').trim();
+  if (normalized.length <= limit) return normalized;
+  return `${normalized.slice(0, limit - 1).trimEnd()}…`;
+}
+
+function clearSectorNotes() {
+  if (inputs.sectorNotesList) {
+    inputs.sectorNotesList.innerHTML = '';
+    inputs.sectorNotesList.hidden = true;
+  }
+  if (inputs.sectorNotesEmpty) {
+    inputs.sectorNotesEmpty.textContent = defaultSectorEmptyText;
+    inputs.sectorNotesEmpty.hidden = false;
+  }
+  sectorNotesReady = false;
+}
+
+function renderSectorNotes(records = []) {
+  if (!inputs.sectorNotesList || !inputs.sectorNotesEmpty) return;
+  if (!records.length) {
+    clearSectorNotes();
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  records.forEach((record) => {
+    const item = document.createElement('li');
+    item.className = 'sector-notes__item';
+    const title = document.createElement('strong');
+    title.textContent = record.sector;
+    const body = document.createElement('p');
+    body.textContent = truncateNotes(record.notes);
+    item.append(title, body);
+    fragment.append(item);
+  });
+
+  inputs.sectorNotesList.innerHTML = '';
+  inputs.sectorNotesList.appendChild(fragment);
+  inputs.sectorNotesList.hidden = false;
+  inputs.sectorNotesEmpty.hidden = true;
+}
+
+async function refreshSectorNotes({ silent = false } = {}) {
+  if (!authContext.isAdmin || !inputs.sectorNotesList) return;
+  if (!silent && inputs.sectorNotesEmpty) {
+    inputs.sectorNotesEmpty.textContent = 'Loading sector guidance…';
+    inputs.sectorNotesEmpty.hidden = false;
+  }
+  try {
+    const { data, error } = await supabase
+      .from('sector_prompts')
+      .select('sector, notes')
+      .order('sector', { ascending: true })
+      .limit(12);
+    if (error) throw error;
+    const records = (data || []).map((entry) => ({
+      sector: String(entry.sector || 'Unknown'),
+      notes: String(entry.notes || '')
+    }));
+    sectorNotesReady = true;
+    renderSectorNotes(records);
+  } catch (error) {
+    console.error('Failed to refresh sector notes', error);
+    if (inputs.sectorNotesEmpty) {
+      inputs.sectorNotesEmpty.textContent = 'Unable to load sector notes right now.';
+      inputs.sectorNotesEmpty.hidden = false;
+    }
+  }
+}
+
+function detachSectorNotesChannel() {
+  if (sectorNotesChannel) {
+    supabase.removeChannel(sectorNotesChannel);
+    sectorNotesChannel = null;
+  }
+}
+
+function subscribeSectorNotes() {
+  if (!authContext.isAdmin || !inputs.sectorNotesList) return;
+  detachSectorNotesChannel();
+  sectorNotesChannel = supabase
+    .channel('planner-sector-prompts')
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'sector_prompts' }, () => {
+      refreshSectorNotes({ silent: true });
+    });
+  sectorNotesChannel.subscribe((status) => {
+    if (status === 'SUBSCRIBED') {
+      refreshSectorNotes({ silent: sectorNotesReady });
+    }
+  });
+}
+
+function applyAccessState({ preserveStatus = false } = {}) {
+  const previousState = lastAccessState;
+  const state = !authContext.user
+    ? 'signed-out'
+    : authContext.isAdmin
+      ? 'admin-ok'
+      : 'no-admin';
+
+  if (state === 'admin-ok' && previousState !== 'admin-ok') {
+    subscribeSectorNotes();
+    refreshSectorNotes({ silent: true });
+  } else if (state !== 'admin-ok' && previousState === 'admin-ok') {
+    detachSectorNotesChannel();
+    clearSectorNotes();
+  } else if (state === 'admin-ok' && !sectorNotesReady) {
+    refreshSectorNotes({ silent: true });
+  }
+
+  if (inputs.startBtn) {
+    inputs.startBtn.disabled = state !== 'admin-ok';
+  }
+
+  if (inputs.stage1Btn) {
+    inputs.stage1Btn.disabled = state !== 'admin-ok' || !activeRunId || (currentRunMeta?.stop_requested ?? false);
+  }
+
+  if (inputs.stage1RefreshBtn) {
+    inputs.stage1RefreshBtn.disabled = !activeRunId;
+  }
+
+  if (inputs.stage2Btn) {
+    inputs.stage2Btn.disabled =
+      state !== 'admin-ok' || !activeRunId || (currentRunMeta?.stop_requested ?? false);
+  }
+
+  if (inputs.stage2RefreshBtn) {
+    inputs.stage2RefreshBtn.disabled = !activeRunId;
+  }
+
+  if (inputs.stage3Btn) {
+    inputs.stage3Btn.disabled =
+      state !== 'admin-ok' || !activeRunId || (currentRunMeta?.stop_requested ?? false);
+  }
+
+  if (inputs.stage3RefreshBtn) {
+    inputs.stage3RefreshBtn.disabled = !activeRunId;
+  }
+
+  if (inputs.stopRunBtn) {
+    inputs.stopRunBtn.disabled = state !== 'admin-ok' || !activeRunId || (currentRunMeta?.stop_requested ?? false);
+  }
+
+  if (inputs.resumeRunBtn) {
+    inputs.resumeRunBtn.disabled = state !== 'admin-ok' || !activeRunId || !(currentRunMeta?.stop_requested ?? false);
+  }
+
+  if (!inputs.status) {
+    lastAccessState = state;
+    return;
+  }
+
+  const changed = state !== lastAccessState;
+  if (changed) {
+    if (!preserveStatus) {
+      if (state === 'admin-ok') inputs.status.textContent = 'Ready';
+      else if (state === 'signed-out') inputs.status.textContent = 'Sign in required';
+      else inputs.status.textContent = 'Admin access required';
+    }
+
+    const logMessage = state === 'admin-ok'
+      ? 'Authenticated as admin. Automation ready to launch.'
+      : state === 'signed-out'
+        ? 'Sign in to launch automated runs.'
+        : 'Current user lacks admin privileges. Contact an administrator to continue.';
+    logStatus(logMessage);
+    lastAccessState = state;
+  }
+}
+
+async function refreshAuthContext() {
+  try {
+    const { data: { session } } = await supabase.auth.getSession();
+    const token = session?.access_token ?? null;
+    const user = session?.user ?? null;
+    let profile = null;
+    let membership = null;
+
+    if (user) {
+      try {
+        await ensureProfile(user);
+      } catch (error) {
+        console.warn('ensureProfile failed', error);
+      }
+
+      const [profileResult, membershipResult] = await Promise.all([
+        supabase
+          .from('profiles')
+          .select('*')
+          .eq('id', user.id)
+          .maybeSingle(),
+        supabase
+          .from('memberships')
+          .select('*')
+          .eq('user_id', user.id)
+          .maybeSingle()
+      ]);
+
+      if (profileResult.error) {
+        console.warn('profiles fetch error', profileResult.error);
+      } else {
+        profile = profileResult.data ?? null;
+      }
+
+      if (membershipResult.error) {
+        console.warn('memberships fetch error', membershipResult.error);
+      } else {
+        membership = membershipResult.data ?? null;
+      }
+    }
+
+    authContext = {
+      user,
+      profile,
+      membership,
+      token,
+      isAdmin: hasAdminRole({ user, profile, membership }),
+      membershipActive: isMembershipActive(membership, { user, profile, membership })
+    };
+  } catch (error) {
+    console.error('Failed to refresh auth context', error);
+    authContext = {
+      user: null,
+      profile: null,
+      membership: null,
+      token: null,
+      isAdmin: false,
+      membershipActive: false
+    };
+  }
+
+  return authContext;
+}
+
+async function syncAccess(options = {}) {
+  await refreshAuthContext();
+  applyAccessState(options);
+}
+
+async function startRun() {
+  if (!inputs.startBtn || !inputs.status) return;
+  await syncAccess({ preserveStatus: true });
+
+  if (!authContext.user) {
+    inputs.status.textContent = 'Sign in required';
+    logStatus('Launch blocked: no active session.');
+    return;
+  }
+
+  if (!authContext.isAdmin) {
+    inputs.status.textContent = 'Admin access required';
+    logStatus('Launch blocked: admin privileges needed.');
+    return;
+  }
+
+  if (!authContext.token) {
+    inputs.status.textContent = 'Session expired';
+    logStatus('Launch blocked: refresh the page or sign in again to renew your session.');
+    await syncAccess();
+    return;
+  }
+
+  const settings = getSettingsFromInputs();
+  inputs.startBtn.disabled = true;
+  inputs.status.textContent = 'Launching…';
+  logStatus(`Submitting run to ${RUNS_CREATE_ENDPOINT}`);
+
+  try {
+    const response = await fetch(RUNS_CREATE_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authContext.token}`
+      },
+      body: JSON.stringify({
+        planner: settings,
+        client_meta: {
+          origin: window.location.origin,
+          pathname: window.location.pathname,
+          triggered_at: new Date().toISOString()
+        }
+      })
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`API responded ${response.status}: ${text}`);
+    }
+
+    const data = await response.json();
+    const runId = typeof data.run_id === 'string' ? data.run_id : null;
+    inputs.status.textContent = `Run created: ${runId || 'unknown id'}`;
+    if (runId) {
+      setActiveRunId(runId, { announce: true, silent: true });
+      if (inputs.stage1Status) inputs.stage1Status.textContent = 'Run queued. Process Stage 1 batches to begin triage.';
+    }
+    const total = typeof data.total_items === 'number' ? data.total_items : 'n/a';
+    logStatus(`Run created successfully with ${total} tickers queued.`);
+  } catch (error) {
+    console.error(error);
+    inputs.status.textContent = 'Launch failed';
+    logStatus(`Launch failed: ${error.message}`);
+  } finally {
+    applyAccessState({ preserveStatus: true });
+  }
+}
+
+function resetDefaults() {
+  persistSettings(defaults);
+  applySettings(defaults);
+  updateCostOutput();
+  logStatus('Settings restored to defaults.');
+  if (inputs.status) inputs.status.textContent = 'Defaults restored';
+}
+
+function bindEvents() {
+  const watchedInputs = [
+    inputs.universe,
+    inputs.stage2Slider,
+    inputs.stage3Slider,
+    inputs.stage1Model,
+    inputs.stage2Model,
+    inputs.stage3Model,
+    inputs.stage1In,
+    inputs.stage1Out,
+    inputs.stage2In,
+    inputs.stage2Out,
+    inputs.stage3In,
+    inputs.stage3Out
+  ].filter(Boolean);
+
+  watchedInputs.forEach((element) => {
+    element.addEventListener('input', () => {
+      if (element === inputs.stage2Slider) {
+        inputs.stage2Value.textContent = `${element.value}%`;
+      }
+      if (element === inputs.stage3Slider) {
+        inputs.stage3Value.textContent = `${element.value}%`;
+      }
+      updateCostOutput();
+    });
+  });
+
+  inputs.startBtn?.addEventListener('click', startRun);
+  inputs.resetBtn?.addEventListener('click', resetDefaults);
+  inputs.stage1Btn?.addEventListener('click', processStage1Batch);
+  inputs.stage1RefreshBtn?.addEventListener('click', () => fetchStage1Summary());
+  inputs.stage2Btn?.addEventListener('click', processStage2Batch);
+  inputs.stage2RefreshBtn?.addEventListener('click', () => fetchStage2Summary());
+  inputs.stage3Btn?.addEventListener('click', processStage3Batch);
+  inputs.stage3RefreshBtn?.addEventListener('click', () => fetchStage3Summary());
+  inputs.stopRunBtn?.addEventListener('click', () => toggleRunStop(true));
+  inputs.resumeRunBtn?.addEventListener('click', () => toggleRunStop(false));
+  inputs.applyRunIdBtn?.addEventListener('click', () => {
+    const value = inputs.runIdInput?.value ?? '';
+    setActiveRunId(value, { announce: true });
+  });
+  inputs.clearRunIdBtn?.addEventListener('click', () => {
+    if (inputs.runIdInput) inputs.runIdInput.value = '';
+    setActiveRunId('', { announce: true });
+  });
+  inputs.runIdInput?.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      setActiveRunId(inputs.runIdInput.value, { announce: true });
+    }
+  });
+}
+
+async function bootstrap() {
+  if (!inputs.startBtn || !inputs.log) {
+    console.warn('Planner controls missing. Skipping initialisation.');
+    return;
+  }
+
+  const initialSettings = loadSettings();
+  applySettings(initialSettings);
+  bindEvents();
+  updateCostOutput();
+  logStatus('Planner ready. Configure and launch when models are wired.');
+  inputs.status.textContent = 'Checking access…';
+
+  const storedRunId = localStorage.getItem(RUN_STORAGE_KEY);
+  if (storedRunId) {
+    setActiveRunId(storedRunId, { announce: false, silent: true });
+  } else {
+    updateRunDisplay();
+    updateRunMeta(null);
+    updateStage1Metrics();
+    if (inputs.stage1Status) inputs.stage1Status.textContent = 'No active run selected.';
+    updateStage2Metrics();
+    renderStage2Insights([]);
+    if (inputs.stage2Status) inputs.stage2Status.textContent = 'No active run selected.';
+    updateStage3Metrics();
+    renderStage3Reports([]);
+    if (inputs.stage3Status) inputs.stage3Status.textContent = 'No active run selected.';
+  }
+
+  await syncAccess();
+
+  supabase.auth.onAuthStateChange(async () => {
+    await syncAccess();
+  });
+}
+
+bootstrap();

--- a/assets/sectors.js
+++ b/assets/sectors.js
@@ -1,0 +1,389 @@
+import {
+  supabase,
+  ensureProfile,
+  hasAdminRole,
+  isMembershipActive
+} from './supabase.js';
+
+const selectors = {
+  createForm: document.getElementById('createForm'),
+  sectorInput: document.getElementById('sectorInput'),
+  notesInput: document.getElementById('notesInput'),
+  createBtn: document.getElementById('createBtn'),
+  createStatus: document.getElementById('createStatus'),
+  suggestions: document.getElementById('sectorSuggestions'),
+  searchInput: document.getElementById('searchInput'),
+  promptList: document.getElementById('promptList'),
+  emptyState: document.getElementById('emptyState'),
+  refreshBtn: document.getElementById('refreshBtn'),
+  accessNotice: document.getElementById('accessNotice')
+};
+
+const state = {
+  prompts: [],
+  filter: '',
+  auth: {
+    ready: false,
+    admin: false,
+    membershipActive: false
+  }
+};
+
+let lastAuthState = 'unknown';
+
+function setFormEnabled(enabled) {
+  const disabled = !enabled;
+  if (selectors.createBtn) selectors.createBtn.disabled = disabled;
+  if (selectors.sectorInput) selectors.sectorInput.disabled = disabled;
+  if (selectors.notesInput) selectors.notesInput.disabled = disabled;
+  if (selectors.searchInput) selectors.searchInput.disabled = disabled;
+  if (selectors.refreshBtn) selectors.refreshBtn.disabled = disabled;
+
+  if (selectors.promptList) {
+    selectors.promptList.querySelectorAll('textarea,button').forEach((element) => {
+      element.disabled = disabled;
+    });
+  }
+}
+
+function setCreateStatus(message, tone = 'muted') {
+  if (!selectors.createStatus) return;
+  selectors.createStatus.textContent = message;
+  selectors.createStatus.dataset.tone = tone;
+}
+
+function normalizeSector(value) {
+  return String(value || '')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function characterCount(value) {
+  return new Intl.NumberFormat('en-US').format((value || '').length);
+}
+
+function updateEmptyState(visible) {
+  if (!selectors.emptyState || !selectors.promptList) return;
+  if (visible) {
+    selectors.emptyState.hidden = false;
+    selectors.promptList.hidden = true;
+  } else {
+    selectors.emptyState.hidden = true;
+    selectors.promptList.hidden = false;
+  }
+}
+
+function renderSuggestions(suggestions) {
+  if (!selectors.suggestions) return;
+  selectors.suggestions.innerHTML = '';
+  suggestions.forEach((sector) => {
+    const option = document.createElement('option');
+    option.value = sector;
+    selectors.suggestions.appendChild(option);
+  });
+}
+
+function buildPromptCard(entry) {
+  const card = document.createElement('article');
+  card.className = 'prompt-card';
+  card.dataset.sector = entry.sector;
+
+  const header = document.createElement('header');
+  const title = document.createElement('h3');
+  title.textContent = entry.sector;
+  header.appendChild(title);
+
+  const meta = document.createElement('div');
+  meta.className = 'meta';
+  meta.textContent = `${characterCount(entry.notes)} characters`;
+  header.appendChild(meta);
+
+  const textarea = document.createElement('textarea');
+  textarea.value = entry.notes || '';
+  textarea.spellcheck = true;
+  textarea.autocomplete = 'off';
+  textarea.dataset.initialValue = textarea.value;
+
+  const footer = document.createElement('footer');
+  const status = document.createElement('span');
+  status.className = 'status';
+  status.textContent = 'Saved';
+
+  const actions = document.createElement('div');
+  actions.className = 'actions';
+
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'button';
+  saveBtn.className = 'btn-primary';
+  saveBtn.textContent = 'Save changes';
+  saveBtn.disabled = true;
+
+  const deleteBtn = document.createElement('button');
+  deleteBtn.type = 'button';
+  deleteBtn.className = 'btn-secondary';
+  deleteBtn.textContent = 'Delete';
+
+  actions.appendChild(saveBtn);
+  actions.appendChild(deleteBtn);
+  footer.appendChild(status);
+  footer.appendChild(actions);
+
+  textarea.addEventListener('input', () => {
+    const trimmed = textarea.value.trim();
+    const initial = textarea.dataset.initialValue ?? '';
+    const changed = trimmed !== initial.trim();
+    saveBtn.disabled = !changed;
+    status.textContent = changed ? 'Unsaved changes' : 'Saved';
+    meta.textContent = `${characterCount(textarea.value)} characters`;
+  });
+
+  saveBtn.addEventListener('click', async () => {
+    const newNotes = textarea.value.trim();
+    status.textContent = 'Saving…';
+    saveBtn.disabled = true;
+    try {
+      await supabase
+        .from('sector_prompts')
+        .upsert({ sector: entry.sector, notes: newNotes }, { onConflict: 'sector' });
+      textarea.dataset.initialValue = newNotes;
+      status.textContent = 'Saved';
+      meta.textContent = `${characterCount(newNotes)} characters`;
+      entry.notes = newNotes;
+    } catch (error) {
+      console.error('Failed to save sector prompt', error);
+      status.textContent = 'Save failed — retry';
+      saveBtn.disabled = false;
+    }
+  });
+
+  deleteBtn.addEventListener('click', async () => {
+    const confirmation = window.confirm(
+      `Remove guidance for ${entry.sector}? This cannot be undone.`
+    );
+    if (!confirmation) return;
+
+    status.textContent = 'Deleting…';
+    saveBtn.disabled = true;
+    deleteBtn.disabled = true;
+
+    try {
+      const { error } = await supabase
+        .from('sector_prompts')
+        .delete()
+        .eq('sector', entry.sector);
+      if (error) throw error;
+      card.remove();
+      state.prompts = state.prompts.filter((prompt) => prompt.sector !== entry.sector);
+      applyFilter();
+    } catch (error) {
+      console.error('Failed to delete sector prompt', error);
+      status.textContent = 'Delete failed';
+      saveBtn.disabled = false;
+      deleteBtn.disabled = false;
+    }
+  });
+
+  card.appendChild(header);
+  card.appendChild(textarea);
+  card.appendChild(footer);
+
+  return card;
+}
+
+function renderPrompts(list) {
+  if (!selectors.promptList) return;
+  selectors.promptList.innerHTML = '';
+
+  if (!list.length) {
+    updateEmptyState(true);
+    return;
+  }
+
+  list.forEach((entry) => {
+    selectors.promptList.appendChild(buildPromptCard(entry));
+  });
+
+  updateEmptyState(false);
+}
+
+function applyFilter() {
+  const term = state.filter.trim().toLowerCase();
+  const filtered = term
+    ? state.prompts.filter((entry) => entry.sector.toLowerCase().includes(term))
+    : [...state.prompts];
+  renderPrompts(filtered);
+}
+
+async function fetchPrompts() {
+  if (!state.auth.admin) return;
+  try {
+    const { data, error } = await supabase
+      .from('sector_prompts')
+      .select('sector, notes')
+      .order('sector', { ascending: true });
+    if (error) throw error;
+    state.prompts = (data || []).map((entry) => ({
+      sector: entry.sector ?? 'Unknown',
+      notes: entry.notes ?? ''
+    }));
+    applyFilter();
+  } catch (error) {
+    console.error('Failed to fetch sector prompts', error);
+  }
+}
+
+async function fetchSuggestions() {
+  try {
+    const { data, error } = await supabase
+      .from('tickers')
+      .select('sector')
+      .not('sector', 'is', null);
+    if (error) throw error;
+    const sectors = new Set();
+    (data || []).forEach((row) => {
+      const value = normalizeSector(row.sector);
+      if (value) sectors.add(value);
+    });
+    state.prompts.forEach((entry) => sectors.add(entry.sector));
+    renderSuggestions([...sectors].sort((a, b) => a.localeCompare(b)));
+  } catch (error) {
+    console.error('Failed to fetch sector suggestions', error);
+  }
+}
+
+async function ensureAccess() {
+  try {
+    const { data: { session } } = await supabase.auth.getSession();
+    const user = session?.user ?? null;
+    let profile = null;
+    let membership = null;
+
+    if (user) {
+      try {
+        await ensureProfile(user);
+      } catch (error) {
+        console.warn('ensureProfile failed', error);
+      }
+
+      const [profileResult, membershipResult] = await Promise.all([
+        supabase.from('profiles').select('*').eq('id', user.id).maybeSingle(),
+        supabase.from('memberships').select('*').eq('user_id', user.id).maybeSingle()
+      ]);
+
+      if (!profileResult.error) profile = profileResult.data ?? null;
+      if (!membershipResult.error) membership = membershipResult.data ?? null;
+    }
+
+    const admin = hasAdminRole({ user, profile, membership });
+    const active = isMembershipActive(membership, { user, profile, membership });
+    state.auth = { ready: true, admin, membershipActive: active };
+
+    const accessState = !user ? 'signed-out' : admin ? 'admin' : 'no-admin';
+    if (accessState !== lastAuthState) {
+      lastAuthState = accessState;
+      if (accessState === 'admin') {
+        setCreateStatus('Ready to edit sector guidance', 'success');
+        selectors.accessNotice.hidden = true;
+        setFormEnabled(true);
+        await fetchPrompts();
+        await fetchSuggestions();
+      } else if (accessState === 'no-admin') {
+        setCreateStatus('Admin access required', 'error');
+        selectors.accessNotice.hidden = false;
+        setFormEnabled(false);
+        state.prompts = [];
+        applyFilter();
+      } else {
+        setCreateStatus('Sign in to manage guidance', 'muted');
+        selectors.accessNotice.hidden = false;
+        setFormEnabled(false);
+        state.prompts = [];
+        applyFilter();
+      }
+    } else if (accessState === 'admin') {
+      // Refresh prompts if still admin and already initialised
+      await fetchPrompts();
+      await fetchSuggestions();
+    }
+  } catch (error) {
+    console.error('Failed to determine access rights', error);
+    setCreateStatus('Access check failed', 'error');
+    selectors.accessNotice.hidden = false;
+    setFormEnabled(false);
+  }
+}
+
+async function handleCreate(event) {
+  event.preventDefault();
+  if (!state.auth.admin) return;
+
+  const sector = normalizeSector(selectors.sectorInput.value);
+  const notes = selectors.notesInput.value.trim();
+
+  if (!sector) {
+    setCreateStatus('Enter a sector name', 'error');
+    selectors.sectorInput.focus();
+    return;
+  }
+
+  if (!notes) {
+    setCreateStatus('Add guidance before saving', 'error');
+    selectors.notesInput.focus();
+    return;
+  }
+
+  setCreateStatus('Saving…', 'muted');
+  selectors.createBtn.disabled = true;
+
+  try {
+    const { error } = await supabase
+      .from('sector_prompts')
+      .upsert({ sector, notes }, { onConflict: 'sector' });
+    if (error) throw error;
+
+    const existingIndex = state.prompts.findIndex((entry) => entry.sector === sector);
+    if (existingIndex >= 0) {
+      state.prompts[existingIndex].notes = notes;
+    } else {
+      state.prompts.push({ sector, notes });
+    }
+    state.prompts.sort((a, b) => a.sector.localeCompare(b.sector));
+
+    selectors.sectorInput.value = '';
+    selectors.notesInput.value = '';
+    setCreateStatus('Saved', 'success');
+    applyFilter();
+    await fetchSuggestions();
+  } catch (error) {
+    console.error('Failed to save sector guidance', error);
+    setCreateStatus('Save failed — retry', 'error');
+  } finally {
+    selectors.createBtn.disabled = false;
+  }
+}
+
+function bindEvents() {
+  selectors.createForm?.addEventListener('submit', handleCreate);
+
+  selectors.searchInput?.addEventListener('input', (event) => {
+    state.filter = event.target.value || '';
+    applyFilter();
+  });
+
+  selectors.refreshBtn?.addEventListener('click', async () => {
+    setCreateStatus('Refreshing…', 'muted');
+    await fetchPrompts();
+    await fetchSuggestions();
+    setCreateStatus('Ready', 'success');
+  });
+}
+
+async function init() {
+  bindEvents();
+  await ensureAccess();
+  supabase.auth.onAuthStateChange(async () => {
+    await ensureAccess();
+  });
+}
+
+init();

--- a/assets/supabase.js
+++ b/assets/supabase.js
@@ -1,8 +1,8 @@
 // /assets/supabase.js
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
-const SUPABASE_URL = 'https://rhzaxqljwvaykuozxzcg.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJoemF4cWxqd3ZheWt1b3p4emNnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc4NzMxNjIsImV4cCI6MjA3MzQ0OTE2Mn0.t2dXlzk8fuaDqMmRgLnRB0Kga3yfMeopwnkDzy275k0';
+export const SUPABASE_URL = 'https://rhzaxqljwvaykuozxzcg.supabase.co';
+export const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJoemF4cWxqd3ZheWt1b3p4emNnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc4NzMxNjIsImV4cCI6MjA3MzQ0OTE2Mn0.t2dXlzk8fuaDqMmRgLnRB0Kga3yfMeopwnkDzy275k0';
 
 export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: { persistSession: true, detectSessionInUrl: true }

--- a/assets/ticker.js
+++ b/assets/ticker.js
@@ -1,0 +1,395 @@
+import { supabase, getUser, getProfile, getMembership, hasAdminRole } from './supabase.js';
+
+const params = new URLSearchParams(window.location.search);
+const state = {
+  ticker: (params.get('ticker') || '').trim().toUpperCase(),
+  runId: params.get('run') || null,
+  runs: [],
+  detail: null
+};
+
+const elements = {
+  gate: document.getElementById('tickerGate'),
+  content: document.getElementById('tickerContent'),
+  title: document.getElementById('tickerTitle'),
+  subtitle: document.getElementById('tickerSubtitle'),
+  runPicker: document.getElementById('runPicker'),
+  exportJson: document.getElementById('exportJson'),
+  copySummary: document.getElementById('copySummary'),
+  metaStatus: document.getElementById('metaStatus'),
+  metaStage: document.getElementById('metaStage'),
+  metaLabel: document.getElementById('metaLabel'),
+  metaGoDeep: document.getElementById('metaGoDeep'),
+  metaSpend: document.getElementById('metaSpend'),
+  metaUpdated: document.getElementById('metaUpdated'),
+  stage1Body: document.getElementById('stage1Body'),
+  stage2Scores: document.getElementById('stage2Scores'),
+  stage2Verdict: document.getElementById('stage2Verdict'),
+  stage2Next: document.getElementById('stage2Next'),
+  stage3Summary: document.getElementById('stage3Summary'),
+  stage3Groups: document.getElementById('stage3Groups')
+};
+
+function isUuid(value) {
+  if (typeof value !== 'string') return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value.trim());
+}
+
+function formatCurrency(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '—';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 }).format(num);
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+function titleCase(value) {
+  if (!value) return '';
+  return value
+    .toString()
+    .split(/[\s_-]+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
+async function ensureAccess() {
+  const user = await getUser();
+  if (!user) {
+    elements.gate.hidden = false;
+    elements.content.hidden = true;
+    return false;
+  }
+  const [profile, membership] = await Promise.all([getProfile(), getMembership()]);
+  if (!hasAdminRole({ user, profile, membership })) {
+    elements.gate.hidden = false;
+    elements.gate.querySelector('p').textContent = 'Only analyst operators and admins can view raw stage outputs. Contact the FutureFunds team to request access.';
+    elements.content.hidden = true;
+    return false;
+  }
+  elements.gate.hidden = true;
+  elements.content.hidden = false;
+  return true;
+}
+
+async function loadRunsForTicker() {
+  const { data, error } = await supabase
+    .from('run_items')
+    .select('run_id, updated_at, stage, status, runs(created_at, status)')
+    .eq('ticker', state.ticker)
+    .order('updated_at', { ascending: false })
+    .limit(40);
+  if (error) {
+    console.error('Failed to load runs for ticker', error);
+    throw error;
+  }
+  const seen = new Set();
+  state.runs = [];
+  (data ?? []).forEach((row) => {
+    if (!row.run_id || seen.has(row.run_id)) return;
+    seen.add(row.run_id);
+    state.runs.push({
+      id: row.run_id,
+      created_at: row.runs?.created_at ?? row.updated_at ?? null,
+      status: row.runs?.status ?? row.status ?? 'unknown'
+    });
+  });
+  if (!state.runId || !isUuid(state.runId) || !seen.has(state.runId)) {
+    state.runId = state.runs[0]?.id ?? null;
+  }
+  renderRunPicker();
+}
+
+function renderRunPicker() {
+  if (!elements.runPicker) return;
+  elements.runPicker.innerHTML = '';
+  if (!state.runs.length) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = 'No runs available';
+    elements.runPicker.append(option);
+    return;
+  }
+  state.runs.forEach((run) => {
+    const option = document.createElement('option');
+    option.value = run.id;
+    const created = run.created_at ? new Date(run.created_at).toLocaleString() : 'Unknown date';
+    option.textContent = `${created} — ${run.status ?? 'unknown'}`;
+    if (run.id === state.runId) option.selected = true;
+    elements.runPicker.append(option);
+  });
+}
+
+async function loadDetails() {
+  if (!state.runId || !state.ticker) return;
+  const { data, error } = await supabase.rpc('run_ticker_details', {
+    p_run_id: state.runId,
+    p_ticker: state.ticker
+  });
+  if (error) {
+    console.error('run_ticker_details error', error);
+    throw error;
+  }
+  const detail = data?.[0] ?? null;
+  state.detail = detail;
+  if (!detail) {
+    elements.subtitle.textContent = 'No data for this ticker in the selected run yet.';
+    clearPanels();
+    return;
+  }
+  updateHero(detail);
+  renderContext(detail);
+  renderStage1(detail.stage1, detail.label);
+  renderStage2(detail.stage2);
+  renderStage3(detail.stage3_summary, detail.stage3_text, detail.stage3_groups);
+}
+
+function updateHero(detail) {
+  elements.title.textContent = `${state.ticker} — ${detail.name ?? 'Unknown company'}`;
+  elements.subtitle.textContent = `${detail.exchange ?? 'Unknown exchange'} · ${detail.sector ?? 'Unknown sector'} · ${detail.country ?? 'Unknown country'}`;
+  document.title = `FutureFunds — ${state.ticker} deep dive`;
+}
+
+function renderContext(detail) {
+  elements.metaStatus.textContent = detail.status ? detail.status.toUpperCase() : 'UNKNOWN';
+  elements.metaStage.textContent = detail.stage != null ? `Stage ${detail.stage}` : '—';
+  elements.metaLabel.textContent = detail.label ? titleCase(detail.label) : '—';
+  elements.metaGoDeep.textContent = detail.stage2_go_deep ? 'Approved' : 'Not approved';
+  elements.metaSpend.textContent = formatCurrency(detail.spend_usd ?? 0);
+  elements.metaUpdated.textContent = formatDate(detail.updated_at);
+}
+
+function clearPanels() {
+  elements.stage1Body.innerHTML = '<p class="muted">No triage output captured for this run.</p>';
+  elements.stage2Scores.textContent = '';
+  elements.stage2Verdict.textContent = '';
+  elements.stage2Next.textContent = '';
+  elements.stage3Summary.classList.add('muted');
+  elements.stage3Summary.textContent = 'Deep dive not yet available.';
+  elements.stage3Groups.innerHTML = '';
+}
+
+function renderStage1(stage1, label) {
+  elements.stage1Body.innerHTML = '';
+  if (!stage1 || typeof stage1 !== 'object') {
+    elements.stage1Body.innerHTML = '<p class="muted">No triage output captured for this run.</p>';
+    return;
+  }
+
+  if (stage1.summary) {
+    const summary = document.createElement('p');
+    summary.textContent = stage1.summary;
+    elements.stage1Body.append(summary);
+  }
+
+  const reasons = Array.isArray(stage1.reasons) ? stage1.reasons : [];
+  if (reasons.length) {
+    const header = document.createElement('h3');
+    header.textContent = 'Key reasons';
+    elements.stage1Body.append(header);
+    const list = document.createElement('ul');
+    list.className = 'list';
+    reasons.forEach((reason) => {
+      const li = document.createElement('li');
+      li.textContent = String(reason);
+      list.append(li);
+    });
+    elements.stage1Body.append(list);
+  }
+
+  const flags = stage1.flags && typeof stage1.flags === 'object' ? stage1.flags : null;
+  if (flags) {
+    const entries = Object.entries(flags).filter(([, value]) => value !== null && value !== false && value !== 'false');
+    if (entries.length) {
+      const header = document.createElement('h3');
+      header.textContent = 'Risk flags';
+      elements.stage1Body.append(header);
+      const list = document.createElement('ul');
+      list.className = 'list';
+      entries.forEach(([key, value]) => {
+        const li = document.createElement('li');
+        li.textContent = `${titleCase(key)}: ${String(value)}`;
+        list.append(li);
+      });
+      elements.stage1Body.append(list);
+    }
+  }
+
+  if (!reasons.length && !flags && !stage1.summary) {
+    elements.stage1Body.innerHTML = '<p class="muted">Stage 1 returned a label with no additional commentary.</p>';
+  }
+}
+
+function renderStage2(stage2) {
+  elements.stage2Scores.innerHTML = '';
+  elements.stage2Verdict.innerHTML = '';
+  elements.stage2Next.innerHTML = '';
+
+  if (!stage2 || typeof stage2 !== 'object') {
+    elements.stage2Scores.innerHTML = '<p class="muted">Stage 2 scoring has not run yet.</p>';
+    return;
+  }
+
+  if (stage2.scores && typeof stage2.scores === 'object') {
+    const header = document.createElement('h3');
+    header.textContent = 'Scores';
+    elements.stage2Scores.append(header);
+    const list = document.createElement('ul');
+    list.className = 'list';
+    Object.entries(stage2.scores).forEach(([key, value]) => {
+      const score = Number(value?.score ?? value);
+      if (!Number.isFinite(score)) return;
+      const rationale = value?.rationale ? ` — ${value.rationale}` : '';
+      const li = document.createElement('li');
+      li.textContent = `${titleCase(key)}: ${score}/10${rationale}`;
+      list.append(li);
+    });
+    elements.stage2Scores.append(list);
+  }
+
+  if (stage2.verdict) {
+    const header = document.createElement('h3');
+    header.textContent = 'Verdict';
+    elements.stage2Verdict.append(header);
+    const paragraph = document.createElement('p');
+    const summary = stage2.verdict.summary || stage2.verdict.why || 'No summary provided.';
+    paragraph.textContent = summary;
+    elements.stage2Verdict.append(paragraph);
+
+    const verdictList = [];
+    if (Array.isArray(stage2.verdict.opportunities) && stage2.verdict.opportunities.length) {
+      verdictList.push({ title: 'Opportunities', values: stage2.verdict.opportunities });
+    }
+    if (Array.isArray(stage2.verdict.risks) && stage2.verdict.risks.length) {
+      verdictList.push({ title: 'Risks', values: stage2.verdict.risks });
+    }
+    verdictList.forEach((entry) => {
+      const subHeader = document.createElement('h3');
+      subHeader.textContent = entry.title;
+      elements.stage2Verdict.append(subHeader);
+      const list = document.createElement('ul');
+      list.className = 'list';
+      entry.values.forEach((item) => {
+        const li = document.createElement('li');
+        li.textContent = String(item);
+        list.append(li);
+      });
+      elements.stage2Verdict.append(list);
+    });
+  }
+
+  if (Array.isArray(stage2.next_steps) && stage2.next_steps.length) {
+    const header = document.createElement('h3');
+    header.textContent = 'Next steps';
+    elements.stage2Next.append(header);
+    const list = document.createElement('ul');
+    list.className = 'list';
+    stage2.next_steps.forEach((step) => {
+      const li = document.createElement('li');
+      li.textContent = String(step);
+      list.append(li);
+    });
+    elements.stage2Next.append(list);
+  }
+}
+
+function renderStage3(summaryJson, summaryText, groupsJson) {
+  const summary = summaryText || summaryJson?.summary || summaryJson?.thesis || summaryJson?.narrative;
+  if (summary) {
+    elements.stage3Summary.classList.remove('muted');
+    elements.stage3Summary.textContent = summary;
+  } else {
+    elements.stage3Summary.classList.add('muted');
+    elements.stage3Summary.textContent = 'Deep dive not yet available.';
+  }
+
+  elements.stage3Groups.innerHTML = '';
+  const groups = Array.isArray(groupsJson) ? groupsJson : [];
+  if (!groups.length) return;
+
+  groups.forEach((group) => {
+    const card = document.createElement('section');
+    card.className = 'group-card';
+    const title = document.createElement('h4');
+    title.textContent = group.question_group ? titleCase(group.question_group) : 'Analysis';
+    card.append(title);
+    const pre = document.createElement('pre');
+    pre.textContent = JSON.stringify(group.answer_json ?? group, null, 2);
+    card.append(pre);
+    elements.stage3Groups.append(card);
+  });
+}
+
+function bindEvents() {
+  if (elements.runPicker) {
+    elements.runPicker.addEventListener('change', () => {
+      const value = elements.runPicker.value;
+      state.runId = isUuid(value) ? value : null;
+      loadDetails().catch((error) => console.error('loadDetails error', error));
+    });
+  }
+
+  if (elements.exportJson) {
+    elements.exportJson.addEventListener('click', () => {
+      if (!state.detail) {
+        alert('Nothing to export yet.');
+        return;
+      }
+      const blob = new Blob([JSON.stringify(state.detail, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${state.ticker}-${state.runId || 'report'}.json`;
+      document.body.append(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    });
+  }
+
+  if (elements.copySummary) {
+    elements.copySummary.addEventListener('click', async () => {
+      const summary = elements.stage3Summary.textContent;
+      if (!summary || summary === 'Deep dive not yet available.') {
+        alert('No deep dive summary to copy yet.');
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(summary);
+        elements.copySummary.textContent = 'Copied!';
+        window.setTimeout(() => {
+          elements.copySummary.textContent = 'Copy thesis';
+        }, 2000);
+      } catch (error) {
+        console.error('clipboard error', error);
+        alert('Unable to copy to clipboard.');
+      }
+    });
+  }
+}
+
+async function init() {
+  if (!state.ticker) {
+    elements.title.textContent = 'Ticker missing';
+    elements.subtitle.textContent = 'Pass ?ticker=SYMBOL in the URL to load a report.';
+    return;
+  }
+  const allowed = await ensureAccess();
+  if (!allowed) return;
+  bindEvents();
+  await loadRunsForTicker();
+  if (!state.runId) {
+    elements.subtitle.textContent = 'No runs have processed this ticker yet.';
+    return;
+  }
+  await loadDetails();
+}
+
+init().catch((error) => {
+  console.error('ticker init error', error);
+  elements.subtitle.textContent = error.message ?? 'Failed to load ticker.';
+});

--- a/assets/universe.js
+++ b/assets/universe.js
@@ -1,702 +1,595 @@
-// /assets/universe.js
-import { supabase, isMembershipActive } from './supabase.js';
+import { supabase, getUser, getProfile, getMembership, hasAdminRole } from './supabase.js';
 
 const state = {
+  session: { user: null, profile: null, membership: null },
+  runs: [],
+  runId: null,
+  filters: {
+    search: '',
+    stage: null,
+    label: null,
+    goDeep: null,
+    sector: null
+  },
   rows: [],
-  filtered: [],
-  q: localStorage.getItem('universe_q') || '',
-  viewMode: localStorage.getItem('universe_view_mode') || 'tags',
+  limit: 50,
+  total: 0,
   loading: false,
-  error: null,
-  isMember: false,
-  isSignedIn: false,
-  authReady: false,
-  previewCount: 0,
-  lockedCount: 0,
+  facets: new Map()
 };
 
-document.addEventListener('DOMContentLoaded', () => {
-  UniversePage().catch((err) => console.error('Universe init error', err));
-});
-
-async function UniversePage() {
-  const $ = (sel) => document.querySelector(sel);
-  const tbody = $('#tbody');
-  const headerRow = $('#headerRow');
-  const qInput = $('#q');
-  const viewButtons = Array.from(document.querySelectorAll('[data-mode]'));
-
-  const BASE_HEADERS = [
-    { key: 'company', label: 'Company name', style: 'min-width:220px' },
-    { key: 'price', label: 'Current Price', style: 'width:130px' },
-    { key: 'risk', label: 'Risk Rating', style: 'width:120px' },
-    { key: 'date', label: 'Date', style: 'width:110px' },
-    { key: 'financials', label: 'Financials', style: 'width:120px' },
-    { key: 'analysis', label: 'Analysis', style: 'width:110px' },
-  ];
-
-  const VIEW_CONFIG = {
-    tags: {
-      columns: [
-        { key: 'tag_moat', label: '[Tag] Moat/quality type', getter: (row) => findTagMatch(row.tags, ['moat', 'quality']) },
-        { key: 'tag_leverage', label: '[Tag] Leverage', getter: (row) => findTagMatch(row.tags, ['lever']) },
-        { key: 'tag_cannibal', label: '[Tag] Cannibal', getter: (row) => findTagMatch(row.tags, ['cannibal']) },
-        { key: 'tag_valuetrap', label: '[Tag] Valuetrap?', getter: (row) => findTagMatch(row.tags, ['value trap', 'valuetrap']) },
-        { key: 'tag_options', label: '[Tag] Options', getter: (row) => findTagMatch(row.tags, ['option']) },
-        { key: 'tag_writedowns', label: '[Tag] Writedowns', getter: (row) => findTagMatch(row.tags, ['writedown']) },
-        { key: 'tag_asymmetric', label: '[Tag] Assymetric/Swingtrade', getter: (row) => findTagMatch(row.tags, ['swing', 'asym']) },
-        { key: 'tag_superinvestors', label: '[Tag] Superinvestors', getter: (row) => findTagMatch(row.tags, ['superinvestor', 'guru']) },
-        { key: 'tag_industry', label: '[Tag] Industry', getter: (row) => findTagMatch(row.tags, ['industry', 'sector', 'tech', 'consumer', 'energy', 'financial', 'health', 'industrial']) },
-      ],
-    },
-    strategies: {
-      columns: [
-        { key: 'strategy_focus', label: 'Strategy focus', getter: (row) => row.strategies?.focus ?? row.strategy_focus },
-        { key: 'strategy_plan', label: 'Entry plan', getter: (row) => row.strategies?.entry ?? row.strategy_entry },
-        { key: 'strategy_exit', label: 'Exit plan', getter: (row) => row.strategies?.exit ?? row.strategy_exit },
-      ],
-    },
-    metrics: {
-      columns: [
-        { key: 'metric_ps', label: 'P/S', getter: (row) => formatMetric(getMetricValue(row, ['ps', 'price_sales', 'price_to_sales'])) },
-        { key: 'metric_pe', label: 'P/E', getter: (row) => formatMetric(getMetricValue(row, ['pe', 'price_earnings', 'price_to_earnings'])) },
-        { key: 'metric_pb', label: 'P/B', getter: (row) => formatMetric(getMetricValue(row, ['pb', 'price_book', 'price_to_book'])) },
-        { key: 'metric_peg', label: 'PEG', getter: (row) => formatMetric(getMetricValue(row, ['peg'])) },
-        { key: 'metric_evebit', label: 'EV/EBIT', getter: (row) => formatMetric(getMetricValue(row, ['ev_ebit', 'evebit'])) },
-        { key: 'metric_evebitda', label: 'EV/EBITDA', getter: (row) => formatMetric(getMetricValue(row, ['ev_ebitda', 'evebitda'])) },
-      ],
-    },
-    placeholder1: {
-      columns: [
-        { key: 'placeholder1_a', label: 'Placeholder 1A', getter: (row) => row.placeholder1?.a ?? row.placeholder1_a },
-        { key: 'placeholder1_b', label: 'Placeholder 1B', getter: (row) => row.placeholder1?.b ?? row.placeholder1_b },
-      ],
-    },
-    placeholder2: {
-      columns: [
-        { key: 'placeholder2_a', label: 'Placeholder 2A', getter: (row) => row.placeholder2?.a ?? row.placeholder2_a },
-        { key: 'placeholder2_b', label: 'Placeholder 2B', getter: (row) => row.placeholder2?.b ?? row.placeholder2_b },
-      ],
-    },
-  };
-  const modal = $('#modal');
-  const mTitle = $('#mTitle');
-  const mBody = $('#mBody');
-  const mClose = $('#mClose');
-
-  if (!tbody) return;
-
-  initMembershipBridge();
-
-  // Initialize filters from storage
-  qInput.value = state.q;
-
-  async function load() {
-    state.loading = true;
-    state.error = null;
-    render();
-    const { data, error } = await supabase
-      .from('universe')
-      .select('*')
-      .order('date', { ascending: false });
-    if (error) {
-      console.warn('universe fetch error', error);
-      state.rows = [];
-      state.error = error.message || 'Unable to load data.';
-    } else {
-      state.rows = (data || []).map(normalizeRow);
-    }
-    state.loading = false;
-  }
-
-  function normalizeRow(row) {
-    return {
-      id: row.id,
-      date: row.date || '',
-      topic: row.topic || '',
-      company: row.company || row.company_name || row.topic || '',
-      prompt_used: row.prompt_used || '',
-      key_findings: Array.isArray(row.key_findings) ? row.key_findings : [],
-      visual_table_md: row.visual_table_md || '',
-      conclusion: row.conclusion || '',
-      analysis_markdown: row.analysis_markdown || row.analysis_full_md || row.analysis_full || '',
-      tags: Array.isArray(row.tags) ? row.tags : Array.isArray(row.tags?.array) ? row.tags.array : [],
-      current_price: normalizeNumeric(row.current_price ?? row.price ?? row.currentPrice),
-      current_price_raw: row.current_price ?? row.price ?? row.currentPrice ?? '',
-      current_price_display: row.current_price_display || row.price_display || '',
-      currency: row.currency_symbol || row.currency || row.currencySymbol || '',
-      risk_rating: row.risk_rating || row.risk || '',
-      strategies: row.strategies || {},
-      metrics: row.metrics || {},
-      placeholder1: row.placeholder1 || {},
-      placeholder2: row.placeholder2 || {},
-      financials_markdown: row.financials_markdown || row.financials_md || '',
-      created_at: row.created_at || null,
-    };
-  }
-
-  function render() {
-    localStorage.setItem('universe_q', (qInput.value = state.q));
-    localStorage.setItem('universe_view_mode', state.viewMode);
-
-    updateViewButtons();
-
-    const dynamicColumns = getDynamicColumns();
-    updateHeader(dynamicColumns);
-    const totalColumns = BASE_HEADERS.length + dynamicColumns.length;
-
-    if (state.loading) {
-      tbody.innerHTML = `<tr><td class="empty" colspan="${totalColumns}">Loading…</td></tr>`;
-      return;
-    }
-    if (state.error) {
-      tbody.innerHTML = `<tr><td class="empty" colspan="${totalColumns}">${escapeHtml(state.error)}</td></tr>`;
-      return;
-    }
-    if (!state.rows.length) {
-      tbody.innerHTML = `<tr><td class="empty" colspan="${totalColumns}">No data yet.</td></tr>`;
-      return;
-    }
-
-    const needle = state.q.trim().toLowerCase();
-    const matchesQuery = (row) => {
-      if (!needle) return true;
-      return JSON.stringify(row).toLowerCase().includes(needle);
-    };
-
-    state.filtered = state.rows.filter(matchesQuery);
-
-    if (!state.filtered.length) {
-      tbody.innerHTML = `<tr><td class="empty" colspan="${totalColumns}">No results. Try clearing filters.</td></tr>`;
-      return;
-    }
-
-    const visibleRows = getPreviewRows();
-    const lockedCount = getLockedCount();
-    state.previewCount = visibleRows.length;
-    state.lockedCount = lockedCount;
-
-    const rows = [];
-    const html = visibleRows.map((row) => buildRow(row, dynamicColumns)).join('');
-    if (html) rows.push(html);
-
-    if (lockedCount > 0) {
-      const lockedLabel = lockedCount === 1 ? '1 more research brief' : `${lockedCount} more research briefs`;
-      const previewLabel = `${visibleRows.length} of ${state.filtered.length}`;
-      const message = state.authReady
-        ? (state.isSignedIn
-            ? `Your account needs an active membership to view the remaining ${lockedLabel}.`
-            : `Join FutureFunds.ai to unlock the remaining ${lockedLabel}.`)
-        : 'Checking membership status…';
-      const secondaryView = state.isSignedIn ? 'profile' : 'signin';
-      const secondaryLabel = state.isSignedIn ? 'Manage account' : 'Sign in';
-      rows.push(`
-        <tr class="locked-row">
-          <td colspan="${totalColumns}">
-            <div class="locked-paywall">
-              <strong>Unlock the full Universe archive</strong>
-              <p>${escapeHtml(message)}</p>
-              <div class="actions">
-                <a class="btn primary" href="/membership.html">View membership plans</a>
-                <button class="btn" type="button" data-open-auth="${escapeHtml(secondaryView)}">${escapeHtml(secondaryLabel)}</button>
-              </div>
-              <p class="locked-note">Preview shows ${escapeHtml(previewLabel)} entries.</p>
-            </div>
-          </td>
-        </tr>`);
-    }
-
-    tbody.innerHTML = rows.join('');
-  }
-
-  function buildRow(row, dynamicColumns) {
-    const rowKey = getRowKey(row);
-    const company = row.company || row.topic || '';
-    const priceText = formatPrice(row);
-    const risk = safeText(row.risk_rating);
-    const date = safeText(row.date);
-    const hasFinancials = !!(row.visual_table_md || row.financials_markdown);
-    const hasAnalysis = !!(row.analysis_markdown || row.conclusion || (row.key_findings || []).length);
-
-    const financialsCell = hasFinancials
-      ? `<button type="button" class="link-btn" data-action="financials" data-row-id="${escapeHtml(rowKey)}">View</button>`
-      : '<span style="color:var(--muted,#94a3b8)">No data</span>';
-    const analysisCell = hasAnalysis
-      ? `<button type="button" class="link-btn" data-action="analysis" data-row-id="${escapeHtml(rowKey)}">Open</button>`
-      : '<span style="color:var(--muted,#94a3b8)">No data</span>';
-
-    const dynamicCells = dynamicColumns
-      .map((col) => {
-        const value = safeText(col.getter ? col.getter(row) : undefined);
-        const className = col.className ? ` class="${col.className}"` : '';
-        return `<td${className}>${escapeHtml(value)}</td>`;
-      })
-      .join('');
-
-    return `
-      <tr data-id="${escapeHtml(rowKey)}">
-        <td class="company-cell">${escapeHtml(company)}</td>
-        <td class="metric-cell">${escapeHtml(priceText)}</td>
-        <td>${escapeHtml(risk)}</td>
-        <td>${escapeHtml(date)}</td>
-        <td>${financialsCell}</td>
-        <td>${analysisCell}</td>
-        ${dynamicCells}
-      </tr>`;
-  }
-
-  function getRowKey(row) {
-    if (!row) return '';
-    if (row.id !== undefined && row.id !== null && row.id !== '') return String(row.id);
-    const topic = row.topic || row.company || '';
-    return `${row.date || ''}|${topic}`;
-  }
-
-  function updateHeader(dynamicColumns) {
-    if (!headerRow) return;
-    const headerHtml = [
-      ...BASE_HEADERS.map((col) => `<th${col.style ? ` style="${col.style}"` : ''}>${col.label}</th>`),
-      ...dynamicColumns.map((col) => `<th>${col.label}</th>`),
-    ].join('');
-    headerRow.innerHTML = headerHtml;
-  }
-
-  function updateViewButtons() {
-    viewButtons.forEach((btn) => {
-      const mode = btn.dataset.mode;
-      const isActive = mode === state.viewMode;
-      btn.classList.toggle('active', isActive);
-      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-    });
-  }
-
-  function getDynamicColumns() {
-    const config = VIEW_CONFIG[state.viewMode];
-    return config && Array.isArray(config.columns) ? config.columns : [];
-  }
-
-  function findTagMatch(tags, keywords = []) {
-    if (!Array.isArray(tags) || !tags.length) return '—';
-    if (!keywords?.length) return safeText(tags[0]);
-    const normalizedTags = tags.map((tag) => String(tag));
-    for (const keyword of keywords) {
-      const needle = String(keyword || '').toLowerCase();
-      if (!needle) continue;
-      const match = normalizedTags.find((tag) => tag.toLowerCase().includes(needle));
-      if (match) return match;
-    }
-    return '—';
-  }
-
-  function safeText(value) {
-    if (value === null || value === undefined) return '—';
-    const str = String(value).trim();
-    return str ? str : '—';
-  }
-
-  function formatPrice(row) {
-    if (!row) return '—';
-    if (row.current_price_display) return safeText(row.current_price_display);
-    const currencyRaw = row.currency ?? '';
-    const currency = safeText(currencyRaw);
-    const currencyLabel = currency === '—' ? '' : currency;
-
-    const value = row.current_price;
-    if (typeof value === 'number' && Number.isFinite(value)) {
-      return currencyLabel ? formatCurrencyLabel(currencyLabel, formatNumber(value)) : formatNumber(value);
-    }
-    if (value !== null && value !== undefined && value !== '') {
-      const num = Number(value);
-      if (Number.isFinite(num)) {
-        return currencyLabel ? formatCurrencyLabel(currencyLabel, formatNumber(num)) : formatNumber(num);
-      }
-      return safeText(value);
-    }
-    if (row.current_price_raw) {
-      return safeText(row.current_price_raw);
-    }
-    return '—';
-  }
-
-  function formatCurrencyLabel(currency, value) {
-    const symbol = currency.trim();
-    if (!symbol) return value;
-    if (/^[A-Za-z]{3}$/.test(symbol)) return `${symbol.toUpperCase()} ${value}`;
-    return `${symbol}${value}`;
-  }
-
-  function formatNumber(num) {
-    const abs = Math.abs(num);
-    let maximumFractionDigits = 2;
-    if (abs >= 1000) maximumFractionDigits = 0;
-    else if (abs >= 100) maximumFractionDigits = 1;
-    else if (abs < 1) maximumFractionDigits = 4;
-    return num.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits });
-  }
-
-  function formatMetric(value) {
-    if (value === null || value === undefined || value === '') return '—';
-    const num = Number(value);
-    if (Number.isFinite(num)) {
-      const abs = Math.abs(num);
-      let maximumFractionDigits = 2;
-      if (abs >= 1000) maximumFractionDigits = 0;
-      else if (abs >= 100) maximumFractionDigits = 1;
-      else if (abs < 1) maximumFractionDigits = 4;
-      return num.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits });
-    }
-    return safeText(value);
-  }
-
-  function getMetricValue(row, keys = []) {
-    if (!row || !keys?.length) return null;
-    const sources = [row.metrics || {}, row];
-    for (const key of keys) {
-      const variants = buildMetricKeyVariants(key);
-      for (const variant of variants) {
-        for (const source of sources) {
-          if (source && source[variant] !== undefined && source[variant] !== null && source[variant] !== '') {
-            return source[variant];
-          }
-        }
-      }
-    }
-    return null;
-  }
-
-  function buildMetricKeyVariants(key) {
-    const base = String(key || '');
-    const variants = new Set([base]);
-    variants.add(base.toLowerCase());
-    variants.add(base.toUpperCase());
-    variants.add(base.replace(/\//g, '_'));
-    variants.add(base.replace(/[_\s]/g, ''));
-    variants.add(base.replace(/\//g, ''));
-    variants.add(`metric_${base}`);
-    variants.add(`metric_${base}`.toLowerCase());
-    variants.add(`metric${base}`);
-    variants.add(`metric${base}`.toLowerCase());
-    variants.add(`ratio_${base}`);
-    variants.add(`ratio${base}`);
-    return [...variants];
-  }
-
-  function normalizeNumeric(value) {
-    if (value === null || value === undefined) return null;
-    if (typeof value === 'number' && Number.isFinite(value)) return value;
-    const str = String(value).trim();
-    if (!str) return null;
-    const cleaned = str.replace(/[^0-9.+-]/g, '');
-    if (!cleaned) return null;
-    const num = Number(cleaned);
-    return Number.isFinite(num) ? num : null;
-  }
-
-  function openModal(row, mode = 'analysis') {
-    if (!row) return;
-
-    if (mode === 'financials') {
-      const markdown = row.financials_markdown || row.visual_table_md || '';
-      mTitle.textContent = `${row.company || row.topic || 'Financials'} — Financials`;
-      if (markdown) {
-        mBody.innerHTML = `
-          <div style="display:grid;gap:12px">
-            <div><strong>Date:</strong> ${escapeHtml(row.date || '')}</div>
-            <pre style="white-space:pre-wrap;margin:0">${escapeHtml(markdown)}</pre>
-            <div class="modal-actions">
-              <button id="copyFinancials" class="btn" type="button" style="padding:8px 10px;border:1px solid var(--border);border-radius:10px;background:var(--panel)">Copy markdown</button>
-            </div>
-          </div>`;
-        const copyFinancials = $('#copyFinancials');
-        if (copyFinancials) {
-          copyFinancials.addEventListener('click', async () => {
-            try {
-              await navigator.clipboard.writeText(markdown);
-              toast('Markdown copied');
-            } catch (err) {
-              console.warn('Clipboard error', err);
-              toast('Unable to copy', true);
-            }
-          });
-        }
-      } else {
-        mBody.innerHTML = '<p style="margin:0">Financial details are not available for this entry.</p>';
-      }
-      modal.style.display = 'flex';
-      return;
-    }
-
-    if (mode === 'full' && row.analysis_markdown) {
-      mTitle.textContent = `${row.company || row.topic || 'Analysis'} — Full analysis`;
-      mBody.innerHTML = renderFullAnalysis(row);
-      modal.style.display = 'flex';
-      const copyFull = $('#copyFull');
-      if (copyFull) {
-        copyFull.addEventListener('click', async () => {
-          try {
-            await navigator.clipboard.writeText(row.analysis_markdown || '');
-            toast('Analysis copied');
-          } catch (err) {
-            console.warn('Clipboard error', err);
-            toast('Unable to copy', true);
-          }
-        });
-      }
-      const backBtn = $('#backToSummary');
-      if (backBtn) {
-        backBtn.addEventListener('click', () => openModal(row, 'analysis'));
-      }
-      return;
-    }
-
-    const findings = (row.key_findings || []).map((item) => `<li>${escapeHtml(item)}</li>`).join('');
-    const risk = safeText(row.risk_rating);
-    const riskBlock = risk !== '—' ? `<div><strong>Risk rating:</strong> ${escapeHtml(risk)}</div>` : '';
-    const tags = (row.tags || []).filter(Boolean);
-    const tagsBlock = tags.length ? `<div><strong>Tags:</strong> ${escapeHtml(tags.join(', '))}</div>` : '';
-
-    mTitle.textContent = `${row.company || row.topic || 'Analysis'} — Summary`;
-    mBody.innerHTML = `
-      <div style="display:grid;gap:12px">
-        <div><strong>Date:</strong> ${escapeHtml(row.date || '')}</div>
-        ${riskBlock}
-        ${findings ? `<div><strong>Key findings:</strong><ul style="margin:6px 0 0;padding-left:18px">${findings}</ul></div>` : ''}
-        ${row.conclusion ? `<div><strong>Conclusion:</strong><br>${escapeHtml(row.conclusion)}</div>` : ''}
-        ${tagsBlock}
-        ${row.analysis_markdown ? '<div class="modal-actions"><button id="viewFullAnalysis" class="btn ghost" type="button">Read full analysis</button></div>' : ''}
-      </div>`;
-    modal.style.display = 'flex';
-    const viewFullBtn = $('#viewFullAnalysis');
-    if (viewFullBtn) {
-      viewFullBtn.addEventListener('click', () => openModal(row, 'full'));
-    }
-  }
-
-  function renderFullAnalysis(row) {
-    return `
-      <div class="analysis-full">
-        <div class="analysis-full__meta"><strong>${escapeHtml(row.company || row.topic || 'Analysis')}</strong> — ${escapeHtml(row.date || '')}</div>
-        ${row.risk_rating ? `<div class="analysis-full__meta"><strong>Risk rating:</strong> ${escapeHtml(row.risk_rating)}</div>` : ''}
-        <pre class="analysis-full__body">${escapeHtml(row.analysis_markdown || '')}</pre>
-        <div class="modal-actions">
-          <button id="copyFull" class="btn" type="button" style="padding:8px 10px;border:1px solid var(--border);border-radius:10px;background:var(--panel)">Copy analysis</button>
-          <button id="backToSummary" class="btn ghost" type="button">Back to summary</button>
-        </div>
-      </div>`;
-  }
-
-  function closeModal() {
-    modal.style.display = 'none';
-  }
-  mClose.addEventListener('click', closeModal);
-  modal.addEventListener('click', (event) => { if (event.target === modal) closeModal(); });
-
-  qInput.addEventListener('input', () => { state.q = qInput.value; render(); });
-  viewButtons.forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const mode = btn.dataset.mode;
-      if (!mode || mode === state.viewMode) return;
-      state.viewMode = mode;
-      localStorage.setItem('universe_view_mode', state.viewMode);
-      render();
-    });
-  });
-
-  $('#btnRefresh').addEventListener('click', async () => {
-    await load();
-    render();
-    toast('Data refreshed');
-  });
-
-  $('#btnExportCsv').addEventListener('click', () => {
-    const rows = getPreviewRows();
-    if (!rows.length) return toast('Nothing to export', true);
-    exportCsv(rows);
-    if (!state.isMember && state.lockedCount > 0) {
-      toast('Preview export generated — join membership for the full dataset.');
-    } else {
-      toast('CSV exported');
-    }
-  });
-
-  $('#btnCopyJson').addEventListener('click', async () => {
-    const rows = getPreviewRows();
-    if (!rows.length) {
-      toast('Nothing to copy', true);
-      return;
-    }
-    await navigator.clipboard.writeText(JSON.stringify(rows, null, 2));
-    if (!state.isMember && state.lockedCount > 0) {
-      toast('Preview copied — join membership for the full dataset.');
-    } else {
-      toast('JSON copied');
-    }
-  });
-
-  tbody.addEventListener('click', (event) => {
-    const target = event.target.closest('button[data-action]');
-    if (!target) return;
-    event.stopPropagation();
-    const action = target.getAttribute('data-action');
-    const id = target.getAttribute('data-row-id');
-    if (!id) return;
-    const row = state.filtered.find((r) => getRowKey(r) === id);
-    if (!row) return;
-    if (action === 'financials') {
-      openModal(row, 'financials');
-    } else if (action === 'analysis') {
-      openModal(row, 'analysis');
-    } else if (action === 'full') {
-      openModal(row, 'full');
-    }
-  });
-
-  window.addEventListener('keydown', (event) => {
-    if (event.key === '/' && document.activeElement !== qInput) {
-      event.preventDefault();
-      qInput.focus();
-    }
-    if (event.key === 'Escape' && modal.style.display === 'flex') closeModal();
-  });
-
-  function toast(message, isError = false) {
-    const el = document.createElement('div');
-    el.textContent = message;
-    el.style.cssText = 'position:fixed;bottom:18px;left:50%;transform:translateX(-50%);background:var(--panel);border:1px solid var(--border);padding:10px 12px;border-radius:12px;box-shadow:var(--shadow);z-index:120';
-    if (isError) el.style.borderColor = 'var(--danger,#ff6b6b)';
-    document.body.appendChild(el);
-    setTimeout(() => el.remove(), 1600);
-  }
-
-  function exportCsv(rows) {
-    if (!rows?.length) return toast('Nothing to export', true);
-    const dynamicColumns = getDynamicColumns();
-    const header = [
-      'company',
-      'current_price',
-      'risk_rating',
-      'date',
-      'conclusion',
-      'financials_markdown',
-      'analysis_markdown',
-      'tags',
-      ...dynamicColumns.map((col) => toSlug(col.label)),
-    ];
-    const csv = [
-      header.join(','),
-      ...rows.map((row) => {
-        const dynamicValues = dynamicColumns.map((col) => csvValue(col.getter ? col.getter(row) : ''));
-        const vals = [
-          csvValue(row.company || row.topic || ''),
-          csvValue(formatPrice(row)),
-          csvValue(row.risk_rating),
-          csvValue(row.date),
-          csvValue(row.conclusion),
-          csvValue(row.financials_markdown || row.visual_table_md || ''),
-          csvValue(row.analysis_markdown || ''),
-          csvValue((row.tags || []).join('|')),
-          ...dynamicValues,
-        ].map(csvEscape);
-        return vals.join(',');
-      })
-    ].join('\n');
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `universe_export_${new Date().toISOString().slice(0,10)}.csv`;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
-  }
-
-  function csvEscape(value) {
-    const str = String(value ?? '');
-    if (/[",\n]/.test(str)) return `"${str.replace(/"/g, '""')}"`;
-    return str;
-  }
-
-  function csvValue(value) {
-    if (value === null || value === undefined) return '';
-    if (typeof value === 'number' && Number.isFinite(value)) return value;
-    const str = String(value).trim();
-    if (!str || str === '—') return '';
-    return str.replace(/\n/g, '\\n');
-  }
-
-  function toSlug(label) {
-    const str = String(label || '').toLowerCase();
-    const slug = str.replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
-    return slug || 'column';
-  }
-
-  function escapeHtml(str) {
-    return String(str ?? '').replace(/[&<>"']/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' }[m]));
-  }
-
-  function computePreviewLimit(total) {
-    if (state.isMember) return total;
-    if (!total) return 0;
-    const raw = Math.ceil(total * 0.2);
-    const limit = Math.max(1, raw);
-    return Math.min(total, limit);
-  }
-
-  function getPreviewRows() {
-    const total = state.filtered.length;
-    if (!total) return [];
-    const limit = computePreviewLimit(total);
-    return state.filtered.slice(0, limit);
-  }
-
-  function getLockedCount() {
-    if (state.isMember) return 0;
-    const total = state.filtered.length;
-    if (!total) return 0;
-    const limit = computePreviewLimit(total);
-    return Math.max(0, total - limit);
-  }
-
-  function initMembershipBridge() {
-    const updateFromAccount = (payload = {}) => {
-      const account = payload && (payload.user !== undefined || payload.membership !== undefined)
-        ? payload
-        : payload.detail || {};
-      const membership = account?.membership || null;
-      const isMember = isMembershipActive
-        ? isMembershipActive(membership, { profile: account?.profile, user: account?.user })
-        : false;
-      const isSignedIn = !!account?.user;
-      const changed = isMember !== state.isMember || isSignedIn !== state.isSignedIn || !state.authReady;
-      state.isMember = isMember;
-      state.isSignedIn = isSignedIn;
-      state.authReady = true;
-      if (changed) render();
-    };
-
-    const readCurrent = () => {
-      if (window.ffAuth && typeof window.ffAuth.getAccount === 'function') {
-        updateFromAccount(window.ffAuth.getAccount());
-      } else {
-        updateFromAccount({});
-      }
-    };
-
-    if (window.ffAuth && typeof window.ffAuth.onReady === 'function') {
-      window.ffAuth.onReady().then(readCurrent).catch(readCurrent);
-    } else {
-      document.addEventListener('ffauth:ready', readCurrent, { once: true });
-      setTimeout(readCurrent, 1200);
-    }
-
-    document.addEventListener('ffauth:change', (event) => {
-      updateFromAccount(event.detail || {});
-    });
-
-    readCurrent();
-  }
-
-  await load();
-  render();
+const elements = {
+  gate: document.getElementById('gate'),
+  content: document.getElementById('universeContent'),
+  runSelect: document.getElementById('runSelect'),
+  search: document.getElementById('q'),
+  refresh: document.getElementById('refreshBtn'),
+  exportCsv: document.getElementById('exportCsvBtn'),
+  copyJson: document.getElementById('copyJsonBtn'),
+  stageFilters: document.getElementById('stageFilters'),
+  labelFilters: document.getElementById('labelFilters'),
+  goDeepFilters: document.getElementById('goDeepFilters'),
+  sectorSelect: document.getElementById('sectorSelect'),
+  tableBody: document.getElementById('tableBody'),
+  loadMore: document.getElementById('loadMoreBtn'),
+  tableStatus: document.getElementById('tableStatus'),
+  metricTickers: document.getElementById('metricTickers'),
+  metricTickersSub: document.getElementById('metricTickersSub'),
+  metricGoDeep: document.getElementById('metricGoDeep'),
+  metricGoDeepSub: document.getElementById('metricGoDeepSub'),
+  metricReports: document.getElementById('metricReports'),
+  metricReportsSub: document.getElementById('metricReportsSub'),
+  metricSpend: document.getElementById('metricSpend'),
+  metricSpendSub: document.getElementById('metricSpendSub')
+};
+
+function formatNumber(value, options = {}) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '—';
+  return new Intl.NumberFormat('en-US', options).format(num);
 }
+
+function formatCurrency(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '—';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 }).format(num);
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+function titleCase(value) {
+  if (!value) return '';
+  return value
+    .toString()
+    .split(/[\s_-]+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function debounce(fn, wait = 300) {
+  let timeout;
+  return (...args) => {
+    window.clearTimeout(timeout);
+    timeout = window.setTimeout(() => fn(...args), wait);
+  };
+}
+
+function setChipActive(group, target) {
+  if (!group) return;
+  [...group.querySelectorAll('.chip')].forEach((chip) => {
+    chip.dataset.active = chip === target ? 'true' : 'false';
+  });
+}
+
+function chipValue(target, attr) {
+  if (!target) return null;
+  const value = target.dataset[attr];
+  if (value === undefined) return null;
+  if (value === '') return null;
+  if (attr === 'stage') return Number.parseInt(value, 10);
+  if (attr === 'go') return value === 'true';
+  return value;
+}
+
+async function ensureAccess() {
+  const user = await getUser();
+  if (!user) {
+    elements.gate.hidden = false;
+    elements.content.hidden = true;
+    return false;
+  }
+  const [profile, membership] = await Promise.all([getProfile(), getMembership()]);
+  if (!hasAdminRole({ user, profile, membership })) {
+    elements.gate.hidden = false;
+    elements.gate.querySelector('p').textContent = 'This cockpit is limited to analyst operators and admins. Please contact the FutureFunds team for access.';
+    elements.content.hidden = true;
+    return false;
+  }
+  state.session = { user, profile, membership };
+  elements.gate.hidden = true;
+  elements.content.hidden = false;
+  return true;
+}
+
+async function loadRuns() {
+  const { data, error } = await supabase
+    .from('runs')
+    .select('id, created_at, status, notes')
+    .order('created_at', { ascending: false })
+    .limit(25);
+  if (error) throw error;
+  state.runs = data ?? [];
+  renderRunOptions();
+  if (!state.runId && state.runs.length) {
+    state.runId = state.runs[0].id;
+  }
+}
+
+function renderRunOptions() {
+  if (!elements.runSelect) return;
+  elements.runSelect.innerHTML = '';
+  if (!state.runs.length) {
+    const option = document.createElement('option');
+    option.textContent = 'No runs yet';
+    option.value = '';
+    elements.runSelect.append(option);
+    return;
+  }
+  state.runs.forEach((run) => {
+    const option = document.createElement('option');
+    option.value = run.id;
+    const created = run.created_at ? new Date(run.created_at).toLocaleString() : 'Unknown date';
+    option.textContent = `${created} — ${run.status ?? 'unknown'}`;
+    if (run.id === state.runId) option.selected = true;
+    elements.runSelect.append(option);
+  });
+}
+
+async function fetchRows(reset = false) {
+  if (!state.runId) return;
+  if (state.loading) return;
+  state.loading = true;
+  if (reset) {
+    state.rows = [];
+  }
+  renderTableState('Loading…');
+  const params = {
+    p_run_id: state.runId,
+    p_search: state.filters.search || null,
+    p_label: state.filters.label || null,
+    p_stage: state.filters.stage ?? null,
+    p_sector: state.filters.sector || null,
+    p_go_deep: state.filters.goDeep ?? null,
+    p_limit: state.limit,
+    p_offset: reset ? 0 : state.rows.length
+  };
+  const { data, error } = await supabase.rpc('run_universe_rows', params);
+  if (error) {
+    console.error('run_universe_rows error', error);
+    renderTableError(error.message);
+    state.loading = false;
+    return;
+  }
+  const total = data?.[0]?.total_count ?? (reset ? 0 : state.total);
+  state.total = Number(total ?? 0);
+  if (reset) {
+    state.rows = data ?? [];
+  } else {
+    state.rows = state.rows.concat(data ?? []);
+  }
+  state.loading = false;
+  renderTable();
+  updateLoadMore();
+  await refreshFacets();
+  await refreshMetrics();
+}
+
+async function refreshFacets() {
+  if (!state.runId) return;
+  const params = {
+    p_run_id: state.runId,
+    p_search: state.filters.search || null,
+    p_label: state.filters.label || null,
+    p_stage: state.filters.stage ?? null,
+    p_sector: state.filters.sector || null,
+    p_go_deep: state.filters.goDeep ?? null
+  };
+  const { data, error } = await supabase.rpc('run_universe_facets', params);
+  if (error) {
+    console.warn('run_universe_facets error', error);
+    return;
+  }
+  const facets = new Map();
+  (data ?? []).forEach((row) => {
+    const metric = row.metric ?? 'unknown';
+    if (!facets.has(metric)) facets.set(metric, new Map());
+    facets.get(metric).set(row.bucket ?? '', Number(row.total ?? 0));
+  });
+  state.facets = facets;
+  renderFacetCounts();
+}
+
+async function refreshMetrics() {
+  if (!state.runId) return;
+  const [stageCountsRes, stage2Res, stage3Res, costRes] = await Promise.all([
+    supabase.rpc('run_stage_status_counts', { p_run_id: state.runId }),
+    supabase.rpc('run_stage2_summary', { p_run_id: state.runId }).maybeSingle(),
+    supabase.rpc('run_stage3_summary', { p_run_id: state.runId }).maybeSingle(),
+    supabase.rpc('run_cost_summary', { p_run_id: state.runId }).maybeSingle()
+  ]);
+
+  const stageCounts = stageCountsRes?.data ?? [];
+  const totalTickers = stageCounts.reduce((acc, row) => acc + Number(row.total ?? 0), 0);
+  elements.metricTickers.textContent = formatNumber(totalTickers);
+  const stage3Completed = Number(stage3Res?.data?.completed ?? 0);
+  const stage3Pending = Number(stage3Res?.data?.pending ?? 0);
+  const stage2GoDeep = Number(stage2Res?.data?.go_deep ?? 0);
+  elements.metricGoDeep.textContent = formatNumber(stage2GoDeep);
+  elements.metricGoDeepSub.textContent = `${formatNumber(stage2Res?.data?.completed ?? 0)} completed, ${formatNumber(stage2Res?.data?.pending ?? 0)} pending`;
+  elements.metricReports.textContent = formatNumber(stage3Completed);
+  elements.metricReportsSub.textContent = `${formatNumber(stage3Pending)} deep dives in queue`;
+  const totalCost = Number(costRes?.data?.total_cost ?? 0);
+  elements.metricSpend.textContent = formatCurrency(totalCost);
+  const tokensIn = Number(costRes?.data?.total_tokens_in ?? 0);
+  const tokensOut = Number(costRes?.data?.total_tokens_out ?? 0);
+  elements.metricSpendSub.textContent = `${formatNumber(tokensIn)} in / ${formatNumber(tokensOut)} out tokens`;
+  elements.metricTickersSub.textContent = `${formatNumber(totalTickers)} tickers across stages`;
+}
+
+function renderFacetCounts() {
+  updateChipCounts(elements.stageFilters, 'stage', (bucket) => {
+    if (!state.facets.has('stage')) return 0;
+    const map = state.facets.get('stage');
+    if (bucket === '') {
+      return Array.from(map.values()).reduce((acc, val) => acc + val, 0);
+    }
+    return map.get(String(bucket)) ?? 0;
+  });
+
+  updateChipCounts(elements.labelFilters, 'label', (bucket) => {
+    if (!state.facets.has('label')) return bucket === '' ? state.total : 0;
+    const map = state.facets.get('label');
+    if (bucket === '') {
+      return Array.from(map.values()).reduce((acc, val) => acc + val, 0);
+    }
+    return map.get(bucket) ?? 0;
+  });
+
+  updateChipCounts(elements.goDeepFilters, 'go', (bucket) => {
+    if (!state.facets.has('go_deep')) return bucket === '' ? state.total : 0;
+    const map = state.facets.get('go_deep');
+    if (bucket === '') {
+      return Array.from(map.values()).reduce((acc, val) => acc + val, 0);
+    }
+    return map.get(bucket) ?? 0;
+  });
+
+  if (elements.sectorSelect) {
+    const selected = elements.sectorSelect.value;
+    const map = state.facets.get('sector');
+    const existing = new Set();
+    if (map) {
+      elements.sectorSelect.innerHTML = '<option value="">All sectors</option>';
+      Array.from(map.entries())
+        .sort((a, b) => (a[0] || '').localeCompare(b[0] || ''))
+        .forEach(([sector, total]) => {
+          const option = document.createElement('option');
+          option.value = sector ?? '';
+          const label = sector ? titleCase(sector) : 'Unknown';
+          option.textContent = `${label} (${formatNumber(total)})`;
+          elements.sectorSelect.append(option);
+          existing.add(option.value);
+        });
+    }
+    if (selected && !existing.has(selected)) {
+      const option = document.createElement('option');
+      option.value = selected;
+      option.textContent = titleCase(selected);
+      option.selected = true;
+      elements.sectorSelect.append(option);
+    } else if (selected) {
+      elements.sectorSelect.value = selected;
+    }
+  }
+}
+
+function updateChipCounts(container, attr, getter) {
+  if (!container) return;
+  [...container.querySelectorAll('.chip')].forEach((chip) => {
+    const bucket = chip.dataset[attr] ?? '';
+    const total = getter(bucket);
+    let badge = chip.querySelector('.chip-count');
+    if (total === 0) {
+      if (badge) badge.remove();
+      return;
+    }
+    if (!badge) {
+      badge = document.createElement('span');
+      badge.className = 'chip-count';
+      chip.append(badge);
+    }
+    badge.textContent = formatNumber(total);
+  });
+}
+
+function renderTableState(message) {
+  if (!elements.tableBody) return;
+  elements.tableBody.innerHTML = `<tr><td class="table-empty" colspan="7">${message}</td></tr>`;
+  elements.tableStatus.textContent = message;
+}
+
+function renderTableError(message) {
+  renderTableState(`Error loading universe: ${message}`);
+}
+
+function renderTable() {
+  if (!elements.tableBody) return;
+  if (!state.rows.length) {
+    renderTableState('No results match the current filters.');
+    updateLoadMore();
+    return;
+  }
+  elements.tableBody.innerHTML = '';
+  state.rows.forEach((row) => {
+    const tr = document.createElement('tr');
+
+    const tickerCell = document.createElement('td');
+    tickerCell.className = 'ticker-cell';
+    const name = row.name ? row.name : 'Unknown company';
+    tickerCell.innerHTML = `<div>${row.ticker}</div><div class="ticker-meta">${name} · ${row.exchange ?? 'n/a'}</div>`;
+    tr.append(tickerCell);
+
+    const stageCell = document.createElement('td');
+    const stageClass = `stage-${row.stage ?? 0}`;
+    const statusLabel = row.status ? row.status.toUpperCase() : 'UNKNOWN';
+    stageCell.innerHTML = `<span class="stage-badge ${stageClass}">Stage ${row.stage ?? 0}</span><div class="ticker-meta">${statusLabel}</div>`;
+    tr.append(stageCell);
+
+    const labelCell = document.createElement('td');
+    if (row.label) {
+      labelCell.innerHTML = `<span class="label-pill">${titleCase(row.label)}</span>`;
+    } else {
+      labelCell.textContent = '—';
+    }
+    if (row.stage2_go_deep) {
+      const goDeep = document.createElement('div');
+      goDeep.className = 'ticker-meta';
+      goDeep.textContent = 'Go-deep approved';
+      labelCell.append(goDeep);
+    }
+    tr.append(labelCell);
+
+    const scoresCell = document.createElement('td');
+    scoresCell.className = 'score-stack';
+    const scores = extractScores(row.stage2);
+    if (scores.length) {
+      scores.forEach((entry) => {
+        const span = document.createElement('span');
+        span.innerHTML = `<strong>${entry.label}</strong><span>${entry.score}</span>`;
+        scoresCell.append(span);
+      });
+      const verdictSummary = getVerdictSummary(row.stage2);
+      if (verdictSummary) {
+        const small = document.createElement('small');
+        small.className = 'ticker-meta';
+        small.textContent = verdictSummary;
+        scoresCell.append(small);
+      }
+    } else {
+      scoresCell.textContent = '—';
+    }
+    tr.append(scoresCell);
+
+    const summaryCell = document.createElement('td');
+    summaryCell.className = 'summary-cell';
+    if (row.stage3_summary) {
+      const para = document.createElement('p');
+      para.textContent = row.stage3_summary;
+      summaryCell.append(para);
+      const updated = document.createElement('small');
+      updated.textContent = `Updated ${formatDate(row.updated_at)}`;
+      summaryCell.append(updated);
+    } else {
+      summaryCell.innerHTML = '<span class="ticker-meta">Deep dive not yet available.</span>';
+    }
+    tr.append(summaryCell);
+
+    const spendCell = document.createElement('td');
+    spendCell.textContent = formatCurrency(row.spend_usd);
+    tr.append(spendCell);
+
+    const actionsCell = document.createElement('td');
+    actionsCell.className = 'actions-cell';
+    const link = document.createElement('a');
+    link.href = `/ticker.html?ticker=${encodeURIComponent(row.ticker)}&run=${encodeURIComponent(row.run_id)}`;
+    link.textContent = 'View report';
+    link.setAttribute('aria-label', `View detailed report for ${row.ticker}`);
+    actionsCell.append(link);
+    tr.append(actionsCell);
+
+    elements.tableBody.append(tr);
+  });
+
+  elements.tableStatus.textContent = `Showing ${formatNumber(state.rows.length)} of ${formatNumber(state.total)} tickers`;
+}
+
+function updateLoadMore() {
+  if (!elements.loadMore) return;
+  const remaining = state.total - state.rows.length;
+  elements.loadMore.disabled = state.loading || remaining <= 0;
+  if (remaining <= 0) {
+    elements.loadMore.textContent = 'All results loaded';
+  } else {
+    elements.loadMore.textContent = `Load ${Math.min(state.limit, remaining)} more`;
+  }
+}
+
+function extractScores(stage2) {
+  if (!stage2 || typeof stage2 !== 'object' || !stage2.scores) return [];
+  const entries = [];
+  try {
+    const scores = stage2.scores;
+    for (const [key, value] of Object.entries(scores)) {
+      const score = Number((value && value.score) ?? value);
+      if (!Number.isFinite(score)) continue;
+      entries.push({ label: titleCase(key), score: `${score}/10` });
+    }
+  } catch (error) {
+    console.warn('Failed to parse stage2 scores', error);
+  }
+  return entries;
+}
+
+function getVerdictSummary(stage2) {
+  if (!stage2 || typeof stage2 !== 'object') return '';
+  const verdict = stage2.verdict;
+  if (!verdict) return '';
+  if (typeof verdict.summary === 'string' && verdict.summary.trim()) {
+    return verdict.summary.trim();
+  }
+  if (typeof verdict.why === 'string' && verdict.why.trim()) {
+    return verdict.why.trim();
+  }
+  return '';
+}
+
+function applyFilter(type, value) {
+  state.filters[type] = value;
+  fetchRows(true);
+}
+
+function setupEvents() {
+  if (elements.runSelect) {
+    elements.runSelect.addEventListener('change', () => {
+      const value = elements.runSelect.value;
+      state.runId = value || null;
+      fetchRows(true);
+    });
+  }
+
+  if (elements.search) {
+    elements.search.addEventListener('input', debounce((event) => {
+      state.filters.search = event.target.value.trim();
+      fetchRows(true);
+    }, 250));
+  }
+
+  if (elements.refresh) {
+    elements.refresh.addEventListener('click', () => fetchRows(true));
+  }
+
+  if (elements.exportCsv) {
+    elements.exportCsv.addEventListener('click', exportCsv);
+  }
+
+  if (elements.copyJson) {
+    elements.copyJson.addEventListener('click', copyJsonToClipboard);
+  }
+
+  if (elements.loadMore) {
+    elements.loadMore.addEventListener('click', () => fetchRows(false));
+  }
+
+  setupChipGroup(elements.stageFilters, 'stage');
+  setupChipGroup(elements.labelFilters, 'label');
+  setupChipGroup(elements.goDeepFilters, 'go');
+
+  if (elements.sectorSelect) {
+    elements.sectorSelect.addEventListener('change', (event) => {
+      const value = event.target.value;
+      state.filters.sector = value ? value : null;
+      fetchRows(true);
+    });
+  }
+}
+
+function setupChipGroup(container, attr) {
+  if (!container) return;
+  container.addEventListener('click', (event) => {
+    const target = event.target.closest('.chip');
+    if (!target) return;
+    setChipActive(container, target);
+    const value = chipValue(target, attr);
+    if (attr === 'stage') {
+      state.filters.stage = value;
+    } else if (attr === 'label') {
+      state.filters.label = value;
+    } else if (attr === 'go') {
+      state.filters.goDeep = value;
+    }
+    fetchRows(true);
+  });
+}
+
+function exportCsv() {
+  if (!state.rows.length) {
+    alert('Nothing to export yet. Load a run first.');
+    return;
+  }
+  const headers = ['Ticker', 'Name', 'Exchange', 'Stage', 'Status', 'Label', 'GoDeep', 'SpendUSD', 'Stage2Scores', 'Stage3Summary'];
+  const lines = [headers.join(',')];
+  state.rows.forEach((row) => {
+    const scorePairs = extractScores(row.stage2).map((entry) => `${entry.label} ${entry.score}`).join(' | ');
+    const values = [
+      row.ticker,
+      row.name ?? '',
+      row.exchange ?? '',
+      row.stage ?? 0,
+      row.status ?? '',
+      row.label ?? '',
+      row.stage2_go_deep ? 'true' : 'false',
+      Number(row.spend_usd ?? 0).toFixed(4),
+      scorePairs.replace(/,/g, ';'),
+      (row.stage3_summary ?? '').replace(/\r?\n|,/g, ' ')
+    ];
+    lines.push(values.map((value) => `"${String(value).replace(/"/g, '""')}"`).join(','));
+  });
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `run-${state.runId ?? 'universe'}.csv`;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function copyJsonToClipboard() {
+  if (!state.rows.length) {
+    alert('Nothing to copy yet. Load a run first.');
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(JSON.stringify(state.rows, null, 2));
+    elements.tableStatus.textContent = 'Copied current rows to clipboard';
+    window.setTimeout(() => {
+      elements.tableStatus.textContent = `Showing ${formatNumber(state.rows.length)} of ${formatNumber(state.total)} tickers`;
+    }, 2400);
+  } catch (error) {
+    console.error('clipboard error', error);
+    alert('Unable to copy to clipboard. Please copy manually from the console.');
+  }
+}
+
+async function init() {
+  const allowed = await ensureAccess();
+  if (!allowed) return;
+  setupEvents();
+  await loadRuns();
+  if (state.runId) {
+    fetchRows(true);
+  } else {
+    renderTableState('Create a run in the planner to populate the universe.');
+  }
+}
+
+init().catch((error) => {
+  console.error('universe init error', error);
+  renderTableError(error.message ?? 'Unknown error');
+});

--- a/docs/equity-analyst-roadmap.md
+++ b/docs/equity-analyst-roadmap.md
@@ -1,0 +1,98 @@
+# Automated Equity Analyst Development Roadmap
+
+This roadmap translates the analyst automation conversation into an actionable, PR-by-PR delivery
+plan. Treat each phase as a small, reviewable milestone so the Codex workflow can ship improvements
+incrementally.
+
+## 0. Foundations (Week 0)
+- [ ] **Repository scaffolding** – confirm `/web`, `/api`, `/sql`, `/docs` folders exist and add
+      `.env.example` with `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `OPENAI_API_KEY`.
+- [ ] **Dependencies** – ensure Supabase and OpenAI SDKs installed where server code will run.
+- [ ] **Design brief** – circulate this roadmap + equity_analyst.html overview with stakeholders.
+
+## 1. Data Contract & Seed (Week 1)
+- [ ] `sql/001_core.sql` – create `tickers`, `runs`, `run_items`, `answers`, `cost_ledger`,
+      `sector_prompts`, and `doc_chunks` tables.
+- [ ] `sql/002_seed.sql` – seed 10 flagship tickers across sectors.
+- [ ] Add Supabase migration scripts / npm tasks to run migrations locally and in staging.
+
+## 2. Planner Experience (Week 1–2)
+- [x] Build `web/admin/planner.html` with live cost estimator (universe slider, survival sliders,
+      per-stage token inputs, model selectors, total cost output).
+- [x] Persist planner state to `localStorage` and surface a **Start Run** CTA.
+- [x] Implement run creation endpoint (Supabase Edge Function `supabase/functions/runs-create`) to
+      insert a run row and queue `run_items` via `runs-create`.
+
+## 3. Stage 1 – Cheap Triage (Week 2)
+- [x] `/api/stage1/consume` worker: pull pending items, call GPT-4o-mini, store JSON label + usage
+      in `answers` and `cost_ledger`, update `run_items`.
+- [x] Planner UI: add **Process Stage 1 batch** control and progress stats (processed / total /
+      remaining).
+- [ ] Add retry/backoff (429, 5xx) and structured error logging for failed items.
+
+## 4. Stage 2 – Thematic Scoring (Week 3)
+- [x] Survivor filter: only `label` in (`consider`, `borderline`).
+- [x] `/api/stage2/consume`: gather sector notes, Stage 1 output, retrieved snippets; call GPT-5-mini
+      with JSON schema covering profitability, reinvestment, leverage, moat, timing.
+- [x] Persist `go_deep` boolean to `run_items` and show Stage 2 progress in planner.
+
+## 5. Sector Intelligence CMS (Week 3)
+- [x] `web/admin/sectors.html`: CRUD editor for `sector_prompts` with autosave + version tag.
+- [x] Surface sector notes summary inside planner to remind analysts what heuristics are in play.
+
+## 6. Stage 3 – Deep Dive Reports (Week 4)
+- [x] `/api/stage3/consume`: for tickers with `go_deep=true`, orchestrate grouped GPT-5 prompts with
+      document excerpts from `doc_chunks`.
+- [x] Store each grouped response in `answers`; synthesise a long-form narrative into
+      `answer_text`.
+- [x] Planner UI: **Process Stage 3 batch**, surface latest reports, and track deep-dive spend.
+
+## 7. Universe & Report Views (Week 4–5)
+- [x] `web/universe.html`: searchable table summarising ticker, stage, label, scores, spend.
+- [x] `web/ticker/{ticker}.html`: render Stage 1–3 outputs, sector notes, and allow CSV / JSON
+      export.
+- [x] Add shareable permalink for members (respect Supabase Auth).
+
+## 8. Cost Governance (Week 5)
+- [ ] Store `runs.budget_usd` and show in planner alongside actual cost-to-date.
+- [ ] Auto-stop runs when spend >= budget or when `stop_requested` is true.
+- [ ] Add sparkline / bar chart for stage-level spend (client-side or lightweight chart lib).
+
+## 9. Automation Loop (Week 6)
+- [ ] `/api/runs/continue` endpoint to sequentially trigger Stage 1 → 3 until batch limit / stop.
+- [ ] Planner toggle for **Auto continue** that polls the endpoint every N seconds.
+- [ ] Optional: schedule nightly cron (Supabase Edge) to run small watchlists.
+
+## 10. Retrieval Augmentation (Week 6–7)
+- [ ] `docs` uploader UI to add filings, transcripts, letters; chunk + embed into `doc_chunks`.
+- [ ] Retrieval helper RPC (e.g., `match_doc_chunks`) returning top-k snippets per query.
+- [ ] Integrate retrieved snippets into Stage 2 & 3 prompts with citation metadata.
+
+## 11. Member Experience & Auth (Week 7)
+- [ ] Gate analyst pages behind Supabase Auth; provide onboarding flow for new members.
+- [ ] Track per-user quotas (e.g., runs per day) using Supabase policies or server logic.
+- [ ] Post-run feedback widget so members can trigger manual follow-up questions (optional).
+
+## 12. Observability & Safety (Week 8)
+- [ ] `/api/health` endpoint (DB + OpenAI status) for uptime monitors.
+- [ ] `error_logs` table + viewer UI capturing payloads, prompt ids, retry counts.
+- [ ] Automated regression tests for prompt output schemas and JSON validators.
+
+## 13. Prompt & Model Registry (Week 8–9)
+- [ ] Store prompt templates as markdown files with interpolation tokens.
+- [ ] Central config (e.g., `config/models.json`) containing price per model, default temperature,
+      cache policy, retry settings.
+- [ ] Loader utility to compose prompts per sector & stage and to map usage -> cost ledger.
+
+## 14. Stretch Enhancements (Backlog)
+- [ ] Cached context via OpenAI Responses API to reuse deterministic summaries.
+- [ ] Advanced scoring ensembles (blend LLM output with deterministic factors).
+- [ ] User-triggered “Focus questions” appended post Stage 3.
+- [ ] Automated notification system (email / Slack) when high-conviction names found.
+
+---
+
+### Working style notes
+- Ship in small PRs; keep each milestone isolated (DB, API, UI) to simplify QA.
+- Document prompts and schema updates in `/docs/changelog.md` for future analysts.
+- Reference `equity_analyst.html` during design reviews to keep UI & DX aligned.

--- a/docs/supabase-schema.md
+++ b/docs/supabase-schema.md
@@ -7,7 +7,7 @@ access rules.
 
 ## Overview
 
-The site ships seven application tables in the `public` schema:
+The site ships a core set of application tables in the `public` schema:
 
 | Table | Purpose |
 | --- | --- |
@@ -18,6 +18,37 @@ The site ships seven application tables in the `public` schema:
 | `editor_models` | Configurable AI model catalogue used by the editor UI. |
 | `editor_api_credentials` | Stores AI provider secrets the editor can retrieve at runtime. |
 | `stock_analysis_todo` | Tracks stock analysis coverage (company, status, type, and analysis date). |
+
+The automated equity analyst pipeline introduces an additional suite of tables that power
+multi-stage model runs and reporting:
+
+| Table | Purpose |
+| --- | --- |
+| `tickers` | Canonical universe of symbols the automation can draw from, one row per ticker. |
+| `sector_prompts` | Optional sector-specific prompt augmentations injected into Stage 2+. |
+| `runs` | High-level batch execution log for each analysis sweep (start time, status, budget flags). |
+| `run_items` | Per-ticker processing state tracking the current stage, label, and spend. |
+| `answers` | Stores structured and narrative outputs produced at each stage of the pipeline. |
+| `cost_ledger` | Aggregated token usage and USD cost per stage/run for budget monitoring. |
+| `doc_chunks` | Optional retrieval corpus of text snippets (10-Ks, transcripts, etc.) used for RAG. |
+
+The analyst dashboard queries a handful of helper functions to avoid shipping large
+payloads to the browser:
+
+| Function | Purpose |
+| --- | --- |
+| `run_stage_status_counts(run_id uuid)` | Aggregates `run_items` into stage/status buckets for progress bars and totals. |
+| `run_stage1_labels(run_id uuid)` | Returns the Stage&nbsp;1 label distribution for survivors (e.g., uninvestible / consider). |
+| `run_stage2_summary(run_id uuid)` | Summarises Stage&nbsp;2 survivors, pending queue, completions, failures, and go-deep approvals. |
+| `run_stage3_summary(run_id uuid)` | Aggregates Stage&nbsp;3 finalists, pending deep dives, completed reports, and failures. |
+| `run_cost_breakdown(run_id uuid)` | Summarises `cost_ledger` spend by stage/model for budget monitoring. |
+| `run_cost_summary(run_id uuid)` | Provides overall spend and token totals for a run. |
+| `run_latest_activity(run_id uuid, limit int)` | Streams the latest answers (stage, ticker, summary) for the activity feed. |
+| `run_universe_rows(run_id uuid, ...)` | Paginates ticker-level snapshots (stage, label, spend, Stage 1–3 JSON) for the universe dashboard. |
+| `run_universe_facets(run_id uuid, ...)` | Returns stage/label/sector counts that power the filter badges in `/universe.html`. |
+| `run_ticker_details(run_id uuid, ticker text)` | Fetches the full dossier (Stage 1–3 outputs) for the ticker drilldown page. |
+
+Apply `sql/003_dashboard_helpers.sql` and `sql/005_universe_snapshot.sql` to provision or update these functions.
 
 The tables rely on three helper routines:
 
@@ -343,3 +374,98 @@ When altering the schema or policies:
 1. Update this reference file alongside any SQL migrations.
 2. Ensure the frontend code still aligns with column names, types, and access rules described above.
 3. Re-run the membership gating scenarios in `/assets/universe.js` and `/assets/editor.js` after deploying database updates.
+
+## Automated equity analyst tables
+
+Keep the following schemas in sync with `/sql/001_core.sql` when running migrations.
+
+### `tickers`
+
+*Primary key*: `ticker text`.
+
+| Column | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `ticker` | `text` | — | Upper-case trading symbol (e.g., `AAPL`). |
+| `name` | `text` | `null` | Company name used in prompts and UI. |
+| `exchange` | `text` | `null` | Listing exchange (NASDAQ, LSE, etc.). |
+| `country` | `text` | `null` | Country code or descriptor. |
+| `sector` | `text` | `null` | High-level sector grouping. |
+| `industry` | `text` | `null` | Optional finer industry classification. |
+| `created_at` | `timestamptz` | `now()` | Auto timestamp. |
+| `updated_at` | `timestamptz` | `now()` | Maintain with trigger or app logic when editing. |
+
+Seed the table with `/sql/002_seed.sql` for local development when you need sample data.
+
+### `sector_prompts`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `sector` | `text` (PK) | Sector label aligned with `tickers.sector`. |
+| `notes` | `text` | Free-form guidance injected into Stage 2 prompts. |
+
+### `runs`
+
+*Primary key*: `id uuid` generated with `gen_random_uuid()`.
+
+| Column | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `id` | `uuid` | `gen_random_uuid()` | Identifier returned to the UI when a run starts. |
+| `created_at` | `timestamptz` | `now()` | Creation timestamp. |
+| `status` | `text` | `'queued'` | Allowed values: `queued`, `running`, `done`, `failed`. |
+| `notes` | `text` | `null` | Optional metadata (e.g., user, budget). |
+| `stop_requested` | `boolean` | `false` | Workers should check this before processing the next batch. |
+
+### `run_items`
+
+Composite primary key: `(run_id, ticker)`.
+
+| Column | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `run_id` | `uuid` | — | References `runs(id)`. |
+| `ticker` | `text` | — | References `tickers(ticker)`. |
+| `stage` | `int` | `0` | Highest completed stage (0=not started, 1=triage, 2=medium, 3=deep). |
+| `label` | `text` | `null` | Outcome label from the last completed stage. |
+| `stage2_go_deep` | `boolean` | `null` | Stage&nbsp;2 verdict flag recorded when the thematic scoring worker runs. |
+| `status` | `text` | `'pending'` | `pending`, `ok`, `skipped`, or `failed`. |
+| `spend_est_usd` | `numeric(12,4)` | `0` | Running total of estimated spend for this ticker. |
+| `updated_at` | `timestamptz` | `now()` | Touch on each stage completion. |
+
+### `answers`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `bigserial` | Primary key. |
+| `run_id` | `uuid` | Foreign key → `runs`. |
+| `ticker` | `text` | Foreign key → `tickers`. |
+| `stage` | `int` | Stage indicator for the response. |
+| `question_group` | `text` | Thematic grouping (triage, medium, moat, etc.). |
+| `answer_json` | `jsonb` | Structured payload (scores, flags, etc.). |
+| `answer_text` | `text` | Optional narrative for final reports. |
+| `tokens_in` | `int` | Prompt token usage from OpenAI API. |
+| `tokens_out` | `int` | Completion token usage. |
+| `cost_usd` | `numeric(12,4)` | USD spend for the call. |
+| `created_at` | `timestamptz` | Timestamp for the response. |
+
+### `cost_ledger`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `bigserial` | Primary key. |
+| `run_id` | `uuid` | Batch identifier. |
+| `stage` | `int` | Stage number the cost corresponds to. |
+| `model` | `text` | Model identifier (e.g., `gpt-4o-mini`). |
+| `tokens_in` | `bigint` | Prompt tokens (aggregated per log entry). |
+| `tokens_out` | `bigint` | Completion tokens. |
+| `cost_usd` | `numeric(12,4)` | USD spend at logging time. |
+| `created_at` | `timestamptz` | Timestamp of the ledger entry. |
+
+### `doc_chunks`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `bigserial` | Primary key. |
+| `ticker` | `text` | References `tickers`. |
+| `source` | `text` | Describes the document source (10-K 2024, investor letter, etc.). |
+| `chunk` | `text` | Plain-text snippet used for retrieval-augmented prompts. |
+
+When enabling pgvector for semantic search, add an `embedding vector` column via a follow-up migration.

--- a/editor.html
+++ b/editor.html
@@ -490,6 +490,9 @@
           <p class="analyst-badge__stamp">Issued <span id="analystDateStamp"></span></p>
           <p class="analyst-badge__status" id="costSnapshotSummary">Track API spend with snapshots.</p>
           <div class="analyst-badge__actions">
+            <a class="btn small primary" href="/equity_analyst.html">
+              Advanced analyst view
+            </a>
             <button
               type="button"
               class="btn small ghost"

--- a/equity_analyst.html
+++ b/equity_analyst.html
@@ -1,0 +1,358 @@
+<!doctype html>
+<html lang="en" data-lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>FutureFunds — Automated Equity Analyst Command Center</title>
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <style>
+    .analyst-shell{max-width:1100px;margin:32px auto 64px;padding:0 16px;display:grid;gap:32px}
+    .analyst-hero{display:grid;gap:20px;border:1px solid var(--border,#e5e7eb);border-radius:26px;background:var(--panel,#fff);padding:28px;box-shadow:0 26px 42px rgba(15,23,42,.08)}
+    .analyst-hero__header{display:grid;gap:10px}
+    .analyst-hero__header .badge{justify-self:flex-start}
+    .analyst-hero__header .editor-title{margin:0;font-size:2rem;color:var(--text,#0f172a)}
+    .analyst-hero__header .editor-intro{margin:0;color:var(--muted,#475569);max-width:720px}
+    .analyst-hero__metrics{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(200px,1fr))}
+    .hero-metric{border:1px solid var(--border,#e5e7eb);border-radius:18px;background:var(--panel-muted,#f8fafc);padding:18px;display:grid;gap:6px}
+    .hero-metric__label{text-transform:uppercase;letter-spacing:.08em;font-size:.75rem;color:var(--muted,#64748b);font-weight:600}
+    .hero-metric__value{font-size:1.9rem;font-weight:700;color:var(--text,#0f172a)}
+    .hero-metric__hint{font-size:.82rem;color:var(--muted,#475569)}
+    .badge{display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;background:rgba(37,99,235,.12);color:var(--accent,#2563eb);font-size:.72rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase}
+    .panel{border:1px solid var(--border,#e5e7eb);border-radius:22px;background:var(--panel,#fff);padding:24px;box-shadow:0 22px 38px rgba(15,23,42,.08);display:grid;gap:18px}
+    .panel__title{margin:0;font-size:1.25rem;font-weight:600;color:var(--text,#0f172a)}
+    .analyst-grid{display:grid;gap:20px;grid-template-columns:1fr}
+    @media (min-width:960px){.analyst-grid{grid-template-columns:minmax(0,.55fr) minmax(0,.45fr)}}
+    .form-stack{display:grid;gap:14px}
+    .form-row{display:grid;gap:8px}
+    .form-row--inline{display:flex;flex-wrap:wrap;align-items:center;gap:10px}
+    .form-row label{font-weight:600;font-size:.92rem;color:var(--text,#0f172a)}
+    select.run-select{min-width:220px;padding:10px 14px;border-radius:14px;border:1px solid var(--border,#e5e7eb);background:var(--panel-muted,#f8fafc);font:inherit;color:var(--text,#0f172a)}
+    button.action-btn{padding:10px 16px;border-radius:14px;border:1px solid rgba(37,99,235,.4);background:rgba(37,99,235,.08);color:var(--accent,#2563eb);font-weight:600;font:inherit;cursor:pointer;transition:background .2s ease,transform .2s ease}
+    button.action-btn:hover{background:rgba(37,99,235,.12);transform:translateY(-1px)}
+    button.action-btn:disabled{opacity:.5;cursor:not-allowed}
+    a.link-pill{display:inline-flex;align-items:center;gap:6px;padding:10px 16px;border-radius:14px;border:1px solid rgba(37,99,235,.4);text-decoration:none;color:var(--accent,#2563eb);font-weight:600}
+    a.link-pill:hover{background:rgba(37,99,235,.08)}
+    .run-meta{display:grid;gap:10px;margin:6px 0 0}
+    .run-meta__item{display:flex;align-items:center;justify-content:space-between;gap:16px;font-size:.86rem}
+    .run-meta__label{text-transform:uppercase;letter-spacing:.08em;font-weight:600;color:var(--muted,#64748b);font-size:.72rem}
+    .run-meta__value{color:var(--text,#0f172a);font-weight:600}
+    .run-notes{border-left:3px solid rgba(37,99,235,.35);padding-left:12px;font-size:.85rem;color:var(--muted,#475569);display:none}
+    .run-notes--visible{display:block}
+    .metrics-grid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(160px,1fr))}
+    .metric-card{border:1px solid var(--border,#e5e7eb);border-radius:18px;background:var(--panel-muted,#f8fafc);padding:16px;display:grid;gap:6px}
+    .metric-card__title{margin:0;font-size:.92rem;font-weight:600;color:var(--text,#0f172a)}
+    .metric-card__value{font-size:1.4rem;font-weight:700;color:var(--text,#0f172a)}
+    .metric-card__hint{font-size:.78rem;color:var(--muted,#64748b)}
+    .cost-summary{display:grid;gap:10px}
+    .cost-summary__title{margin:8px 0 0;font-size:.95rem;font-weight:600;color:var(--text,#0f172a)}
+    .cost-summary__list{list-style:none;padding:0;margin:0;display:grid;gap:6px;font-size:.82rem;color:var(--muted,#475569)}
+    .cost-summary__list strong{color:var(--text,#0f172a)}
+    .pipeline-grid{display:grid;gap:18px}
+    @media (min-width:900px){.pipeline-grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
+    .pipeline-card{border:1px solid var(--border,#e5e7eb);border-radius:20px;background:var(--panel-muted,#f8fafc);padding:20px;display:grid;gap:12px}
+    .pipeline-card__header{display:flex;align-items:center;justify-content:space-between;gap:12px}
+    .pipeline-card__title{margin:0;font-size:1.05rem;font-weight:600;color:var(--text,#0f172a)}
+    .pipeline-card__meta{font-size:.78rem;color:var(--muted,#64748b)}
+    .progress-shell{position:relative;height:12px;border-radius:999px;background:rgba(37,99,235,.16);overflow:hidden}
+    .progress-shell__bar{position:absolute;top:0;left:0;height:100%;width:0;background:var(--accent,#2563eb);transition:width .3s ease}
+    .pipeline-card__stats{display:grid;gap:6px;font-size:.84rem;color:var(--muted,#475569)}
+    .pipeline-card__stats span{color:var(--text,#0f172a);font-weight:600}
+    .label-list{list-style:none;margin:4px 0 0;padding:0;display:grid;gap:4px;font-size:.82rem;color:var(--muted,#475569)}
+    .label-list strong{color:var(--text,#0f172a)}
+    .text-success{color:var(--accent,#2563eb)}
+    .text-fail{color:#b91c1c}
+    .activity-table{width:100%;border-collapse:separate;border-spacing:0;margin:8px 0 0;font-size:.85rem}
+    .activity-table th,.activity-table td{padding:10px 12px;border-bottom:1px solid var(--border,#e5e7eb);text-align:left}
+    .activity-table tbody tr:hover{background:rgba(37,99,235,.08)}
+    .activity-empty{margin:8px 0 0;font-size:.86rem;color:var(--muted,#64748b)}
+    .notice{font-size:.85rem;color:var(--muted,#64748b)}
+    .notice--warning{color:#b45309}
+    .checklist{list-style:none;margin:0;padding:0;display:grid;gap:8px;font-size:.88rem}
+    .checklist li{display:flex;gap:8px;align-items:flex-start}
+    .checklist li span{color:var(--muted,#475569)}
+    .analysis-export__fields{display:grid;gap:16px}
+    @media (min-width:820px){.analysis-export__fields{grid-template-columns:repeat(2,minmax(0,1fr))}}
+    .analysis-export__actions{display:flex;flex-wrap:wrap;gap:12px;align-items:center}
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="/">
+      <img src="/images/logo.webp" alt="FutureFunds.ai logo" class="logo" />
+      <span>FutureFunds.ai</span>
+    </a>
+    <button class="nav-toggle" id="navToggle" type="button" aria-expanded="false" aria-controls="siteNav">
+      <span class="sr-only">Menu</span>
+      <span class="nav-toggle__bar"></span>
+    </button>
+    <nav class="nav" id="siteNav" aria-label="Primary navigation">
+      <div class="nav-links">
+        <div class="nav-item nav-item--team">
+          <a href="/team.html" class="nav-link" data-i18n="nav.team">Experiment</a>
+        </div>
+        <div class="nav-item nav-item--has-panel nav-item--tools">
+          <a href="/tools.html" class="nav-link" data-i18n="nav.investmentTools">Investment Tools</a>
+          <div class="nav-panel nav-panel--tools" role="group" aria-label="Investment tools">
+            <div class="nav-panel__header">
+              <span class="nav-panel__title">Featured tools</span>
+              <a class="nav-panel__cta" href="/tools.html">Explore tools →</a>
+            </div>
+            <div class="nav-panel__content nav-panel__content--tools">
+              <a class="nav-tool" href="/tool.html?id=ff-pms">
+                <span class="chip membership">Member</span>
+                <h4>Portfolio OS</h4>
+                <p>Run strategies end-to-end with sheets + AI copilots.</p>
+              </a>
+              <a class="nav-tool" href="/tool.html?id=stockalpha-journal">
+                <span class="chip free">Free</span>
+                <h4>StockAlpha Journal</h4>
+                <p>Track theses, catalysts, and behavioral loops.</p>
+              </a>
+              <a class="nav-tool" href="/tool.html?id=valuebot">
+                <span class="chip paid">Paid</span>
+                <h4>ValueBot Valuation</h4>
+                <p>Get sourced, step-by-step valuations on demand.</p>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div class="nav-item nav-item--has-panel nav-item--ai">
+          <a href="/ai-economy.html" class="nav-link" data-i18n="nav.aiEconomy">The AI Economy</a>
+          <div class="nav-panel nav-panel--ai" role="group" aria-label="AI economy preview">
+            <div class="nav-panel__header">
+              <span class="nav-panel__title">AI economy brief</span>
+              <a class="nav-panel__cta" href="/ai-economy.html">Dive in →</a>
+            </div>
+            <div class="nav-ai">
+              <p class="nav-ai__pitch">Weekly signals on how automation, capital, and policy collide. Built from filings, expert transcripts, and on-chain data.</p>
+              <form class="nav-ai__signup newsletter-form" action="/ai-economy.html#newsletter" method="get">
+                <label class="sr-only" for="nav-ai-email">Email address</label>
+                <input id="nav-ai-email" type="email" name="email" placeholder="you@example.com" autocomplete="email" />
+                <button type="submit" class="btn primary">Get the brief</button>
+                <p class="nav-ai__status newsletter-status muted" aria-live="polite"></p>
+              </form>
+            </div>
+          </div>
+        </div>
+        <a href="/portfolio.html" class="nav-link" data-i18n="nav.portfolios">Portfolios</a>
+        <a href="/universe.html" class="nav-link" data-i18n="nav.universe">Universe</a>
+      </div>
+      <div class="nav-actions">
+        <button id="langBtn" class="btn small">EN ▾</button>
+        <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+          <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+          <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+        </button>
+        <a id="membershipLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
+      </div>
+    </nav>
+  </header>
+
+  <main class="analyst-shell">
+    <section class="analyst-hero">
+      <div class="analyst-hero__header">
+        <span class="badge">Automation Control</span>
+        <h1 class="editor-title">Automated Equity Analyst Command Center</h1>
+        <p class="editor-intro">Coordinate staged AI coverage, watch spend in real time, and surface the latest analyst summaries. This dashboard reads directly from Supabase so operators can steer the sequential research robot with live data.</p>
+      </div>
+      <div class="analyst-hero__metrics">
+        <div class="hero-metric">
+          <span class="hero-metric__label">Universe processed</span>
+          <span class="hero-metric__value" id="metricTotalTickers">—</span>
+          <span class="hero-metric__hint">Stage&nbsp;1 complete: <strong id="metricStage1Complete">—</strong></span>
+        </div>
+        <div class="hero-metric">
+          <span class="hero-metric__label">Next queues</span>
+          <span class="hero-metric__value" id="metricStage2Queue">—</span>
+          <span class="hero-metric__hint">Deep dive queue: <strong id="metricStage3Queue">—</strong></span>
+        </div>
+        <div class="hero-metric">
+          <span class="hero-metric__label">Spend to date</span>
+          <span class="hero-metric__value" id="metricSpend">—</span>
+          <span class="hero-metric__hint">Tokens used: <strong id="metricTokens">—</strong></span>
+        </div>
+      </div>
+    </section>
+
+    <section class="analyst-grid">
+      <article class="panel">
+        <h2 class="panel__title">Run overview</h2>
+        <div class="form-stack">
+          <div class="form-row">
+            <label for="runSelect">Active run</label>
+            <div class="form-row--inline">
+              <select id="runSelect" class="run-select" aria-describedby="accessNotice">
+                <option value="">Select a run…</option>
+              </select>
+              <button type="button" class="action-btn" id="refreshRunsBtn">Refresh</button>
+              <a class="link-pill" href="/planner.html">Open planner →</a>
+            </div>
+          </div>
+          <p id="accessNotice" class="notice">Sign in with analyst access to load run telemetry.</p>
+          <p id="dashboardStatus" class="notice" hidden></p>
+        </div>
+        <div class="run-meta" aria-live="polite">
+          <div class="run-meta__item">
+            <span class="run-meta__label">Status</span>
+            <span class="run-meta__value" id="runStatus">—</span>
+          </div>
+          <div class="run-meta__item">
+            <span class="run-meta__label">Created</span>
+            <span class="run-meta__value" id="runCreated">—</span>
+          </div>
+          <div class="run-meta__item">
+            <span class="run-meta__label">Stage 1 pending</span>
+            <span class="run-meta__value" id="runStage1Pending">—</span>
+          </div>
+          <div class="run-meta__item">
+            <span class="run-meta__label">Failures</span>
+            <span class="run-meta__value" id="runFailures">—</span>
+          </div>
+          <div class="run-meta__item">
+            <span class="run-meta__label">Stop requested</span>
+            <span class="run-meta__value" id="runStopRequested">—</span>
+          </div>
+        </div>
+        <div id="runNotes" class="run-notes" aria-live="polite"></div>
+      </article>
+
+      <article class="panel">
+        <h2 class="panel__title">Funnel snapshot</h2>
+        <div class="metrics-grid">
+          <article class="metric-card">
+            <h3 class="metric-card__title">Pending Stage 1</h3>
+            <div class="metric-card__value" id="metricStage1Pending">—</div>
+            <p class="metric-card__hint">Awaiting triage</p>
+          </article>
+          <article class="metric-card">
+            <h3 class="metric-card__title">Stage 1 done</h3>
+            <div class="metric-card__value" id="metricStage1Done">—</div>
+            <p class="metric-card__hint">Ready for deeper review</p>
+          </article>
+          <article class="metric-card">
+            <h3 class="metric-card__title">Stage 2 done</h3>
+            <div class="metric-card__value" id="metricStage2Done">—</div>
+            <p class="metric-card__hint">Structured insights captured</p>
+          </article>
+          <article class="metric-card">
+            <h3 class="metric-card__title">Stage 3 done</h3>
+            <div class="metric-card__value" id="metricStage3Done">—</div>
+            <p class="metric-card__hint">Deep dives published</p>
+          </article>
+          <article class="metric-card">
+            <h3 class="metric-card__title">Failures</h3>
+            <div class="metric-card__value text-fail" id="metricFailures">—</div>
+            <p class="metric-card__hint">Monitor logs in Supabase</p>
+          </article>
+        </div>
+        <div class="cost-summary">
+          <h3 class="cost-summary__title">Cost breakdown</h3>
+          <ul class="cost-summary__list" id="costBreakdownList"></ul>
+        </div>
+      </article>
+    </section>
+
+    <section class="panel">
+      <div class="pipeline-card__header">
+        <h2 class="panel__title">Pipeline status</h2>
+        <span class="pipeline-card__meta" id="pipelineUpdated">—</span>
+      </div>
+      <div class="pipeline-grid">
+        <article class="pipeline-card" data-stage="1">
+          <div class="pipeline-card__header">
+            <h3 class="pipeline-card__title">Stage 1 · Triage</h3>
+            <span class="pipeline-card__meta" id="stage1Percent">0%</span>
+          </div>
+          <div class="progress-shell" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Stage 1 completion">
+            <div class="progress-shell__bar" id="stage1Progress"></div>
+          </div>
+          <div class="pipeline-card__stats">
+            <div>Completed: <span id="stage1CompletedCount">—</span></div>
+            <div>Pending: <span id="stage1PendingCount">—</span></div>
+            <div class="text-fail">Failed: <span id="stage1FailedCount">—</span></div>
+          </div>
+          <ul class="label-list" id="stage1LabelList"></ul>
+        </article>
+        <article class="pipeline-card" data-stage="2">
+          <div class="pipeline-card__header">
+            <h3 class="pipeline-card__title">Stage 2 · Structured insights</h3>
+            <span class="pipeline-card__meta" id="stage2Percent">0%</span>
+          </div>
+          <div class="progress-shell" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Stage 2 completion">
+            <div class="progress-shell__bar" id="stage2Progress"></div>
+          </div>
+          <div class="pipeline-card__stats">
+            <div>Completed: <span id="stage2CompletedCount">—</span></div>
+            <div>In queue: <span id="stage2QueueCount">—</span></div>
+            <div class="text-fail">Failures: <span id="stage2FailedCount">—</span></div>
+          </div>
+        </article>
+        <article class="pipeline-card" data-stage="3">
+          <div class="pipeline-card__header">
+            <h3 class="pipeline-card__title">Stage 3 · Deep dives</h3>
+            <span class="pipeline-card__meta" id="stage3Percent">0%</span>
+          </div>
+          <div class="progress-shell" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Stage 3 completion">
+            <div class="progress-shell__bar" id="stage3Progress"></div>
+          </div>
+          <div class="pipeline-card__stats">
+            <div>Completed: <span id="stage3CompletedCount">—</span></div>
+            <div>In queue: <span id="stage3QueueCount">—</span></div>
+            <div class="text-fail">Failures: <span id="stage3FailedCount">—</span></div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="panel">
+      <div class="pipeline-card__header">
+        <h2 class="panel__title">Latest activity</h2>
+        <span class="pipeline-card__meta">Most recent answers across all stages</span>
+      </div>
+      <table class="activity-table">
+        <thead>
+          <tr>
+            <th scope="col">Time</th>
+            <th scope="col">Ticker</th>
+            <th scope="col">Stage</th>
+            <th scope="col">Label</th>
+            <th scope="col">Summary</th>
+          </tr>
+        </thead>
+        <tbody id="activityBody"></tbody>
+      </table>
+      <p class="activity-empty" id="activityEmpty">Run Stage&nbsp;1 to see triage verdicts appear here in real time.</p>
+    </section>
+
+    <section class="panel analysis-export">
+      <h2 class="panel__title">Operational checklist</h2>
+      <div class="analysis-export__fields">
+        <article class="metric-card">
+          <h3 class="metric-card__title">Live today</h3>
+          <ul class="checklist">
+            <li>✅ <span>Stage&nbsp;1 batches stream into Supabase with cost logging.</span></li>
+            <li>✅ <span>Command center mirrors live counts, label mix, and spend.</span></li>
+            <li>✅ <span>Planner hand-off lets operators launch new runs instantly.</span></li>
+          </ul>
+        </article>
+        <article class="metric-card">
+          <h3 class="metric-card__title">Up next</h3>
+          <ul class="checklist">
+            <li>🔄 <span>Wire Stage&nbsp;2 worker + sector CMS inputs.</span></li>
+            <li>🔄 <span>Budget guardrails that auto-stop when spend caps hit.</span></li>
+            <li>🔄 <span>Optional RAG snippets to enrich Stage&nbsp;3 deep dives.</span></li>
+          </ul>
+        </article>
+      </div>
+      <div class="analysis-export__actions">
+        <a class="link-pill" href="/docs/equity-analyst-roadmap.md">Development roadmap →</a>
+        <a class="link-pill" href="/planner.html">Open cost planner →</a>
+      </div>
+      <p class="notice">Need to backfill tickers or prompt notes? Start in the planner, then monitor execution here as each stage progresses.</p>
+    </section>
+  </main>
+
+  <script type="module" src="/assets/equity-analyst.js"></script>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/planner.html
+++ b/planner.html
@@ -1,0 +1,955 @@
+<!doctype html>
+<html lang="en" data-lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>FutureFunds — Run Planner & Cost Estimator</title>
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      margin: 0;
+      background: var(--page,#f8fafc);
+      color: var(--text,#0f172a);
+    }
+    .planner-wrap {
+      max-width: 1040px;
+      margin: 0 auto;
+      padding: 32px 20px 80px;
+      display: grid;
+      gap: 28px;
+    }
+    .planner-headline {
+      display: grid;
+      gap: 8px;
+    }
+    .planner-headline h1 {
+      margin: 0;
+      font-size: clamp(1.8rem, 2.6vw, 2.4rem);
+      font-weight: 700;
+    }
+    .planner-headline p {
+      margin: 0;
+      max-width: 720px;
+      color: var(--muted,#475569);
+      font-size: 1rem;
+    }
+    .planner-grid {
+      display: grid;
+      gap: 18px;
+    }
+    @media (min-width: 940px) {
+      .planner-grid {
+        grid-template-columns: minmax(0, 0.62fr) minmax(0, 0.38fr);
+        align-items: start;
+      }
+    }
+    .panel {
+      border: 1px solid var(--border,#e2e8f0);
+      border-radius: 20px;
+      background: var(--panel,#fff);
+      box-shadow: 0 18px 36px rgba(15,23,42,.08);
+      padding: 22px;
+      display: grid;
+      gap: 20px;
+    }
+    .panel h2 {
+      margin: 0;
+      font-size: 1.35rem;
+      font-weight: 600;
+    }
+    .panel h3 {
+      margin: 0 0 6px;
+      font-size: 1.05rem;
+      font-weight: 600;
+    }
+    .panel p {
+      margin: 0;
+      color: var(--muted,#475569);
+      font-size: .92rem;
+    }
+    .planner-form {
+      display: grid;
+      gap: 20px;
+    }
+    .field {
+      display: grid;
+      gap: 8px;
+    }
+    .field label {
+      font-size: .9rem;
+      font-weight: 600;
+      color: var(--text,#0f172a);
+    }
+    .field input[type="number"],
+    .field input[type="text"],
+    .field select {
+      height: 42px;
+      padding: 0 12px;
+      border-radius: 12px;
+      border: 1px solid var(--border,#cbd5f5);
+      font: inherit;
+      background: rgba(255,255,255,.92);
+      transition: border-color .2s ease, box-shadow .2s ease;
+    }
+    .field input[type="number"]:focus,
+    .field input[type="text"]:focus,
+    .field select:focus {
+      outline: none;
+      border-color: var(--accent,#2563eb);
+      box-shadow: 0 0 0 3px rgba(37,99,235,.2);
+    }
+    .range-field {
+      display: grid;
+      gap: 6px;
+    }
+    .range-field label {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: .9rem;
+      font-weight: 600;
+    }
+    .range-field span {
+      color: var(--accent,#2563eb);
+      font-variant-numeric: tabular-nums;
+    }
+    input[type="range"] {
+      accent-color: var(--accent,#2563eb);
+    }
+    .stage-grid {
+      display: grid;
+      gap: 16px;
+    }
+    @media (min-width: 720px) {
+      .stage-grid {
+        grid-template-columns: repeat(3, minmax(0,1fr));
+      }
+    }
+    .stage-card {
+      border: 1px solid rgba(37,99,235,.25);
+      background: rgba(37,99,235,.05);
+      border-radius: 18px;
+      padding: 16px;
+      display: grid;
+      gap: 12px;
+    }
+    .stage-card header {
+      display: grid;
+      gap: 4px;
+    }
+    .stage-card header strong {
+      font-size: 1rem;
+      color: var(--accent,#2563eb);
+    }
+    .stage-card header span {
+      font-size: .8rem;
+      color: var(--muted,#475569);
+      letter-spacing: .02em;
+      text-transform: uppercase;
+    }
+    .stage-card .field {
+      gap: 6px;
+    }
+    .stage-card small {
+      color: var(--muted,#475569);
+      font-size: .78rem;
+    }
+    .planner-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+    .btn-primary {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      border: none;
+      border-radius: 999px;
+      padding: 12px 22px;
+      font-weight: 600;
+      font-size: .95rem;
+      cursor: pointer;
+      background: linear-gradient(120deg, #2563eb, #4338ca);
+      color: #fff;
+      transition: transform .18s ease, box-shadow .18s ease;
+    }
+    .btn-primary:active {
+      transform: translateY(1px);
+    }
+    .btn-secondary {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 999px;
+      padding: 10px 18px;
+      font-size: .9rem;
+      border: 1px solid var(--border,#cbd5f5);
+      background: rgba(241,245,249,.8);
+      color: var(--text,#0f172a);
+      cursor: pointer;
+    }
+    .btn-danger {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 999px;
+      padding: 10px 18px;
+      font-size: .9rem;
+      border: 1px solid rgba(220,38,38,.4);
+      background: rgba(248,113,113,.12);
+      color: #b91c1c;
+      cursor: pointer;
+    }
+    .btn-danger:disabled {
+      opacity: .55;
+      cursor: not-allowed;
+    }
+    .cost-output {
+      border: 1px solid rgba(15,23,42,.08);
+      border-radius: 18px;
+      padding: 18px;
+      background: rgba(15,23,42,.04);
+      display: grid;
+      gap: 12px;
+      font-size: .95rem;
+    }
+    .cost-output strong {
+      font-size: 1.1rem;
+    }
+    .cost-output ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 6px;
+    }
+    .cost-output li {
+      display: flex;
+      justify-content: space-between;
+      font-variant-numeric: tabular-nums;
+    }
+    .cost-output hr {
+      border: none;
+      border-top: 1px solid rgba(15,23,42,.1);
+      margin: 8px 0;
+    }
+    .status-log {
+      border: 1px solid var(--border,#e2e8f0);
+      border-radius: 14px;
+      padding: 16px;
+      background: rgba(255,255,255,.8);
+      display: grid;
+      gap: 10px;
+      font-size: .9rem;
+    }
+    .status-log pre {
+      margin: 0;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: "JetBrains Mono", "Fira Code", monospace;
+      background: rgba(15,23,42,.06);
+      padding: 12px;
+      border-radius: 12px;
+    }
+    a.inline-link {
+      color: var(--accent,#2563eb);
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .controller-panel {
+      border: 1px solid rgba(15,23,42,.1);
+      border-radius: 22px;
+      background: var(--panel,#fff);
+      box-shadow: 0 18px 32px rgba(15,23,42,.08);
+      padding: 24px;
+      display: grid;
+      gap: 22px;
+    }
+
+    .controller-panel header h2 {
+      margin: 0;
+      font-size: 1.4rem;
+      font-weight: 700;
+    }
+
+    .controller-panel header p {
+      margin: 4px 0 0;
+      color: var(--muted,#475569);
+      font-size: .94rem;
+      max-width: 680px;
+    }
+
+    .field-inline {
+      display: grid;
+      gap: 8px;
+    }
+
+    .field-inline label {
+      font-size: .9rem;
+      font-weight: 600;
+      color: var(--text,#0f172a);
+    }
+
+    .field-inline__controls {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    .field-inline__controls input[type="text"] {
+      flex: 1 1 280px;
+      min-width: 220px;
+      height: 42px;
+      padding: 0 12px;
+      border-radius: 12px;
+      border: 1px solid var(--border,#cbd5f5);
+      font: inherit;
+      background: rgba(255,255,255,.92);
+      transition: border-color .2s ease, box-shadow .2s ease;
+    }
+
+    .field-inline__controls input[type="text"]:focus {
+      outline: none;
+      border-color: var(--accent,#2563eb);
+      box-shadow: 0 0 0 3px rgba(37,99,235,.2);
+    }
+
+    .field-inline small {
+      font-size: .78rem;
+      color: var(--muted,#64748b);
+    }
+
+    .run-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      align-items: center;
+      margin: 10px 0 6px;
+    }
+
+    .run-meta__stat {
+      display: grid;
+      gap: 2px;
+      min-width: 140px;
+      padding: 10px 14px;
+      border-radius: 12px;
+      background: rgba(37,99,235,.08);
+    }
+
+    .run-meta__stat span {
+      font-size: .75rem;
+      letter-spacing: .05em;
+      text-transform: uppercase;
+      color: var(--muted,#475569);
+    }
+
+    .run-meta__stat strong {
+      font-size: .95rem;
+      color: var(--text,#0f172a);
+    }
+
+    .run-meta__actions {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    .run-meta__status {
+      color: var(--muted,#475569);
+      font-size: .8rem;
+    }
+
+    .run-meta__status strong {
+      color: var(--text,#0f172a);
+    }
+
+    .controller-metrics {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: repeat(auto-fit,minmax(140px,1fr));
+    }
+
+    .controller-metrics__item {
+      border: 1px solid rgba(15,23,42,.08);
+      border-radius: 16px;
+      padding: 14px 16px;
+      background: rgba(37,99,235,.05);
+      display: grid;
+      gap: 4px;
+    }
+
+    .controller-metrics__item dt {
+      font-size: .8rem;
+      font-weight: 600;
+      color: var(--muted,#475569);
+      text-transform: uppercase;
+      letter-spacing: .05em;
+    }
+
+    .controller-metrics__item dd {
+      margin: 0;
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: var(--text,#0f172a);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .controller-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+    .sector-notes {
+      border: 1px solid rgba(37,99,235,.18);
+      background: rgba(37,99,235,.05);
+      border-radius: 16px;
+      padding: 18px;
+      display: grid;
+      gap: 12px;
+    }
+    .sector-notes__header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+    }
+    .sector-notes__header h3 {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 600;
+    }
+    .sector-notes__manage {
+      font-size: .85rem;
+      font-weight: 600;
+      color: var(--accent,#2563eb);
+      text-decoration: none;
+      white-space: nowrap;
+    }
+    .sector-notes__manage:hover,
+    .sector-notes__manage:focus {
+      text-decoration: underline;
+    }
+    .sector-notes__empty {
+      margin: 0;
+      font-size: .85rem;
+      color: var(--muted,#475569);
+    }
+    .sector-notes__list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 10px;
+    }
+    .sector-notes__item {
+      display: grid;
+      gap: 4px;
+    }
+    .sector-notes__item strong {
+      font-size: .88rem;
+      color: var(--text,#0f172a);
+    }
+    .sector-notes__item p {
+      margin: 0;
+      font-size: .82rem;
+      color: var(--muted,#475569);
+    }
+
+    .controller-actions span[role="status"] {
+      font-size: .85rem;
+      color: var(--muted,#475569);
+    }
+
+    .recent-results h3 {
+      margin: 0 0 8px;
+      font-size: 1.05rem;
+      font-weight: 600;
+    }
+
+    .recent-table {
+      width: 100%;
+      border-collapse: collapse;
+      border-radius: 14px;
+      overflow: hidden;
+      border: 1px solid rgba(15,23,42,.08);
+      font-size: .88rem;
+    }
+
+    .recent-table thead {
+      background: rgba(15,23,42,.06);
+    }
+
+    .recent-table th,
+    .recent-table td {
+      padding: 10px 12px;
+      text-align: left;
+    }
+
+    .recent-table tbody tr:nth-child(odd) {
+      background: rgba(15,23,42,.02);
+    }
+
+    .recent-table td[data-label] {
+      font-weight: 600;
+    }
+
+    .recent-empty {
+      text-align: center;
+      color: var(--muted,#64748b);
+      padding: 16px;
+    }
+
+    .run-id-display {
+      font-size: .8rem;
+      color: var(--muted,#475569);
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .run-id-display code {
+      padding: 2px 6px;
+      border-radius: 8px;
+      background: rgba(15,23,42,.08);
+      font-family: "JetBrains Mono", "Fira Code", monospace;
+      font-size: .78rem;
+    }
+
+    @media (max-width: 720px) {
+      .controller-actions {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .controller-actions .btn-primary,
+      .controller-actions .btn-secondary {
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="/">
+      <img src="/images/logo.webp" alt="FutureFunds.ai logo" class="logo" />
+      <span>FutureFunds.ai</span>
+    </a>
+
+    <button class="nav-toggle" id="navToggle" type="button" aria-expanded="false" aria-controls="siteNav">
+      <span class="sr-only">Menu</span>
+      <span class="nav-toggle__bar"></span>
+    </button>
+
+    <nav class="nav" id="siteNav" aria-label="Primary navigation">
+      <div class="nav-links">
+        <div class="nav-item nav-item--team">
+          <a href="/team.html" class="nav-link" data-i18n="nav.team">Experiment</a>
+        </div>
+        <div class="nav-item nav-item--has-panel nav-item--tools">
+          <a href="/tools.html" class="nav-link" data-i18n="nav.investmentTools">Investment Tools</a>
+          <div class="nav-panel nav-panel--tools" role="group" aria-label="Investment tools">
+            <div class="nav-panel__header">
+              <span class="nav-panel__title">Featured tools</span>
+              <a class="nav-panel__cta" href="/tools.html">Explore tools →</a>
+            </div>
+            <div class="nav-panel__content nav-panel__content--tools">
+              <a class="nav-tool" href="/tool.html?id=ff-pms">
+                <span class="chip membership">Member</span>
+                <h4>Portfolio OS</h4>
+                <p>Run strategies end-to-end with sheets + AI copilots.</p>
+              </a>
+              <a class="nav-tool" href="/tool.html?id=stockalpha-journal">
+                <span class="chip free">Free</span>
+                <h4>StockAlpha Journal</h4>
+                <p>Track theses, catalysts, and behavioral loops.</p>
+              </a>
+              <a class="nav-tool" href="/tool.html?id=valuebot">
+                <span class="chip paid">Paid</span>
+                <h4>ValueBot Valuation</h4>
+                <p>Get sourced, step-by-step valuations on demand.</p>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div class="nav-item nav-item--has-panel nav-item--ai">
+          <a href="/ai-economy.html" class="nav-link" data-i18n="nav.aiEconomy">The AI Economy</a>
+          <div class="nav-panel nav-panel--ai" role="group" aria-label="AI economy preview">
+            <div class="nav-panel__header">
+              <span class="nav-panel__title">AI economy brief</span>
+              <a class="nav-panel__cta" href="/ai-economy.html">Dive in →</a>
+            </div>
+            <div class="nav-ai">
+              <p class="nav-ai__pitch">Weekly signals on how automation, capital, and policy collide. Built from filings, expert transcripts, and on-chain data.</p>
+              <form class="nav-ai__signup newsletter-form" action="/ai-economy.html#newsletter" method="get">
+                <label class="sr-only" for="nav-ai-email">Email address</label>
+                <input id="nav-ai-email" type="email" name="email" placeholder="you@example.com" autocomplete="email" />
+                <button type="submit" class="btn primary">Get the brief</button>
+                <p class="nav-ai__status newsletter-status muted" aria-live="polite"></p>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div class="nav-item nav-item--has-panel nav-item--blog">
+          <a href="/blog.html" class="nav-link" data-i18n="nav.blog">Blog</a>
+          <div class="nav-panel nav-panel--blog" role="group" aria-label="Latest articles">
+            <div class="nav-panel__header">
+              <span class="nav-panel__title">Latest updates</span>
+              <a class="nav-panel__cta" href="/blog.html">See all posts →</a>
+            </div>
+            <div class="nav-panel__content nav-panel__content--blog">
+              <a class="nav-article" href="/ai-article.html">
+                <span class="chip free">Free</span>
+                <h4>Can AI run your investment process?</h4>
+                <p>Dispatches from the FutureFunds lab.</p>
+              </a>
+              <a class="nav-article" href="/ai-economy.html">
+                <span class="chip free">Free</span>
+                <h4>The AI economy brief</h4>
+                <p>Macro signals we’re tracking.</p>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div class="nav-item nav-item--login">
+          <a href="/login.html" class="nav-link" data-i18n="nav.login">Member login</a>
+        </div>
+      </div>
+    </nav>
+  </header>
+
+  <main class="planner-wrap">
+    <header class="planner-headline">
+      <a class="inline-link" href="/equity_analyst.html">← Back to analyst blueprint</a>
+      <h1>Market Scan Planner & Cost Estimator</h1>
+      <p>Configure universe size, survival funnels, token budgets, and model choices before launching an automated run. Settings persist locally so you can iterate as you calibrate.</p>
+    </header>
+
+    <section class="planner-grid">
+      <article class="panel">
+        <div class="planner-form" id="plannerForm">
+          <div class="field">
+            <label for="universeInput">Universe size (tickers)</label>
+            <input type="number" id="universeInput" name="universe" min="1" value="40000" />
+          </div>
+
+          <div class="range-field">
+            <label for="stage2Slider">Survive to Stage 2 <span id="stage2Value">15%</span></label>
+            <input type="range" id="stage2Slider" min="0" max="100" value="15" />
+          </div>
+
+          <div class="range-field">
+            <label for="stage3Slider">Stage 3 share of Stage 2 <span id="stage3Value">12%</span></label>
+            <input type="range" id="stage3Slider" min="0" max="100" value="12" />
+          </div>
+
+          <div class="stage-grid">
+            <section class="stage-card" data-stage="1">
+              <header>
+                <span>Stage 1</span>
+                <strong>Triage</strong>
+              </header>
+              <div class="field">
+                <label for="modelStage1">Model</label>
+                <select id="modelStage1">
+                  <option value="4o-mini">GPT-4o-mini</option>
+                  <option value="5-mini">GPT-5 mini</option>
+                  <option value="5">GPT-5</option>
+                </select>
+              </div>
+              <div class="field">
+                <label for="stage1InputTokens">Tokens in (per stock)</label>
+                <input type="number" id="stage1InputTokens" min="0" step="100" value="3000" />
+              </div>
+              <div class="field">
+                <label for="stage1OutputTokens">Tokens out (per stock)</label>
+                <input type="number" id="stage1OutputTokens" min="0" step="100" value="600" />
+              </div>
+            </section>
+
+            <section class="stage-card" data-stage="2">
+              <header>
+                <span>Stage 2</span>
+                <strong>Medium depth</strong>
+              </header>
+              <div class="field">
+                <label for="modelStage2">Model</label>
+                <select id="modelStage2">
+                  <option value="5-mini" selected>GPT-5 mini</option>
+                  <option value="4o-mini">GPT-4o-mini</option>
+                  <option value="5">GPT-5</option>
+                </select>
+              </div>
+              <div class="field">
+                <label for="stage2InputTokens">Tokens in (per survivor)</label>
+                <input type="number" id="stage2InputTokens" min="0" step="100" value="30000" />
+              </div>
+              <div class="field">
+                <label for="stage2OutputTokens">Tokens out (per survivor)</label>
+                <input type="number" id="stage2OutputTokens" min="0" step="100" value="6000" />
+              </div>
+            </section>
+
+            <section class="stage-card" data-stage="3">
+              <header>
+                <span>Stage 3</span>
+                <strong>Deep dive</strong>
+              </header>
+              <div class="field">
+                <label for="modelStage3">Model</label>
+                <select id="modelStage3">
+                  <option value="5" selected>GPT-5</option>
+                  <option value="5-mini">GPT-5 mini</option>
+                </select>
+              </div>
+              <div class="field">
+                <label for="stage3InputTokens">Tokens in (per finalist)</label>
+                <input type="number" id="stage3InputTokens" min="0" step="100" value="100000" />
+              </div>
+              <div class="field">
+                <label for="stage3OutputTokens">Tokens out (per finalist)</label>
+                <input type="number" id="stage3OutputTokens" min="0" step="100" value="20000" />
+              </div>
+            </section>
+          </div>
+
+          <div class="planner-actions">
+            <button class="btn-primary" type="button" id="startRunBtn">Start automated run</button>
+            <button class="btn-secondary" type="button" id="resetDefaultsBtn">Reset defaults</button>
+            <span id="startRunStatus" role="status" aria-live="polite"></span>
+          </div>
+        </div>
+      </article>
+
+      <aside class="panel">
+        <div>
+          <h2>Estimated spend</h2>
+          <p>Numbers refresh automatically as you tweak the controls. Costs use the current public list prices per 1M tokens.</p>
+        </div>
+        <section class="cost-output" id="costOutput">
+          <ul>
+            <li><span>Stage 1</span><span>$0.00</span></li>
+            <li><span>Stage 2</span><span>$0.00</span></li>
+            <li><span>Stage 3</span><span>$0.00</span></li>
+          </ul>
+          <hr />
+          <div><strong>Total:</strong> <span id="totalCost">$0.00</span></div>
+          <p id="survivorSummary">—</p>
+        </section>
+        <section class="status-log">
+          <h3>Launch status</h3>
+          <pre id="statusLog">Ready when you are.</pre>
+        </section>
+      </aside>
+    </section>
+
+    <section class="panel controller-panel" id="stage1Panel">
+      <header>
+        <h2>Stage 1 — Triage processor</h2>
+        <p>Batch GPT-driven classifications to prune uninvestible names before spending on deeper research. Process small groups to stay within rate limits.</p>
+      </header>
+
+      <div class="field-inline">
+        <label for="runIdInput">Active run identifier</label>
+        <div class="field-inline__controls">
+          <input type="text" id="runIdInput" placeholder="Paste run UUID" autocomplete="off" />
+          <button type="button" class="btn-secondary" id="applyRunIdBtn">Apply</button>
+          <button type="button" class="btn-secondary" id="clearRunIdBtn">Clear</button>
+          <span class="run-id-display">Current:<code id="runIdDisplay">—</code></span>
+        </div>
+        <small>The latest run ID is stored automatically after you launch a new batch from this planner.</small>
+      </div>
+
+      <div class="run-meta" aria-live="polite">
+        <div class="run-meta__stat">
+          <span>Status</span>
+          <strong id="runStatusText">—</strong>
+        </div>
+        <div class="run-meta__stat">
+          <span>Stop requested</span>
+          <strong id="runStopText">—</strong>
+        </div>
+        <div class="run-meta__actions">
+          <button type="button" class="btn-danger" id="stopRunBtn">Request stop</button>
+          <button type="button" class="btn-secondary" id="resumeRunBtn">Resume run</button>
+        </div>
+      </div>
+      <div class="run-meta__status" id="runMetaStatus">Select a run to manage stop requests.</div>
+
+      <dl class="controller-metrics" aria-live="polite" aria-label="Stage one progress metrics">
+        <div class="controller-metrics__item">
+          <dt>Total queued</dt>
+          <dd id="stage1Total">—</dd>
+        </div>
+        <div class="controller-metrics__item">
+          <dt>Pending triage</dt>
+          <dd id="stage1Pending">—</dd>
+        </div>
+        <div class="controller-metrics__item">
+          <dt>Completed</dt>
+          <dd id="stage1Completed">—</dd>
+        </div>
+        <div class="controller-metrics__item">
+          <dt>Failed</dt>
+          <dd id="stage1Failed">—</dd>
+        </div>
+      </dl>
+
+      <div class="controller-actions">
+        <button class="btn-primary" type="button" id="processStage1Btn">Process Stage 1 batch</button>
+        <button class="btn-secondary" type="button" id="refreshStage1Btn">Refresh status</button>
+        <span id="stage1Status" role="status" aria-live="polite"></span>
+      </div>
+
+      <section class="recent-results" aria-live="polite">
+        <h3>Latest classifications</h3>
+        <table class="recent-table">
+          <thead>
+            <tr>
+              <th scope="col">Ticker</th>
+              <th scope="col">Label</th>
+              <th scope="col">Summary</th>
+              <th scope="col">Updated</th>
+            </tr>
+          </thead>
+          <tbody id="stage1RecentBody">
+            <tr>
+              <td colspan="4" class="recent-empty">No classifications yet.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+    <section class="panel controller-panel" id="stage2Panel">
+      <header>
+        <h2>Stage 2 — Thematic scoring</h2>
+        <p>Score promising names with GPT-5 mini and decide whether to advance them to the deep-dive queue. Track go-deep approvals as you go.</p>
+      </header>
+
+      <dl class="controller-metrics" aria-live="polite" aria-label="Stage two progress metrics">
+        <div class="controller-metrics__item">
+          <dt>Total survivors</dt>
+          <dd id="stage2Total">—</dd>
+        </div>
+        <div class="controller-metrics__item">
+          <dt>Pending scoring</dt>
+          <dd id="stage2Pending">—</dd>
+        </div>
+        <div class="controller-metrics__item">
+          <dt>Completed</dt>
+          <dd id="stage2Completed">—</dd>
+        </div>
+        <div class="controller-metrics__item">
+          <dt>Go-deep approvals</dt>
+          <dd id="stage2GoDeep">—</dd>
+        </div>
+        <div class="controller-metrics__item">
+          <dt>Failed</dt>
+          <dd id="stage2Failed">—</dd>
+        </div>
+      </dl>
+
+      <section class="sector-notes" aria-live="polite">
+        <div class="sector-notes__header">
+          <h3>Sector guidance in play</h3>
+          <a class="sector-notes__manage" href="/sectors.html">Manage sectors →</a>
+        </div>
+        <p id="sectorNotesEmpty" class="sector-notes__empty">No sector notes yet. Add heuristics to customise Stage 2 scoring.</p>
+        <ul id="sectorNotesList" class="sector-notes__list" hidden></ul>
+      </section>
+
+      <div class="controller-actions">
+        <button class="btn-primary" type="button" id="processStage2Btn">Process Stage 2 batch</button>
+        <button class="btn-secondary" type="button" id="refreshStage2Btn">Refresh status</button>
+        <span id="stage2Status" role="status" aria-live="polite"></span>
+      </div>
+
+    <section class="recent-results" aria-live="polite">
+      <h3>Latest Stage 2 insights</h3>
+      <table class="recent-table">
+        <thead>
+          <tr>
+            <th scope="col">Ticker</th>
+            <th scope="col">Go deep?</th>
+            <th scope="col">Summary</th>
+            <th scope="col">Updated</th>
+          </tr>
+        </thead>
+        <tbody id="stage2RecentBody">
+          <tr>
+            <td colspan="4" class="recent-empty">No Stage 2 calls yet.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </section>
+
+  <section class="panel controller-panel" id="stage3Panel">
+    <header>
+      <h2>Stage 3 — Deep-dive reports</h2>
+      <p>Generate research-grade narratives with GPT-5 for the finalists flagged by Stage 2. Monitor completions and rerun batches as fresh data arrives.</p>
+    </header>
+
+    <dl class="controller-metrics" aria-live="polite" aria-label="Stage three progress metrics">
+      <div class="controller-metrics__item">
+        <dt>Finalists</dt>
+        <dd id="stage3Finalists">—</dd>
+      </div>
+      <div class="controller-metrics__item">
+        <dt>Pending deep dives</dt>
+        <dd id="stage3Pending">—</dd>
+      </div>
+      <div class="controller-metrics__item">
+        <dt>Completed reports</dt>
+        <dd id="stage3Completed">—</dd>
+      </div>
+      <div class="controller-metrics__item">
+        <dt>Deep-dive spend</dt>
+        <dd id="stage3Spend">—</dd>
+      </div>
+      <div class="controller-metrics__item">
+        <dt>Failed</dt>
+        <dd id="stage3Failed">—</dd>
+      </div>
+    </dl>
+
+    <div class="controller-actions">
+      <button class="btn-primary" type="button" id="processStage3Btn">Process Stage 3 batch</button>
+      <button class="btn-secondary" type="button" id="refreshStage3Btn">Refresh status</button>
+      <span id="stage3Status" role="status" aria-live="polite"></span>
+    </div>
+
+    <section class="recent-results" aria-live="polite">
+      <h3>Latest deep-dive reports</h3>
+      <table class="recent-table">
+        <thead>
+          <tr>
+            <th scope="col">Ticker</th>
+            <th scope="col">Verdict</th>
+            <th scope="col">Thesis highlight</th>
+            <th scope="col">Updated</th>
+          </tr>
+        </thead>
+        <tbody id="stage3RecentBody">
+          <tr>
+            <td colspan="4" class="recent-empty">No deep dives yet.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </section>
+</main>
+
+  <script type="module" src="/assets/planner.js"></script>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/sectors.html
+++ b/sectors.html
@@ -1,0 +1,351 @@
+<!doctype html>
+<html lang="en" data-lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>FutureFunds — Sector Prompt Library</title>
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      margin: 0;
+      background: var(--page,#f8fafc);
+      color: var(--text,#0f172a);
+    }
+    main {
+      max-width: 1040px;
+      margin: 0 auto;
+      padding: 32px 20px 96px;
+      display: grid;
+      gap: 28px;
+    }
+    .hero {
+      display: grid;
+      gap: 10px;
+    }
+    .hero h1 {
+      margin: 0;
+      font-size: clamp(1.85rem, 3vw, 2.6rem);
+      font-weight: 700;
+    }
+    .hero p {
+      margin: 0;
+      max-width: 720px;
+      font-size: 1rem;
+      color: var(--muted,#475569);
+    }
+    .grid {
+      display: grid;
+      gap: 22px;
+    }
+    @media (min-width: 920px) {
+      .grid-two {
+        grid-template-columns: minmax(0,0.46fr) minmax(0,0.54fr);
+        align-items: start;
+      }
+    }
+    .panel {
+      border: 1px solid var(--border,#e2e8f0);
+      border-radius: 20px;
+      background: var(--panel,#fff);
+      box-shadow: 0 18px 36px rgba(15,23,42,.08);
+      padding: 24px;
+      display: grid;
+      gap: 18px;
+    }
+    .panel h2 {
+      margin: 0;
+      font-size: 1.32rem;
+      font-weight: 600;
+    }
+    .panel p {
+      margin: 0;
+      font-size: .95rem;
+      color: var(--muted,#475569);
+    }
+    .field {
+      display: grid;
+      gap: 6px;
+    }
+    .field label {
+      font-size: .85rem;
+      font-weight: 600;
+      color: var(--text,#0f172a);
+    }
+    input[type="text"],
+    textarea {
+      font: inherit;
+      border: 1px solid var(--border,#cbd5f5);
+      border-radius: 12px;
+      padding: 10px 12px;
+      background: rgba(255,255,255,.96);
+      transition: border-color .18s ease, box-shadow .18s ease;
+    }
+    textarea {
+      min-height: 160px;
+      resize: vertical;
+      line-height: 1.5;
+    }
+    input[type="text"]:focus,
+    textarea:focus {
+      outline: none;
+      border-color: var(--accent,#2563eb);
+      box-shadow: 0 0 0 3px rgba(37,99,235,.2);
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+    button {
+      border: none;
+      border-radius: 999px;
+      padding: 10px 20px;
+      font-weight: 600;
+      cursor: pointer;
+      font-size: .9rem;
+    }
+    .btn-primary {
+      background: linear-gradient(120deg, #2563eb, #4338ca);
+      color: #fff;
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      justify-content: center;
+    }
+    .btn-secondary {
+      background: rgba(226,232,240,.8);
+      color: var(--text,#0f172a);
+      border: 1px solid rgba(148,163,184,.6);
+    }
+    .status {
+      font-size: .82rem;
+      color: var(--muted,#475569);
+    }
+    .prompt-list {
+      display: grid;
+      gap: 18px;
+    }
+    .prompt-card {
+      border: 1px solid rgba(37,99,235,.22);
+      border-radius: 18px;
+      padding: 18px;
+      background: rgba(37,99,235,.05);
+      display: grid;
+      gap: 14px;
+    }
+    .prompt-card header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+    }
+    .prompt-card h3 {
+      margin: 0;
+      font-size: 1.05rem;
+      font-weight: 600;
+      color: var(--accent,#2563eb);
+    }
+    .prompt-card .meta {
+      font-size: .78rem;
+      color: var(--muted,#475569);
+    }
+    .prompt-card textarea {
+      min-height: 120px;
+    }
+    .prompt-card footer {
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+    }
+    .prompt-card footer .status {
+      font-size: .78rem;
+    }
+    .empty-state {
+      text-align: center;
+      padding: 36px 18px;
+      border: 1px dashed rgba(148,163,184,.4);
+      border-radius: 16px;
+      color: var(--muted,#475569);
+      font-size: .95rem;
+    }
+    .access-warning {
+      border: 1px solid rgba(248,113,113,.4);
+      background: rgba(248,113,113,.08);
+      color: #b91c1c;
+      padding: 18px;
+      border-radius: 16px;
+      font-weight: 600;
+    }
+    .search-bar {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    .search-bar input[type="search"] {
+      flex: 1;
+      min-width: 180px;
+      font: inherit;
+      border: 1px solid var(--border,#cbd5f5);
+      border-radius: 12px;
+      padding: 9px 12px;
+      background: rgba(255,255,255,.96);
+    }
+    .search-bar input[type="search"]:focus {
+      outline: none;
+      border-color: var(--accent,#2563eb);
+      box-shadow: 0 0 0 3px rgba(37,99,235,.2);
+    }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="/">
+      <img src="/images/logo.webp" alt="FutureFunds.ai logo" class="logo" />
+      <span>FutureFunds.ai</span>
+    </a>
+
+    <button class="nav-toggle" id="navToggle" type="button" aria-expanded="false" aria-controls="siteNav">
+      <span class="sr-only">Menu</span>
+      <span class="nav-toggle__bar"></span>
+    </button>
+
+    <nav class="nav" id="siteNav" aria-label="Primary navigation">
+      <div class="nav-links">
+        <div class="nav-item nav-item--team">
+          <a href="/team.html" class="nav-link" data-i18n="nav.team">Experiment</a>
+        </div>
+        <div class="nav-item nav-item--has-panel nav-item--tools">
+          <a href="/tools.html" class="nav-link" data-i18n="nav.investmentTools">Investment Tools</a>
+          <div class="nav-panel nav-panel--tools" role="group" aria-label="Investment tools">
+            <div class="nav-panel__header">
+              <span class="nav-panel__title">Featured tools</span>
+              <a class="nav-panel__cta" href="/tools.html">Explore tools →</a>
+            </div>
+            <div class="nav-panel__content nav-panel__content--tools">
+              <a class="nav-tool" href="/tool.html?id=ff-pms">
+                <span class="chip membership">Member</span>
+                <h4>Portfolio OS</h4>
+                <p>Run strategies end-to-end with sheets + AI copilots.</p>
+              </a>
+              <a class="nav-tool" href="/tool.html?id=stockalpha-journal">
+                <span class="chip free">Free</span>
+                <h4>StockAlpha Journal</h4>
+                <p>Track theses, catalysts, and behavioral loops.</p>
+              </a>
+              <a class="nav-tool" href="/tool.html?id=valuebot">
+                <span class="chip paid">Paid</span>
+                <h4>ValueBot Valuation</h4>
+                <p>Get sourced, step-by-step valuations on demand.</p>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div class="nav-item nav-item--has-panel nav-item--ai">
+          <a href="/ai-economy.html" class="nav-link" data-i18n="nav.aiEconomy">The AI Economy</a>
+          <div class="nav-panel nav-panel--ai" role="group" aria-label="AI economy preview">
+            <div class="nav-panel__header">
+              <span class="nav-panel__title">AI economy brief</span>
+              <a class="nav-panel__cta" href="/ai-economy.html">Dive in →</a>
+            </div>
+            <div class="nav-ai">
+              <p class="nav-ai__pitch">Weekly signals on how automation, capital, and policy collide. Built from filings, expert transcripts, and on-chain data.</p>
+              <form class="nav-ai__signup newsletter-form" action="/ai-economy.html#newsletter" method="get">
+                <label class="sr-only" for="nav-ai-email">Email address</label>
+                <input id="nav-ai-email" type="email" name="email" placeholder="you@example.com" autocomplete="email" />
+                <button type="submit" class="btn primary">Get the brief</button>
+                <p class="nav-ai__status newsletter-status muted" aria-live="polite"></p>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div class="nav-item nav-item--has-panel nav-item--blog">
+          <a href="/blog.html" class="nav-link" data-i18n="nav.blog">Blog</a>
+          <div class="nav-panel nav-panel--blog" role="group" aria-label="Latest articles">
+            <div class="nav-panel__header">
+              <span class="nav-panel__title">Latest updates</span>
+              <a class="nav-panel__cta" href="/blog.html">See all posts →</a>
+            </div>
+            <div class="nav-panel__content nav-panel__content--blog">
+              <a class="nav-article" href="/ai-article.html">
+                <span class="chip free">Free</span>
+                <h4>Can AI run your investment process?</h4>
+                <p>Dispatches from the FutureFunds lab.</p>
+              </a>
+              <a class="nav-article" href="/ai-economy.html">
+                <span class="chip membership">Member</span>
+                <h4>AI & macro weekly brief</h4>
+                <p>Macro playbooks, automation vectors, regime maps.</p>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="nav-cta">
+        <a class="btn secondary" href="/login.html">Sign in</a>
+      </div>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero">
+      <p class="chip" style="width:fit-content;background:rgba(37,99,235,.12);color:#1d4ed8;padding:6px 12px;border-radius:999px;font-weight:600;">Analyst ops</p>
+      <h1>Sector prompt library</h1>
+      <p>Capture repeatable heuristics for each sector so Stage&nbsp;2 scoring can emphasise the correct playbook. Notes auto-sync with the planner and Stage&nbsp;2 worker.</p>
+    </section>
+
+    <section class="grid grid-two">
+      <article class="panel" aria-labelledby="createPromptTitle">
+        <div>
+          <h2 id="createPromptTitle">Add or update a sector</h2>
+          <p>Start with the sectors you cover most often. Notes should focus on the key quality, risk, and timing heuristics you want the analyst agents to respect.</p>
+        </div>
+        <form id="createForm" class="grid" autocomplete="off">
+          <div class="field">
+            <label for="sectorInput">Sector name</label>
+            <input id="sectorInput" name="sector" type="text" list="sectorSuggestions" placeholder="e.g. Technology" required />
+            <datalist id="sectorSuggestions"></datalist>
+          </div>
+          <div class="field">
+            <label for="notesInput">Guidance for Stage 2</label>
+            <textarea id="notesInput" name="notes" placeholder="Outline the heuristics, red flags, and what qualifies for a deep dive…" required></textarea>
+          </div>
+          <div class="actions">
+            <button type="submit" class="btn-primary" id="createBtn">Save sector guidance</button>
+            <span class="status" id="createStatus" aria-live="polite">Draft</span>
+          </div>
+        </form>
+      </article>
+
+      <article class="panel" aria-labelledby="searchTitle">
+        <div>
+          <h2 id="searchTitle">Browse existing guidance</h2>
+          <p>Search, edit, or remove sector prompts. Changes save instantly for all operators.</p>
+        </div>
+        <div class="search-bar">
+          <input id="searchInput" type="search" placeholder="Search sectors…" aria-label="Search sectors" />
+          <button type="button" class="btn-secondary" id="refreshBtn">Refresh</button>
+        </div>
+        <div id="listContainer">
+          <div class="empty-state" id="emptyState">No sector guidance saved yet. Add your first notes to power Stage&nbsp;2 insights.</div>
+          <div class="prompt-list" id="promptList" hidden></div>
+        </div>
+      </article>
+    </section>
+
+    <section id="accessNotice" class="access-warning" hidden>
+      Admin access required. Sign in with an administrator account to manage sector guidance.
+    </section>
+  </main>
+
+  <script src="/assets/site-nav.js" defer></script>
+  <script type="module" src="/assets/sectors.js"></script>
+</body>
+</html>

--- a/sql/001_core.sql
+++ b/sql/001_core.sql
@@ -1,0 +1,69 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.tickers (
+  ticker text primary key,
+  name text,
+  exchange text,
+  country text,
+  sector text,
+  industry text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table if not exists public.sector_prompts (
+  sector text primary key,
+  notes text
+);
+
+create table if not exists public.runs (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz default now(),
+  status text check (status in ('queued','running','done','failed')) default 'queued',
+  notes text,
+  stop_requested boolean default false
+);
+
+create table if not exists public.run_items (
+  run_id uuid references public.runs(id) on delete cascade,
+  ticker text references public.tickers(ticker) on delete cascade,
+  stage int default 0,
+  label text,
+  stage2_go_deep boolean,
+  status text check (status in ('pending','ok','skipped','failed')) default 'pending',
+  spend_est_usd numeric(12,4) default 0,
+  updated_at timestamptz default now(),
+  primary key (run_id, ticker)
+);
+
+create table if not exists public.answers (
+  id bigserial primary key,
+  run_id uuid references public.runs(id) on delete cascade,
+  ticker text references public.tickers(ticker) on delete cascade,
+  stage int,
+  question_group text,
+  answer_json jsonb,
+  answer_text text,
+  tokens_in int,
+  tokens_out int,
+  cost_usd numeric(12,4),
+  created_at timestamptz default now()
+);
+
+create table if not exists public.cost_ledger (
+  id bigserial primary key,
+  run_id uuid references public.runs(id),
+  stage int,
+  model text,
+  tokens_in bigint,
+  tokens_out bigint,
+  cost_usd numeric(12,4),
+  created_at timestamptz default now()
+);
+
+create table if not exists public.doc_chunks (
+  id bigserial primary key,
+  ticker text references public.tickers(ticker) on delete cascade,
+  source text,
+  chunk text
+);

--- a/sql/002_seed.sql
+++ b/sql/002_seed.sql
@@ -1,0 +1,11 @@
+insert into public.tickers (ticker, name, exchange, country, sector, industry) values
+('AAPL','Apple Inc.','NASDAQ','US','Technology','Consumer Electronics'),
+('MSFT','Microsoft Corp.','NASDAQ','US','Technology','Software'),
+('JPM','JPMorgan Chase & Co.','NYSE','US','Financials','Banks'),
+('BRK.B','Berkshire Hathaway Inc.','NYSE','US','Financials','Insurance'),
+('AMZN','Amazon.com, Inc.','NASDAQ','US','Consumer Discretionary','Internet & Direct Marketing'),
+('TSLA','Tesla, Inc.','NASDAQ','US','Consumer Discretionary','Automobiles'),
+('NVDA','NVIDIA Corporation','NASDAQ','US','Technology','Semiconductors'),
+('UNH','UnitedHealth Group Inc.','NYSE','US','Health Care','Managed Health Care'),
+('BABA','Alibaba Group','NYSE','CN','Consumer Discretionary','Internet Retail'),
+('SHEL','Shell PLC','LSE','UK','Energy','Oil & Gas');

--- a/sql/003_dashboard_helpers.sql
+++ b/sql/003_dashboard_helpers.sql
@@ -1,0 +1,152 @@
+-- Helper routines for the analyst command center dashboard
+-- These functions are idempotent (create or replace) so they can be applied safely.
+
+create or replace function public.run_stage_status_counts(p_run_id uuid)
+returns table(stage int, status text, total bigint)
+language sql
+stable
+as $$
+  select coalesce(stage, 0) as stage,
+         status,
+         count(*)::bigint as total
+    from public.run_items
+   where run_id = p_run_id
+   group by coalesce(stage, 0), status
+   order by coalesce(stage, 0), status;
+$$;
+
+create or replace function public.run_stage1_labels(p_run_id uuid)
+returns table(label text, total bigint)
+language sql
+stable
+as $$
+  select coalesce(nullif(label, ''), 'Unlabeled') as label,
+         count(*)::bigint as total
+    from public.run_items
+   where run_id = p_run_id
+     and stage >= 1
+     and status = 'ok'
+   group by coalesce(nullif(label, ''), 'Unlabeled')
+   order by total desc, label asc;
+$$;
+
+create or replace function public.run_cost_breakdown(p_run_id uuid)
+returns table(stage int, model text, tokens_in bigint, tokens_out bigint, cost_usd numeric)
+language sql
+stable
+as $$
+  select stage,
+         model,
+         coalesce(sum(tokens_in), 0)::bigint      as tokens_in,
+         coalesce(sum(tokens_out), 0)::bigint     as tokens_out,
+         coalesce(sum(cost_usd), 0)::numeric(12,4) as cost_usd
+    from public.cost_ledger
+   where run_id = p_run_id
+   group by stage, model
+   order by stage, model;
+$$;
+
+create or replace function public.run_cost_summary(p_run_id uuid)
+returns table(total_cost numeric, total_tokens_in bigint, total_tokens_out bigint)
+language sql
+stable
+as $$
+  select coalesce(sum(cost_usd), 0)::numeric(12,4) as total_cost,
+         coalesce(sum(tokens_in), 0)::bigint       as total_tokens_in,
+         coalesce(sum(tokens_out), 0)::bigint      as total_tokens_out
+    from public.cost_ledger
+   where run_id = p_run_id;
+$$;
+
+create or replace function public.run_latest_activity(p_run_id uuid, p_limit integer default 10)
+returns table(ticker text, stage int, question_group text, created_at timestamptz, label text, summary text)
+language sql
+stable
+as $$
+  select a.ticker,
+         coalesce(a.stage, 0) as stage,
+         coalesce(a.question_group, '—') as question_group,
+         a.created_at,
+         ri.label,
+         coalesce(
+           a.answer_json ->> 'summary',
+           case
+             when jsonb_typeof(a.answer_json -> 'reasons') = 'array' then
+               array_to_string(array(select jsonb_array_elements_text(a.answer_json -> 'reasons') limit 1), '; ')
+             else null
+           end,
+           nullif(trim(both '"' from left(a.answer_json::text, 200)), ''),
+           left(coalesce(a.answer_text, ''), 200)
+         ) as summary
+    from public.answers a
+    left join public.run_items ri
+      on ri.run_id = a.run_id
+     and ri.ticker = a.ticker
+   where a.run_id = p_run_id
+   order by a.created_at desc
+   limit greatest(p_limit, 1);
+$$;
+
+create or replace function public.run_stage2_summary(p_run_id uuid)
+returns table(
+  total_survivors bigint,
+  pending bigint,
+  completed bigint,
+  failed bigint,
+  go_deep bigint
+)
+language sql
+stable
+as $$
+  with survivors as (
+    select run_id,
+           ticker,
+           stage,
+           status,
+           lower(coalesce(label, '')) as normalized_label,
+           coalesce(stage2_go_deep, false) as stage2_go_deep
+      from public.run_items
+     where run_id = p_run_id
+       and status <> 'skipped'
+  ),
+  filtered as (
+    select *
+      from survivors
+     where normalized_label in ('consider', 'borderline')
+  )
+  select count(*)::bigint as total_survivors,
+         count(*) filter (where stage = 1 and status = 'ok')::bigint as pending,
+         count(*) filter (where stage >= 2 and status = 'ok')::bigint as completed,
+         count(*) filter (where stage >= 2 and status = 'failed')::bigint as failed,
+         count(*) filter (where stage >= 2 and status = 'ok' and stage2_go_deep)::bigint as go_deep
+    from filtered;
+$$;
+
+create or replace function public.run_stage3_summary(p_run_id uuid)
+returns table(
+  total_finalists bigint,
+  pending bigint,
+  completed bigint,
+  failed bigint
+)
+language sql
+stable
+as $$
+  with finalists as (
+    select run_id,
+           ticker,
+           stage,
+           status,
+           coalesce(stage2_go_deep, false) as stage2_go_deep
+      from public.run_items
+     where run_id = p_run_id
+       and status <> 'skipped'
+       and coalesce(stage2_go_deep, false)
+  )
+  select count(*)::bigint as total_finalists,
+         count(*) filter (where stage < 3 and status = 'ok')::bigint as pending,
+         count(*) filter (where stage >= 3 and status = 'ok')::bigint as completed,
+         count(*) filter (where stage >= 3 and status = 'failed')::bigint as failed
+    from finalists;
+$$;
+

--- a/sql/004_stage2_patch.sql
+++ b/sql/004_stage2_patch.sql
@@ -1,0 +1,8 @@
+-- Stage 2 rollout adjustments
+-- Safe to run multiple times; adds the go-deep column and ensures helper function is up to date.
+
+alter table if exists public.run_items
+  add column if not exists stage2_go_deep boolean;
+
+-- Ensure the Stage 2 summary helper exists with the latest definition.
+\i ./003_dashboard_helpers.sql

--- a/sql/005_universe_snapshot.sql
+++ b/sql/005_universe_snapshot.sql
@@ -1,0 +1,291 @@
+-- Universe snapshot helpers for run exploration and ticker drilldowns
+-- These routines can be re-run safely (create or replace).
+
+create or replace function public.run_universe_rows(
+  p_run_id uuid,
+  p_search text default null,
+  p_label text default null,
+  p_stage int default null,
+  p_sector text default null,
+  p_go_deep boolean default null,
+  p_status text default null,
+  p_limit integer default 100,
+  p_offset integer default 0
+)
+returns table(
+  run_id uuid,
+  ticker text,
+  name text,
+  exchange text,
+  country text,
+  sector text,
+  industry text,
+  stage int,
+  status text,
+  label text,
+  stage2_go_deep boolean,
+  spend_usd numeric,
+  updated_at timestamptz,
+  stage1 jsonb,
+  stage2 jsonb,
+  stage3 jsonb,
+  stage3_summary text,
+  total_count bigint
+)
+language sql
+stable
+as $$
+  with base as (
+    select
+      ri.run_id,
+      ri.ticker,
+      t.name,
+      t.exchange,
+      t.country,
+      t.sector,
+      t.industry,
+      coalesce(ri.stage, 0) as stage,
+      ri.status,
+      coalesce(ri.label, '') as label,
+      coalesce(ri.stage2_go_deep, false) as stage2_go_deep,
+      coalesce(ri.spend_est_usd, 0)::numeric(12,4) as spend_usd,
+      ri.updated_at
+    from public.run_items ri
+    join public.tickers t on t.ticker = ri.ticker
+    where ri.run_id = p_run_id
+      and (p_status is null or ri.status = p_status)
+      and (p_stage is null or coalesce(ri.stage, 0) = p_stage)
+      and (p_label is null or lower(coalesce(ri.label, '')) = lower(p_label))
+      and (p_go_deep is null or coalesce(ri.stage2_go_deep, false) = p_go_deep)
+      and (p_sector is null or lower(coalesce(t.sector, '')) = lower(p_sector))
+      and (
+        p_search is null
+        or p_search = ''
+        or t.ticker ilike '%' || p_search || '%'
+        or t.name ilike '%' || p_search || '%'
+      )
+  )
+  select
+    base.run_id,
+    base.ticker,
+    base.name,
+    base.exchange,
+    base.country,
+    base.sector,
+    base.industry,
+    base.stage,
+    base.status,
+    base.label,
+    base.stage2_go_deep,
+    base.spend_usd,
+    base.updated_at,
+    stage1.answer_json as stage1,
+    stage2.answer_json as stage2,
+    stage3_summary.answer_json as stage3,
+    coalesce(stage3_summary.answer_text, stage3_summary.answer_json ->> 'summary') as stage3_summary,
+    count(*) over () as total_count
+  from base
+  left join lateral (
+    select answer_json
+      from public.answers
+     where run_id = base.run_id
+       and ticker = base.ticker
+       and stage = 1
+     order by created_at desc
+     limit 1
+  ) stage1 on true
+  left join lateral (
+    select answer_json
+      from public.answers
+     where run_id = base.run_id
+       and ticker = base.ticker
+       and stage = 2
+     order by created_at desc
+     limit 1
+  ) stage2 on true
+  left join lateral (
+    select answer_json, answer_text
+      from public.answers
+     where run_id = base.run_id
+       and ticker = base.ticker
+       and stage = 3
+       and coalesce(question_group, '') = 'summary'
+     order by created_at desc
+     limit 1
+  ) stage3_summary on true
+  order by base.stage desc, base.status asc, base.label asc, base.ticker
+  limit least(greatest(coalesce(p_limit, 100), 1), 500)
+  offset greatest(coalesce(p_offset, 0), 0);
+$$;
+
+create or replace function public.run_universe_facets(
+  p_run_id uuid,
+  p_search text default null,
+  p_label text default null,
+  p_stage int default null,
+  p_sector text default null,
+  p_go_deep boolean default null,
+  p_status text default null
+)
+returns table(metric text, bucket text, total bigint)
+language sql
+stable
+as $$
+  with filtered as (
+    select
+      ri.run_id,
+      ri.ticker,
+      coalesce(ri.stage, 0) as stage,
+      coalesce(ri.label, '') as label,
+      ri.status,
+      coalesce(ri.stage2_go_deep, false) as stage2_go_deep,
+      t.sector
+    from public.run_items ri
+    join public.tickers t on t.ticker = ri.ticker
+    where ri.run_id = p_run_id
+      and (p_status is null or ri.status = p_status)
+      and (p_stage is null or coalesce(ri.stage, 0) = p_stage)
+      and (p_label is null or lower(coalesce(ri.label, '')) = lower(p_label))
+      and (p_go_deep is null or coalesce(ri.stage2_go_deep, false) = p_go_deep)
+      and (p_sector is null or lower(coalesce(t.sector, '')) = lower(p_sector))
+      and (
+        p_search is null
+        or p_search = ''
+        or t.ticker ilike '%' || p_search || '%'
+        or t.name ilike '%' || p_search || '%'
+      )
+  )
+  select 'stage' as metric, stage::text as bucket, count(*)::bigint as total
+    from filtered
+   group by stage
+  union all
+  select 'label' as metric, nullif(label, '') as bucket, count(*)::bigint as total
+    from filtered
+   group by nullif(label, '')
+  union all
+  select 'status' as metric, status as bucket, count(*)::bigint as total
+    from filtered
+   group by status
+  union all
+  select 'sector' as metric, nullif(sector, '') as bucket, count(*)::bigint as total
+    from filtered
+   group by nullif(sector, '')
+  union all
+  select 'go_deep' as metric, case when stage2_go_deep then 'true' else 'false' end as bucket, count(*)::bigint as total
+    from filtered
+   group by stage2_go_deep;
+$$;
+
+create or replace function public.run_ticker_details(
+  p_run_id uuid,
+  p_ticker text
+)
+returns table(
+  run_id uuid,
+  ticker text,
+  name text,
+  exchange text,
+  country text,
+  sector text,
+  industry text,
+  stage int,
+  status text,
+  label text,
+  stage2_go_deep boolean,
+  spend_usd numeric,
+  updated_at timestamptz,
+  stage1 jsonb,
+  stage2 jsonb,
+  stage3_summary jsonb,
+  stage3_text text,
+  stage3_groups jsonb
+)
+language sql
+stable
+as $$
+  with base as (
+    select
+      ri.run_id,
+      ri.ticker,
+      t.name,
+      t.exchange,
+      t.country,
+      t.sector,
+      t.industry,
+      coalesce(ri.stage, 0) as stage,
+      ri.status,
+      coalesce(ri.label, '') as label,
+      coalesce(ri.stage2_go_deep, false) as stage2_go_deep,
+      coalesce(ri.spend_est_usd, 0)::numeric(12,4) as spend_usd,
+      ri.updated_at
+    from public.run_items ri
+    join public.tickers t on t.ticker = ri.ticker
+    where ri.run_id = p_run_id
+      and ri.ticker = p_ticker
+    limit 1
+  ),
+  stage1 as (
+    select answer_json
+      from public.answers
+     where run_id = p_run_id
+       and ticker = p_ticker
+       and stage = 1
+     order by created_at desc
+     limit 1
+  ),
+  stage2 as (
+    select answer_json
+      from public.answers
+     where run_id = p_run_id
+       and ticker = p_ticker
+       and stage = 2
+     order by created_at desc
+     limit 1
+  ),
+  stage3_summary as (
+    select answer_json, answer_text
+      from public.answers
+     where run_id = p_run_id
+       and ticker = p_ticker
+       and stage = 3
+       and coalesce(question_group, '') = 'summary'
+     order by created_at desc
+     limit 1
+  ),
+  stage3_groups as (
+    select coalesce(jsonb_agg(jsonb_build_object(
+        'question_group', question_group,
+        'answer_json', answer_json,
+        'created_at', created_at
+      ) order by created_at desc), '[]'::jsonb) as groups
+      from public.answers
+     where run_id = p_run_id
+       and ticker = p_ticker
+       and stage = 3
+       and coalesce(question_group, '') <> 'summary'
+  )
+  select
+    base.run_id,
+    base.ticker,
+    base.name,
+    base.exchange,
+    base.country,
+    base.sector,
+    base.industry,
+    base.stage,
+    base.status,
+    base.label,
+    base.stage2_go_deep,
+    base.spend_usd,
+    base.updated_at,
+    stage1.answer_json as stage1,
+    stage2.answer_json as stage2,
+    stage3_summary.answer_json as stage3_summary,
+    coalesce(stage3_summary.answer_text, stage3_summary.answer_json ->> 'summary') as stage3_text,
+    stage3_groups.groups as stage3_groups
+  from base
+  left join stage1 on true
+  left join stage2 on true
+  left join stage3_summary on true
+  left join stage3_groups on true;
+$$;

--- a/supabase/functions/runs-create/index.ts
+++ b/supabase/functions/runs-create/index.ts
@@ -1,0 +1,305 @@
+import { serve } from 'https://deno.land/std@0.210.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4';
+
+type JsonRecord = Record<string, unknown>;
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS'
+};
+
+const jsonHeaders = {
+  ...corsHeaders,
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store'
+};
+
+function jsonResponse(status: number, body: JsonRecord) {
+  return new Response(JSON.stringify(body), { status, headers: jsonHeaders });
+}
+
+function normalizeTicker(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().toUpperCase();
+  if (!trimmed) return null;
+  if (!/^[A-Z0-9\-\.]+$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+function clamp(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function asNumber(value: unknown, fallback = 0) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function collectRoles(source: unknown, bucket: Set<string>) {
+  if (!source) return;
+  if (Array.isArray(source)) {
+    source.forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  if (typeof source === 'object') {
+    Object.values(source as Record<string, unknown>).forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  const parts = String(source)
+    .split(/[\s,]+/)
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+  parts.forEach((role) => bucket.add(role));
+}
+
+function hasAdminMarker(record: Record<string, unknown> | null | undefined) {
+  if (!record) return false;
+  const flagKeys = ['is_admin', 'admin', 'isAdmin', 'is_superadmin', 'superuser', 'staff', 'is_staff'];
+  return flagKeys.some((key) => Boolean((record as Record<string, unknown>)[key]));
+}
+
+function isAdminContext(context: { user: JsonRecord | null; profile: JsonRecord | null; membership: JsonRecord | null }) {
+  const { user, profile, membership } = context;
+  if (hasAdminMarker(profile) || hasAdminMarker(membership) || hasAdminMarker(user ?? undefined)) {
+    return true;
+  }
+
+  const bucket = new Set<string>();
+  collectRoles(profile?.role, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_name, bucket);
+  collectRoles((profile as JsonRecord | null)?.user_role, bucket);
+  collectRoles((profile as JsonRecord | null)?.roles, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_tags, bucket);
+  collectRoles((profile as JsonRecord | null)?.access_level, bucket);
+
+  collectRoles(user?.app_metadata, bucket);
+  collectRoles(user?.user_metadata, bucket);
+
+  collectRoles(membership?.role, bucket);
+  collectRoles(membership?.roles, bucket);
+  collectRoles(membership?.access_level, bucket);
+
+  const privileged = new Set(['admin', 'administrator', 'superadmin', 'owner', 'editor', 'staff']);
+  for (const role of bucket) {
+    if (privileged.has(role)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function sanitizeStage(input: any, fallback: { model: string; inTokens: number; outTokens: number }) {
+  return {
+    model: typeof input?.model === 'string' ? input.model : fallback.model,
+    inTokens: clamp(asNumber(input?.inTokens, fallback.inTokens), 0, 1_000_000),
+    outTokens: clamp(asNumber(input?.outTokens, fallback.outTokens), 0, 1_000_000)
+  };
+}
+
+function sanitizePlanner(input: any) {
+  const defaults = {
+    universe: 40000,
+    surviveStage2: 15,
+    surviveStage3: 12,
+    stage1: { model: '4o-mini', inTokens: 3000, outTokens: 600 },
+    stage2: { model: '5-mini', inTokens: 30000, outTokens: 6000 },
+    stage3: { model: '5', inTokens: 100000, outTokens: 20000 }
+  };
+
+  const universe = clamp(asNumber(input?.universe, defaults.universe), 0, 60000);
+  const surviveStage2 = clamp(asNumber(input?.surviveStage2, defaults.surviveStage2), 0, 100);
+  const surviveStage3 = clamp(asNumber(input?.surviveStage3, defaults.surviveStage3), 0, 100);
+
+  return {
+    universe,
+    surviveStage2,
+    surviveStage3,
+    stage1: sanitizeStage(input?.stage1, defaults.stage1),
+    stage2: sanitizeStage(input?.stage2, defaults.stage2),
+    stage3: sanitizeStage(input?.stage3, defaults.stage3)
+  };
+}
+
+function estimateCost(planner: ReturnType<typeof sanitizePlanner>) {
+  const survivorsStage2 = Math.round(planner.universe * (planner.surviveStage2 / 100));
+  const survivorsStage3 = Math.round(survivorsStage2 * (planner.surviveStage3 / 100));
+
+  const costs = {
+    '5': { in: 1.25, out: 10.0 },
+    '5-mini': { in: 0.25, out: 2.0 },
+    '4o-mini': { in: 0.15, out: 0.60 }
+  } as Record<string, { in: number; out: number }>;
+
+  const stageCost = (count: number, tokensIn: number, tokensOut: number, model: string) => {
+    const price = costs[model];
+    if (!price || !count) return 0;
+    const inCost = (count * tokensIn / 1_000_000) * price.in;
+    const outCost = (count * tokensOut / 1_000_000) * price.out;
+    return inCost + outCost;
+  };
+
+  const stage1 = stageCost(planner.universe, planner.stage1.inTokens, planner.stage1.outTokens, planner.stage1.model);
+  const stage2 = stageCost(survivorsStage2, planner.stage2.inTokens, planner.stage2.outTokens, planner.stage2.model);
+  const stage3 = stageCost(survivorsStage3, planner.stage3.inTokens, planner.stage3.outTokens, planner.stage3.model);
+
+  return {
+    stage1,
+    stage2,
+    stage3,
+    total: stage1 + stage2 + stage3
+  };
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error('Missing Supabase configuration.');
+    return jsonResponse(500, { error: 'Server not configured for Supabase access' });
+  }
+
+  let payload: any;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error('Invalid JSON payload', error);
+    return jsonResponse(400, { error: 'Invalid JSON payload' });
+  }
+
+  const planner = sanitizePlanner(payload?.planner ?? {});
+  const rawTickers = Array.isArray(payload?.tickers) ? payload.tickers : [];
+  const normalizedTickers = Array.from(new Set(rawTickers.map(normalizeTicker).filter((value): value is string => Boolean(value))));
+
+  const requestedUniverse = planner.universe || normalizedTickers.length;
+  const MAX_TICKERS = 60000;
+  const targetCount = clamp(normalizedTickers.length > 0 ? normalizedTickers.length : requestedUniverse, 1, MAX_TICKERS);
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+  const accessToken = tokenMatch?.[1]?.trim();
+
+  if (!accessToken) {
+    return jsonResponse(401, { error: 'Missing bearer token' });
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, { auth: { persistSession: false } });
+
+  const { data: userData, error: userError } = await supabaseAdmin.auth.getUser(accessToken);
+  if (userError || !userData?.user) {
+    console.error('Invalid session token', userError);
+    return jsonResponse(401, { error: 'Invalid or expired session token' });
+  }
+
+  const user = userData.user as JsonRecord;
+  const userId = user?.id as string;
+
+  const [profileResult, membershipResult] = await Promise.all([
+    supabaseAdmin
+      .from('profiles')
+      .select('*')
+      .eq('id', userId)
+      .maybeSingle(),
+    supabaseAdmin
+      .from('memberships')
+      .select('*')
+      .eq('user_id', userId)
+      .maybeSingle()
+  ]);
+
+  if (profileResult.error) {
+    console.warn('profiles query error', profileResult.error);
+  }
+  if (membershipResult.error) {
+    console.warn('memberships query error', membershipResult.error);
+  }
+
+  const profile = profileResult.data as JsonRecord | null;
+  const membership = membershipResult.data as JsonRecord | null;
+
+  if (!isAdminContext({ user, profile, membership })) {
+    return jsonResponse(403, { error: 'Admin access required' });
+  }
+
+  let tickers = normalizedTickers;
+  if (tickers.length === 0) {
+    const { data, error } = await supabaseAdmin
+      .from('tickers')
+      .select('ticker')
+      .order('updated_at', { ascending: false, nullsLast: true })
+      .order('ticker', { ascending: true })
+      .limit(targetCount);
+
+    if (error) {
+      console.error('Failed to load tickers', error);
+      return jsonResponse(500, { error: 'Failed to load tickers', details: error.message });
+    }
+
+    tickers = (data ?? [])
+      .map((row) => normalizeTicker(row.ticker))
+      .filter((value): value is string => Boolean(value));
+  } else if (tickers.length > targetCount) {
+    tickers = tickers.slice(0, targetCount);
+  }
+
+  if (tickers.length === 0) {
+    return jsonResponse(404, { error: 'No tickers available to enqueue' });
+  }
+
+  const runSummary = {
+    planner,
+    estimated_cost: estimateCost(planner),
+    requested_tickers: normalizedTickers.length,
+    resolved_tickers: tickers.length,
+    created_at: new Date().toISOString(),
+    created_by: userId,
+    client_meta: payload?.client_meta ?? null
+  };
+
+  const { data: runRow, error: runError } = await supabaseAdmin
+    .from('runs')
+    .insert({ status: 'running', notes: JSON.stringify(runSummary) })
+    .select('id')
+    .single();
+
+  if (runError || !runRow) {
+    console.error('Failed to create run', runError);
+    return jsonResponse(500, { error: 'Failed to create run', details: runError?.message ?? null });
+  }
+
+  const runId = runRow.id as string;
+  const runItems = tickers.map((ticker) => ({
+    run_id: runId,
+    ticker,
+    status: 'pending',
+    stage: 0,
+    spend_est_usd: 0
+  }));
+
+  const chunkSize = 1000;
+  for (let index = 0; index < runItems.length; index += chunkSize) {
+    const chunk = runItems.slice(index, index + chunkSize);
+    const { error } = await supabaseAdmin.from('run_items').insert(chunk);
+    if (error) {
+      console.error('Failed to insert run items', error);
+      await supabaseAdmin.from('runs').update({ status: 'failed' }).eq('id', runId);
+      return jsonResponse(500, { error: 'Failed to enqueue tickers', details: error.message, run_id: runId });
+    }
+  }
+
+  return jsonResponse(200, {
+    run_id: runId,
+    total_items: runItems.length,
+    planner,
+    estimated_cost: runSummary.estimated_cost
+  });
+});

--- a/supabase/functions/runs-stop/index.ts
+++ b/supabase/functions/runs-stop/index.ts
@@ -1,0 +1,186 @@
+import { serve } from 'https://deno.land/std@0.210.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4';
+
+type JsonRecord = Record<string, unknown>;
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS'
+};
+
+const jsonHeaders = {
+  ...corsHeaders,
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store'
+};
+
+function jsonResponse(status: number, body: JsonRecord) {
+  return new Response(JSON.stringify(body), { status, headers: jsonHeaders });
+}
+
+function isUuid(value: unknown) {
+  if (typeof value !== 'string') return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value.trim());
+}
+
+function collectRoles(source: unknown, bucket: Set<string>) {
+  if (!source) return;
+  if (Array.isArray(source)) {
+    source.forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  if (typeof source === 'object') {
+    Object.values(source as Record<string, unknown>).forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  const parts = String(source)
+    .split(/[\s,]+/)
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+  parts.forEach((role) => bucket.add(role));
+}
+
+function hasAdminMarker(record: Record<string, unknown> | null | undefined) {
+  if (!record) return false;
+  const flagKeys = ['is_admin', 'admin', 'isAdmin', 'is_superadmin', 'superuser', 'staff', 'is_staff'];
+  return flagKeys.some((key) => Boolean((record as Record<string, unknown>)[key]));
+}
+
+function isAdminContext(context: { user: JsonRecord | null; profile: JsonRecord | null; membership: JsonRecord | null }) {
+  const { user, profile, membership } = context;
+  if (hasAdminMarker(profile) || hasAdminMarker(membership) || hasAdminMarker(user ?? undefined)) {
+    return true;
+  }
+
+  const bucket = new Set<string>();
+  collectRoles(profile?.role, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_name, bucket);
+  collectRoles((profile as JsonRecord | null)?.user_role, bucket);
+  collectRoles((profile as JsonRecord | null)?.roles, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_tags, bucket);
+  collectRoles((profile as JsonRecord | null)?.access_level, bucket);
+
+  collectRoles(user?.app_metadata, bucket);
+  collectRoles(user?.user_metadata, bucket);
+
+  collectRoles(membership?.role, bucket);
+  collectRoles(membership?.roles, bucket);
+  collectRoles(membership?.access_level, bucket);
+
+  const privileged = new Set(['admin', 'administrator', 'superadmin', 'owner', 'editor', 'staff']);
+  for (const role of bucket) {
+    if (privileged.has(role)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error('Missing Supabase configuration for runs-stop');
+    return jsonResponse(500, { error: 'Server misconfigured' });
+  }
+
+  let payload: any;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error('Invalid JSON payload for runs-stop', error);
+    return jsonResponse(400, { error: 'Invalid JSON payload' });
+  }
+
+  const requestedRunId = typeof payload?.run_id === 'string' ? payload.run_id.trim() : '';
+  const runId = isUuid(requestedRunId) ? requestedRunId : null;
+  if (!runId) {
+    return jsonResponse(400, { error: 'Valid run_id is required' });
+  }
+
+  const stopRequested = Boolean(payload?.stop_requested);
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+  const accessToken = tokenMatch?.[1]?.trim();
+  if (!accessToken) {
+    return jsonResponse(401, { error: 'Missing bearer token' });
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, { auth: { persistSession: false } });
+
+  const { data: userData, error: userError } = await supabaseAdmin.auth.getUser(accessToken);
+  if (userError || !userData?.user) {
+    console.error('Invalid session token for runs-stop', userError);
+    return jsonResponse(401, { error: 'Invalid or expired session token' });
+  }
+
+  const [profileResult, membershipResult] = await Promise.all([
+    supabaseAdmin.from('profiles').select('*').eq('id', userData.user.id).maybeSingle(),
+    supabaseAdmin.from('memberships').select('*').eq('user_id', userData.user.id).maybeSingle()
+  ]);
+
+  if (profileResult.error) {
+    console.error('Failed to load profile for runs-stop', profileResult.error);
+  }
+  if (membershipResult.error) {
+    console.error('Failed to load membership for runs-stop', membershipResult.error);
+  }
+
+  const context = {
+    user: userData.user as JsonRecord,
+    profile: (profileResult.data ?? null) as JsonRecord | null,
+    membership: (membershipResult.data ?? null) as JsonRecord | null
+  };
+
+  if (!isAdminContext(context)) {
+    return jsonResponse(403, { error: 'Admin access required' });
+  }
+
+  const { data: runRecord, error: loadError } = await supabaseAdmin
+    .from('runs')
+    .select('id, status, stop_requested, notes, created_at')
+    .eq('id', runId)
+    .maybeSingle();
+
+  if (loadError) {
+    console.error('Failed to load run for runs-stop', loadError);
+    return jsonResponse(500, { error: 'Failed to load run', details: loadError.message });
+  }
+
+  if (!runRecord) {
+    return jsonResponse(404, { error: 'Run not found' });
+  }
+
+  if (runRecord.stop_requested === stopRequested) {
+    return jsonResponse(200, { message: 'No change', run: runRecord });
+  }
+
+  const { data: updated, error: updateError } = await supabaseAdmin
+    .from('runs')
+    .update({ stop_requested: stopRequested })
+    .eq('id', runId)
+    .select('id, status, stop_requested, notes, created_at')
+    .maybeSingle();
+
+  if (updateError) {
+    console.error('Failed to update run stop flag', updateError);
+    return jsonResponse(500, { error: 'Failed to update run', details: updateError.message });
+  }
+
+  return jsonResponse(200, {
+    message: stopRequested ? 'Run flagged to stop' : 'Stop request cleared',
+    run: updated
+  });
+});

--- a/supabase/functions/stage1-consume/index.ts
+++ b/supabase/functions/stage1-consume/index.ts
@@ -1,0 +1,473 @@
+import { serve } from 'https://deno.land/std@0.210.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4';
+
+type JsonRecord = Record<string, unknown>;
+
+type Metrics = {
+  total: number;
+  pending: number;
+  completed: number;
+  failed: number;
+};
+
+type StageResult = {
+  ticker: string;
+  label: string | null;
+  summary: string;
+  updated_at: string;
+  status: 'ok' | 'failed';
+};
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS'
+};
+
+const jsonHeaders = {
+  ...corsHeaders,
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store'
+};
+
+const MODEL_ALIASES: Record<string, string> = {
+  '4o-mini': 'gpt-4o-mini',
+  '5-mini': 'gpt-5-mini',
+  '5': 'gpt-5-preview'
+};
+
+const PRICE_LOOKUP: Record<string, { in: number; out: number }> = {
+  '4o-mini': { in: 0.15, out: 0.6 },
+  '5-mini': { in: 0.25, out: 2.0 },
+  '5': { in: 1.25, out: 10.0 }
+};
+
+const SYSTEM_PROMPT = `You are a buy-side screening analyst. Classify each ticker as one of "uninvestible", "borderline", or "consider". ` +
+  `Return strict JSON with the shape {"label": "uninvestible|borderline|consider", "reasons": [short bullet strings], "flags": {"leverage": string, "governance": string, "dilution": string}}. ` +
+  `Be decisive, grounded in fundamentals, and keep reasons concise.`;
+
+function jsonResponse(status: number, body: JsonRecord) {
+  return new Response(JSON.stringify(body), { status, headers: jsonHeaders });
+}
+
+function clamp(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function asNumber(value: unknown, fallback: number) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function isUuid(value: unknown) {
+  if (typeof value !== 'string') return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value.trim());
+}
+
+function collectRoles(source: unknown, bucket: Set<string>) {
+  if (!source) return;
+  if (Array.isArray(source)) {
+    source.forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  if (typeof source === 'object') {
+    Object.values(source as Record<string, unknown>).forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  const parts = String(source)
+    .split(/[\s,]+/)
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+  parts.forEach((role) => bucket.add(role));
+}
+
+function hasAdminMarker(record: Record<string, unknown> | null | undefined) {
+  if (!record) return false;
+  const flagKeys = ['is_admin', 'admin', 'isAdmin', 'is_superadmin', 'superuser', 'staff', 'is_staff'];
+  return flagKeys.some((key) => Boolean((record as Record<string, unknown>)[key]));
+}
+
+function isAdminContext(context: { user: JsonRecord | null; profile: JsonRecord | null; membership: JsonRecord | null }) {
+  const { user, profile, membership } = context;
+  if (hasAdminMarker(profile) || hasAdminMarker(membership) || hasAdminMarker(user ?? undefined)) {
+    return true;
+  }
+
+  const bucket = new Set<string>();
+  collectRoles(profile?.role, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_name, bucket);
+  collectRoles((profile as JsonRecord | null)?.user_role, bucket);
+  collectRoles((profile as JsonRecord | null)?.roles, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_tags, bucket);
+  collectRoles((profile as JsonRecord | null)?.access_level, bucket);
+
+  collectRoles(user?.app_metadata, bucket);
+  collectRoles(user?.user_metadata, bucket);
+
+  collectRoles(membership?.role, bucket);
+  collectRoles(membership?.roles, bucket);
+  collectRoles(membership?.access_level, bucket);
+
+  const privileged = new Set(['admin', 'administrator', 'superadmin', 'owner', 'editor', 'staff']);
+  for (const role of bucket) {
+    if (privileged.has(role)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function computeMetrics(client: ReturnType<typeof createClient>, runId: string): Promise<Metrics> {
+  const [totalRes, pendingRes, completedRes, failedRes] = await Promise.all([
+    client.from('run_items').select('*', { count: 'exact', head: true }).eq('run_id', runId),
+    client
+      .from('run_items')
+      .select('*', { count: 'exact', head: true })
+      .eq('run_id', runId)
+      .eq('status', 'pending')
+      .eq('stage', 0),
+    client
+      .from('run_items')
+      .select('*', { count: 'exact', head: true })
+      .eq('run_id', runId)
+      .eq('status', 'ok')
+      .gte('stage', 1),
+    client
+      .from('run_items')
+      .select('*', { count: 'exact', head: true })
+      .eq('run_id', runId)
+      .eq('status', 'failed')
+  ]);
+
+  if (totalRes.error) throw totalRes.error;
+  if (pendingRes.error) throw pendingRes.error;
+  if (completedRes.error) throw completedRes.error;
+  if (failedRes.error) throw failedRes.error;
+
+  return {
+    total: totalRes.count ?? 0,
+    pending: pendingRes.count ?? 0,
+    completed: completedRes.count ?? 0,
+    failed: failedRes.count ?? 0
+  };
+}
+
+async function fetchTickerMeta(client: ReturnType<typeof createClient>, ticker: string) {
+  const { data } = await client
+    .from('tickers')
+    .select('name, exchange, country, sector, industry')
+    .eq('ticker', ticker)
+    .maybeSingle();
+  return data ?? {};
+}
+
+function buildUserPrompt(ticker: string, meta: Record<string, unknown>) {
+  const parts = [
+    `Ticker: ${ticker}`,
+    `Name: ${meta.name ?? 'Unknown'}`,
+    `Exchange: ${meta.exchange ?? 'n/a'}`,
+    `Country: ${meta.country ?? 'n/a'}`,
+    `Sector: ${meta.sector ?? 'n/a'}`,
+    `Industry: ${meta.industry ?? 'n/a'}`
+  ];
+  return parts.join('\n');
+}
+
+async function callOpenAI(apiKey: string, model: string, ticker: string, meta: Record<string, unknown>) {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0.1,
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: buildUserPrompt(ticker, meta) }
+      ]
+    })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OpenAI error ${response.status}: ${text}`);
+  }
+
+  const payload = await response.json();
+  const message = payload?.choices?.[0]?.message?.content ?? '{}';
+  let parsed: JsonRecord;
+  try {
+    parsed = JSON.parse(message);
+  } catch (error) {
+    throw new Error(`Failed to parse OpenAI response JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const usage = payload?.usage ?? { prompt_tokens: 0, completion_tokens: 0 };
+  return { parsed, usage };
+}
+
+function computeCost(modelKey: string, usage: { prompt_tokens?: number; completion_tokens?: number }) {
+  const price = PRICE_LOOKUP[modelKey] ?? PRICE_LOOKUP['4o-mini'];
+  const promptTokens = usage.prompt_tokens ?? 0;
+  const completionTokens = usage.completion_tokens ?? 0;
+  const inCost = (promptTokens / 1_000_000) * price.in;
+  const outCost = (completionTokens / 1_000_000) * price.out;
+  return {
+    cost: inCost + outCost,
+    promptTokens,
+    completionTokens
+  };
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const openaiKey = Deno.env.get('OPENAI_API_KEY');
+
+  if (!supabaseUrl || !serviceRoleKey || !openaiKey) {
+    console.error('Missing required environment configuration for stage1-consume');
+    return jsonResponse(500, { error: 'Server misconfigured' });
+  }
+
+  let payload: any;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error('Invalid JSON payload', error);
+    return jsonResponse(400, { error: 'Invalid JSON payload' });
+  }
+
+  const limit = clamp(asNumber(payload?.limit, 8), 1, 25);
+  const requestedRunId = typeof payload?.run_id === 'string' ? payload.run_id.trim() : '';
+  const runId = isUuid(requestedRunId) ? requestedRunId : null;
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+  const accessToken = tokenMatch?.[1]?.trim();
+  if (!accessToken) {
+    return jsonResponse(401, { error: 'Missing bearer token' });
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, { auth: { persistSession: false } });
+
+  const { data: userData, error: userError } = await supabaseAdmin.auth.getUser(accessToken);
+  if (userError || !userData?.user) {
+    console.error('Invalid session token', userError);
+    return jsonResponse(401, { error: 'Invalid or expired session token' });
+  }
+
+  const [profileResult, membershipResult] = await Promise.all([
+    supabaseAdmin.from('profiles').select('*').eq('id', userData.user.id).maybeSingle(),
+    supabaseAdmin.from('memberships').select('*').eq('user_id', userData.user.id).maybeSingle()
+  ]);
+
+  if (profileResult.error) {
+    console.error('Failed to load profile', profileResult.error);
+  }
+  if (membershipResult.error) {
+    console.error('Failed to load membership', membershipResult.error);
+  }
+
+  const context = {
+    user: userData.user as JsonRecord,
+    profile: (profileResult.data ?? null) as JsonRecord | null,
+    membership: (membershipResult.data ?? null) as JsonRecord | null
+  };
+
+  if (!isAdminContext(context)) {
+    return jsonResponse(403, { error: 'Admin access required' });
+  }
+
+  let runRow;
+  if (runId) {
+    const { data, error } = await supabaseAdmin
+      .from('runs')
+      .select('id, status, stop_requested, notes')
+      .eq('id', runId)
+      .maybeSingle();
+    if (error) {
+      console.error('Failed to load run', error);
+      return jsonResponse(500, { error: 'Failed to load run', details: error.message });
+    }
+    runRow = data;
+  } else {
+    const { data, error } = await supabaseAdmin
+      .from('runs')
+      .select('id, status, stop_requested, notes')
+      .in('status', ['running', 'queued'])
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) {
+      console.error('Failed to select latest run', error);
+      return jsonResponse(500, { error: 'Failed to select latest run', details: error.message });
+    }
+    runRow = data;
+  }
+
+  if (!runRow) {
+    return jsonResponse(404, { error: 'Run not found' });
+  }
+
+  if (runRow.stop_requested) {
+    const metrics = await computeMetrics(supabaseAdmin, runRow.id);
+    return jsonResponse(409, {
+      error: 'Run flagged to stop',
+      run_id: runRow.id,
+      metrics
+    });
+  }
+
+  const modelKeyRaw = ((): string => {
+    try {
+      const notes = typeof runRow.notes === 'string' ? JSON.parse(runRow.notes) : runRow.notes;
+      return notes?.planner?.stage1?.model ?? '4o-mini';
+    } catch {
+      return '4o-mini';
+    }
+  })();
+
+  const modelKey = PRICE_LOOKUP[modelKeyRaw] ? modelKeyRaw : '4o-mini';
+  const openaiModel = MODEL_ALIASES[modelKey] ?? MODEL_ALIASES['4o-mini'];
+
+  const { data: pending, error: pendingError } = await supabaseAdmin
+    .from('run_items')
+    .select('ticker, spend_est_usd')
+    .eq('run_id', runRow.id)
+    .eq('status', 'pending')
+    .eq('stage', 0)
+    .order('updated_at', { ascending: true })
+    .limit(limit);
+
+  if (pendingError) {
+    console.error('Failed to load pending run items', pendingError);
+    return jsonResponse(500, { error: 'Failed to load pending run items', details: pendingError.message });
+  }
+
+  const items = pending ?? [];
+  if (items.length === 0) {
+    const metrics = await computeMetrics(supabaseAdmin, runRow.id);
+    const message = metrics.pending === 0
+      ? 'Stage 1 complete for this run.'
+      : 'No pending items available for Stage 1.';
+    return jsonResponse(200, {
+      run_id: runRow.id,
+      processed: 0,
+      failed: 0,
+      metrics,
+      results: [],
+      message
+    });
+  }
+
+  const results: StageResult[] = [];
+  let processed = 0;
+  let failures = 0;
+
+  for (const item of items) {
+    const ticker = item.ticker as string;
+    const startedAt = new Date().toISOString();
+    try {
+      const meta = await fetchTickerMeta(supabaseAdmin, ticker);
+      const { parsed, usage } = await callOpenAI(openaiKey, openaiModel, ticker, meta);
+      const { cost, promptTokens, completionTokens } = computeCost(modelKey, usage);
+
+      await supabaseAdmin.from('answers').insert({
+        run_id: runRow.id,
+        ticker,
+        stage: 1,
+        question_group: 'triage',
+        answer_json: parsed,
+        tokens_in: promptTokens,
+        tokens_out: completionTokens,
+        cost_usd: cost,
+        created_at: startedAt
+      });
+
+      await supabaseAdmin
+        .from('run_items')
+        .update({
+          stage: 1,
+          status: 'ok',
+          label: typeof parsed?.label === 'string' ? parsed.label : null,
+          stage2_go_deep: null,
+          spend_est_usd: Number(item.spend_est_usd ?? 0) + cost,
+          updated_at: new Date().toISOString()
+        })
+        .eq('run_id', runRow.id)
+        .eq('ticker', ticker);
+
+      await supabaseAdmin.from('cost_ledger').insert({
+        run_id: runRow.id,
+        stage: 1,
+        model: modelKey,
+        tokens_in: promptTokens,
+        tokens_out: completionTokens,
+        cost_usd: cost,
+        created_at: startedAt
+      });
+
+      const summary = Array.isArray(parsed?.reasons) && parsed.reasons.length
+        ? String(parsed.reasons[0])
+        : typeof parsed?.summary === 'string'
+          ? parsed.summary
+          : typeof parsed?.reason === 'string'
+            ? parsed.reason
+            : '—';
+
+      results.push({
+        ticker,
+        label: typeof parsed?.label === 'string' ? parsed.label : null,
+        summary,
+        updated_at: startedAt,
+        status: 'ok'
+      });
+      processed += 1;
+    } catch (error) {
+      console.error(`Stage 1 processing failed for ${ticker}`, error);
+      failures += 1;
+      const message = error instanceof Error ? error.message : String(error);
+      results.push({
+        ticker,
+        label: null,
+        summary: message,
+        updated_at: startedAt,
+        status: 'failed'
+      });
+
+      await supabaseAdmin
+        .from('run_items')
+        .update({ status: 'failed', stage2_go_deep: null, updated_at: new Date().toISOString() })
+        .eq('run_id', runRow.id)
+        .eq('ticker', ticker);
+    }
+  }
+
+  const metrics = await computeMetrics(supabaseAdmin, runRow.id);
+  const message = processed > 0
+    ? `Processed ${processed} ticker${processed === 1 ? '' : 's'}. Pending: ${metrics.pending}.`
+    : 'No tickers processed.';
+
+  return jsonResponse(200, {
+    run_id: runRow.id,
+    processed,
+    failed: failures,
+    metrics,
+    results,
+    model: modelKey,
+    message
+  });
+});

--- a/supabase/functions/stage2-consume/index.ts
+++ b/supabase/functions/stage2-consume/index.ts
@@ -1,0 +1,572 @@
+import { serve } from 'https://deno.land/std@0.210.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4';
+
+type JsonRecord = Record<string, unknown>;
+
+type Stage2Result = {
+  ticker: string;
+  go_deep: boolean;
+  summary: string;
+  updated_at: string;
+  status: 'ok' | 'failed';
+};
+
+type Stage2Metrics = {
+  total_survivors: number;
+  pending: number;
+  completed: number;
+  failed: number;
+  go_deep: number;
+};
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS'
+};
+
+const jsonHeaders = {
+  ...corsHeaders,
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store'
+};
+
+const MODEL_ALIASES: Record<string, string> = {
+  '4o-mini': 'gpt-4o-mini',
+  '5-mini': 'gpt-5-mini',
+  '5': 'gpt-5-preview'
+};
+
+const PRICE_LOOKUP: Record<string, { in: number; out: number }> = {
+  '4o-mini': { in: 0.15, out: 0.6 },
+  '5-mini': { in: 0.25, out: 2.0 },
+  '5': { in: 1.25, out: 10.0 }
+};
+
+const SURVIVOR_LABELS = new Set(['consider', 'borderline']);
+
+const SYSTEM_PROMPT =
+  `You are a buy-side equity analyst performing a thematic scoring pass. ` +
+  `Return strict JSON with the shape {"scores": {"profitability": {"score": int, "rationale": string}, "reinvestment": {"score": int, "rationale": string}, "leverage": {"score": int, "rationale": string}, "moat": {"score": int, "rationale": string}, "timing": {"score": int, "rationale": string}}, ` +
+  `"verdict": {"go_deep": boolean, "summary": string, "risks": [string], "opportunities": [string]}, "next_steps": [string]}. ` +
+  `Scores must be integers from 0-10. Keep rationales under 160 characters and ground all commentary in the provided facts.`;
+
+function jsonResponse(status: number, body: JsonRecord) {
+  return new Response(JSON.stringify(body), { status, headers: jsonHeaders });
+}
+
+function clamp(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function asNumber(value: unknown, fallback: number) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function isUuid(value: unknown) {
+  if (typeof value !== 'string') return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value.trim());
+}
+
+function collectRoles(source: unknown, bucket: Set<string>) {
+  if (!source) return;
+  if (Array.isArray(source)) {
+    source.forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  if (typeof source === 'object') {
+    Object.values(source as Record<string, unknown>).forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  const parts = String(source)
+    .split(/[\s,]+/)
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+  parts.forEach((role) => bucket.add(role));
+}
+
+function hasAdminMarker(record: Record<string, unknown> | null | undefined) {
+  if (!record) return false;
+  const flagKeys = ['is_admin', 'admin', 'isAdmin', 'is_superadmin', 'superuser', 'staff', 'is_staff'];
+  return flagKeys.some((key) => Boolean((record as Record<string, unknown>)[key]));
+}
+
+function isAdminContext(context: { user: JsonRecord | null; profile: JsonRecord | null; membership: JsonRecord | null }) {
+  const { user, profile, membership } = context;
+  if (hasAdminMarker(profile) || hasAdminMarker(membership) || hasAdminMarker(user ?? undefined)) {
+    return true;
+  }
+
+  const bucket = new Set<string>();
+  collectRoles(profile?.role, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_name, bucket);
+  collectRoles((profile as JsonRecord | null)?.user_role, bucket);
+  collectRoles((profile as JsonRecord | null)?.roles, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_tags, bucket);
+  collectRoles((profile as JsonRecord | null)?.access_level, bucket);
+
+  collectRoles(user?.app_metadata, bucket);
+  collectRoles(user?.user_metadata, bucket);
+
+  collectRoles(membership?.role, bucket);
+  collectRoles(membership?.roles, bucket);
+  collectRoles(membership?.access_level, bucket);
+
+  const privileged = new Set(['admin', 'administrator', 'superadmin', 'owner', 'editor', 'staff']);
+  for (const role of bucket) {
+    if (privileged.has(role)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function normalizeLabel(value: unknown) {
+  if (typeof value !== 'string') return '';
+  return value.trim().toLowerCase();
+}
+
+function survivorFilter(builder: ReturnType<typeof createClient>['from']) {
+  return builder.filter('label', 'in', '("consider","borderline","CONSIDER","BORDERLINE")');
+}
+
+async function computeMetrics(client: ReturnType<typeof createClient>, runId: string): Promise<Stage2Metrics> {
+  const { data, error } = await client.rpc('run_stage2_summary', { p_run_id: runId }).maybeSingle();
+  if (error) throw error;
+  return {
+    total_survivors: Number(data?.total_survivors ?? 0),
+    pending: Number(data?.pending ?? 0),
+    completed: Number(data?.completed ?? 0),
+    failed: Number(data?.failed ?? 0),
+    go_deep: Number(data?.go_deep ?? 0)
+  };
+}
+
+async function fetchTickerMeta(client: ReturnType<typeof createClient>, ticker: string) {
+  const { data } = await client
+    .from('tickers')
+    .select('name, exchange, country, sector, industry')
+    .eq('ticker', ticker)
+    .maybeSingle();
+  return data ?? {};
+}
+
+async function fetchSectorNotes(client: ReturnType<typeof createClient>, sector: string | null | undefined) {
+  if (!sector) return null;
+  const { data } = await client.from('sector_prompts').select('notes').eq('sector', sector).maybeSingle();
+  return typeof data?.notes === 'string' && data.notes.trim().length ? data.notes.trim() : null;
+}
+
+async function fetchStage1Answer(client: ReturnType<typeof createClient>, runId: string, ticker: string) {
+  const { data } = await client
+    .from('answers')
+    .select('answer_json')
+    .eq('run_id', runId)
+    .eq('ticker', ticker)
+    .eq('stage', 1)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return (data?.answer_json ?? null) as JsonRecord | null;
+}
+
+function buildUserPrompt(
+  ticker: string,
+  meta: Record<string, unknown>,
+  stage1: JsonRecord | null,
+  sectorNotes: string | null
+) {
+  const lines: string[] = [];
+  lines.push(`Ticker: ${ticker}`);
+  lines.push(`Name: ${meta.name ?? 'Unknown'}`);
+  lines.push(`Exchange: ${meta.exchange ?? 'n/a'}`);
+  lines.push(`Country: ${meta.country ?? 'n/a'}`);
+  lines.push(`Sector: ${meta.sector ?? 'n/a'}`);
+  lines.push(`Industry: ${meta.industry ?? 'n/a'}`);
+  lines.push('');
+
+  const stage1Label = stage1?.label ?? stage1?.classification ?? null;
+  if (stage1Label) {
+    lines.push(`Stage 1 classification: ${stage1Label}`);
+  }
+  const reasons = Array.isArray(stage1?.reasons) ? stage1?.reasons : [];
+  if (reasons && reasons.length) {
+    lines.push('Stage 1 reasons:');
+    reasons.slice(0, 4).forEach((reason: unknown, index: number) => {
+      lines.push(`  ${index + 1}. ${String(reason)}`);
+    });
+  }
+  const flags = stage1?.flags as JsonRecord | null;
+  if (flags && typeof flags === 'object') {
+    const flagEntries = Object.entries(flags)
+      .filter(([, value]) => value != null && value !== '')
+      .map(([key, value]) => `${key}: ${value}`);
+    if (flagEntries.length) {
+      lines.push('Risk flags:');
+      flagEntries.slice(0, 4).forEach((flag) => lines.push(`  - ${flag}`));
+    }
+  }
+
+  if (typeof stage1?.summary === 'string' && stage1.summary.trim()) {
+    lines.push('Stage 1 summary:');
+    lines.push(stage1.summary.trim());
+  }
+
+  if (sectorNotes) {
+    lines.push('');
+    lines.push('Sector heuristics to consider:');
+    lines.push(sectorNotes);
+  }
+
+  lines.push('');
+  lines.push('Deliver mid-depth scoring with crisp rationales tied to these facts.');
+  return lines.join('\n');
+}
+
+async function callOpenAI(
+  apiKey: string,
+  model: string,
+  ticker: string,
+  meta: Record<string, unknown>,
+  stage1: JsonRecord | null,
+  sectorNotes: string | null
+) {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0.2,
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: buildUserPrompt(ticker, meta, stage1, sectorNotes) }
+      ]
+    })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OpenAI error ${response.status}: ${text}`);
+  }
+
+  const payload = await response.json();
+  const message = payload?.choices?.[0]?.message?.content ?? '{}';
+  let parsed: JsonRecord;
+  try {
+    parsed = JSON.parse(message);
+  } catch (error) {
+    throw new Error(`Failed to parse OpenAI response JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  const usage = payload?.usage ?? { prompt_tokens: 0, completion_tokens: 0 };
+  return { parsed, usage };
+}
+
+function computeCost(modelKey: string, usage: { prompt_tokens?: number; completion_tokens?: number }) {
+  const price = PRICE_LOOKUP[modelKey] ?? PRICE_LOOKUP['5-mini'];
+  const promptTokens = usage.prompt_tokens ?? 0;
+  const completionTokens = usage.completion_tokens ?? 0;
+  const inCost = (promptTokens / 1_000_000) * price.in;
+  const outCost = (completionTokens / 1_000_000) * price.out;
+  return {
+    cost: inCost + outCost,
+    promptTokens,
+    completionTokens
+  };
+}
+
+function extractSummary(answer: JsonRecord) {
+  const verdict = answer?.verdict as JsonRecord | undefined;
+  if (verdict && typeof verdict.summary === 'string' && verdict.summary.trim()) {
+    return verdict.summary.trim();
+  }
+
+  const nextSteps = Array.isArray(answer?.next_steps) ? answer?.next_steps : [];
+  if (nextSteps.length) {
+    return String(nextSteps[0]);
+  }
+
+  const scores = answer?.scores as JsonRecord | undefined;
+  if (scores && typeof scores === 'object') {
+    for (const [key, value] of Object.entries(scores)) {
+      if (value && typeof (value as JsonRecord).rationale === 'string' && (value as JsonRecord).rationale.trim()) {
+        return `${key}: ${(value as JsonRecord).rationale}`;
+      }
+    }
+  }
+
+  return '—';
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const openaiKey = Deno.env.get('OPENAI_API_KEY');
+
+  if (!supabaseUrl || !serviceRoleKey || !openaiKey) {
+    console.error('Missing required environment configuration for stage2-consume');
+    return jsonResponse(500, { error: 'Server misconfigured' });
+  }
+
+  let payload: any;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error('Invalid JSON payload', error);
+    return jsonResponse(400, { error: 'Invalid JSON payload' });
+  }
+
+  const limit = clamp(asNumber(payload?.limit, 4), 1, 15);
+  const requestedRunId = typeof payload?.run_id === 'string' ? payload.run_id.trim() : '';
+  const runId = isUuid(requestedRunId) ? requestedRunId : null;
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+  const accessToken = tokenMatch?.[1]?.trim();
+  if (!accessToken) {
+    return jsonResponse(401, { error: 'Missing bearer token' });
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, { auth: { persistSession: false } });
+
+  const { data: userData, error: userError } = await supabaseAdmin.auth.getUser(accessToken);
+  if (userError || !userData?.user) {
+    console.error('Invalid session token', userError);
+    return jsonResponse(401, { error: 'Invalid or expired session token' });
+  }
+
+  const [profileResult, membershipResult] = await Promise.all([
+    supabaseAdmin.from('profiles').select('*').eq('id', userData.user.id).maybeSingle(),
+    supabaseAdmin.from('memberships').select('*').eq('user_id', userData.user.id).maybeSingle()
+  ]);
+
+  if (profileResult.error) {
+    console.error('Failed to load profile', profileResult.error);
+  }
+  if (membershipResult.error) {
+    console.error('Failed to load membership', membershipResult.error);
+  }
+
+  const context = {
+    user: userData.user as JsonRecord,
+    profile: (profileResult.data ?? null) as JsonRecord | null,
+    membership: (membershipResult.data ?? null) as JsonRecord | null
+  };
+
+  if (!isAdminContext(context)) {
+    return jsonResponse(403, { error: 'Admin access required' });
+  }
+
+  let runRow;
+  if (runId) {
+    const { data, error } = await supabaseAdmin
+      .from('runs')
+      .select('id, status, stop_requested, notes')
+      .eq('id', runId)
+      .maybeSingle();
+    if (error) {
+      console.error('Failed to load run', error);
+      return jsonResponse(500, { error: 'Failed to load run', details: error.message });
+    }
+    runRow = data;
+  } else {
+    const { data, error } = await supabaseAdmin
+      .from('runs')
+      .select('id, status, stop_requested, notes')
+      .in('status', ['running', 'queued'])
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) {
+      console.error('Failed to select latest run', error);
+      return jsonResponse(500, { error: 'Failed to select latest run', details: error.message });
+    }
+    runRow = data;
+  }
+
+  if (!runRow) {
+    return jsonResponse(404, { error: 'Run not found' });
+  }
+
+  if (runRow.stop_requested) {
+    const metrics = await computeMetrics(supabaseAdmin, runRow.id);
+    return jsonResponse(409, {
+      error: 'Run flagged to stop',
+      run_id: runRow.id,
+      metrics
+    });
+  }
+
+  const modelKeyRaw = ((): string => {
+    try {
+      const notes = typeof runRow.notes === 'string' ? JSON.parse(runRow.notes) : runRow.notes;
+      return notes?.planner?.stage2?.model ?? '5-mini';
+    } catch {
+      return '5-mini';
+    }
+  })();
+
+  const modelKey = PRICE_LOOKUP[modelKeyRaw] ? modelKeyRaw : '5-mini';
+  const openaiModel = MODEL_ALIASES[modelKey] ?? MODEL_ALIASES['5-mini'];
+
+  const { data: pending, error: pendingError } = await survivorFilter(
+    supabaseAdmin
+      .from('run_items')
+      .select('ticker, label, spend_est_usd')
+      .eq('run_id', runRow.id)
+      .eq('status', 'ok')
+      .eq('stage', 1)
+      .order('updated_at', { ascending: true })
+  ).limit(limit);
+
+  if (pendingError) {
+    console.error('Failed to load Stage 2 candidates', pendingError);
+    return jsonResponse(500, { error: 'Failed to load Stage 2 candidates', details: pendingError.message });
+  }
+
+  const items = pending ?? [];
+  if (!items.length) {
+    const metrics = await computeMetrics(supabaseAdmin, runRow.id);
+    const message = metrics.pending === 0
+      ? 'Stage 2 complete or no survivors available.'
+      : 'No eligible Stage 2 survivors pending.';
+    return jsonResponse(200, {
+      run_id: runRow.id,
+      processed: 0,
+      failed: 0,
+      metrics,
+      results: [],
+      model: modelKey,
+      message
+    });
+  }
+
+  const results: Stage2Result[] = [];
+  let processed = 0;
+  let failures = 0;
+
+  for (const item of items) {
+    const ticker = item.ticker as string;
+    const startedAt = new Date().toISOString();
+
+    try {
+      const meta = await fetchTickerMeta(supabaseAdmin, ticker);
+      const sector = typeof meta?.sector === 'string' ? (meta.sector as string) : null;
+      const sectorNotes = await fetchSectorNotes(supabaseAdmin, sector);
+      const stage1Answer = await fetchStage1Answer(supabaseAdmin, runRow.id, ticker);
+
+      if (!SURVIVOR_LABELS.has(normalizeLabel(item.label))) {
+        results.push({
+          ticker,
+          go_deep: false,
+          summary: 'Ticker no longer qualifies for Stage 2.',
+          updated_at: startedAt,
+          status: 'failed'
+        });
+        await supabaseAdmin
+          .from('run_items')
+          .update({ stage: 1, status: 'failed', updated_at: new Date().toISOString() })
+          .eq('run_id', runRow.id)
+          .eq('ticker', ticker);
+        failures += 1;
+        continue;
+      }
+
+      const { parsed, usage } = await callOpenAI(openaiKey, openaiModel, ticker, meta, stage1Answer, sectorNotes);
+      const { cost, promptTokens, completionTokens } = computeCost(modelKey, usage);
+      const verdict = (parsed?.verdict ?? null) as JsonRecord | null;
+      const goDeep = Boolean(verdict?.go_deep);
+
+      await supabaseAdmin.from('answers').insert({
+        run_id: runRow.id,
+        ticker,
+        stage: 2,
+        question_group: 'medium',
+        answer_json: parsed,
+        tokens_in: promptTokens,
+        tokens_out: completionTokens,
+        cost_usd: cost,
+        created_at: startedAt
+      });
+
+      await supabaseAdmin
+        .from('run_items')
+        .update({
+          stage: 2,
+          status: 'ok',
+          stage2_go_deep: goDeep,
+          spend_est_usd: Number(item.spend_est_usd ?? 0) + cost,
+          updated_at: new Date().toISOString()
+        })
+        .eq('run_id', runRow.id)
+        .eq('ticker', ticker);
+
+      await supabaseAdmin.from('cost_ledger').insert({
+        run_id: runRow.id,
+        stage: 2,
+        model: modelKey,
+        tokens_in: promptTokens,
+        tokens_out: completionTokens,
+        cost_usd: cost,
+        created_at: startedAt
+      });
+
+      results.push({
+        ticker,
+        go_deep: goDeep,
+        summary: extractSummary(parsed),
+        updated_at: startedAt,
+        status: 'ok'
+      });
+      processed += 1;
+    } catch (error) {
+      console.error(`Stage 2 processing failed for ${ticker}`, error);
+      failures += 1;
+      const message = error instanceof Error ? error.message : String(error);
+
+      await supabaseAdmin
+        .from('run_items')
+        .update({ stage: 2, status: 'failed', stage2_go_deep: null, updated_at: new Date().toISOString() })
+        .eq('run_id', runRow.id)
+        .eq('ticker', ticker);
+
+      results.push({
+        ticker,
+        go_deep: false,
+        summary: message,
+        updated_at: startedAt,
+        status: 'failed'
+      });
+    }
+  }
+
+  const metrics = await computeMetrics(supabaseAdmin, runRow.id);
+  const message = processed > 0
+    ? `Processed ${processed} ticker${processed === 1 ? '' : 's'}. Pending survivors: ${metrics.pending}.`
+    : 'No tickers processed.';
+
+  return jsonResponse(200, {
+    run_id: runRow.id,
+    processed,
+    failed: failures,
+    metrics,
+    results,
+    model: modelKey,
+    message
+  });
+});

--- a/supabase/functions/stage3-consume/index.ts
+++ b/supabase/functions/stage3-consume/index.ts
@@ -1,0 +1,648 @@
+import { serve } from 'https://deno.land/std@0.210.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4';
+
+type JsonRecord = Record<string, unknown>;
+
+type Stage3Result = {
+  ticker: string;
+  verdict: string | null;
+  summary: string;
+  updated_at: string;
+  status: 'ok' | 'failed';
+};
+
+type Stage3Metrics = {
+  finalists: number;
+  pending: number;
+  completed: number;
+  failed: number;
+  spend?: number;
+};
+
+type DocChunk = {
+  source: string | null;
+  chunk: string | null;
+};
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS'
+};
+
+const jsonHeaders = {
+  ...corsHeaders,
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store'
+};
+
+const MODEL_ALIASES: Record<string, string> = {
+  '4o-mini': 'gpt-4o-mini',
+  '5-mini': 'gpt-5-mini',
+  '5': 'gpt-5-preview'
+};
+
+const PRICE_LOOKUP: Record<string, { in: number; out: number }> = {
+  '4o-mini': { in: 0.15, out: 0.6 },
+  '5-mini': { in: 0.25, out: 2.0 },
+  '5': { in: 1.25, out: 10.0 }
+};
+
+function jsonResponse(status: number, body: JsonRecord) {
+  return new Response(JSON.stringify(body), { status, headers: jsonHeaders });
+}
+
+function clamp(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function asNumber(value: unknown, fallback: number) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function isUuid(value: unknown) {
+  if (typeof value !== 'string') return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value.trim());
+}
+
+function collectRoles(source: unknown, bucket: Set<string>) {
+  if (!source) return;
+  if (Array.isArray(source)) {
+    source.forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  if (typeof source === 'object') {
+    Object.values(source as Record<string, unknown>).forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  const parts = String(source)
+    .split(/[\s,]+/)
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+  parts.forEach((role) => bucket.add(role));
+}
+
+function hasAdminMarker(record: Record<string, unknown> | null | undefined) {
+  if (!record) return false;
+  const flagKeys = ['is_admin', 'admin', 'isAdmin', 'is_superadmin', 'superuser', 'staff', 'is_staff'];
+  return flagKeys.some((key) => Boolean((record as Record<string, unknown>)[key]));
+}
+
+function isAdminContext(context: { user: JsonRecord | null; profile: JsonRecord | null; membership: JsonRecord | null }) {
+  const { user, profile, membership } = context;
+  if (hasAdminMarker(profile) || hasAdminMarker(membership) || hasAdminMarker(user ?? undefined)) {
+    return true;
+  }
+
+  const bucket = new Set<string>();
+  collectRoles(profile?.role, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_name, bucket);
+  collectRoles((profile as JsonRecord | null)?.user_role, bucket);
+  collectRoles((profile as JsonRecord | null)?.roles, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_tags, bucket);
+  collectRoles((profile as JsonRecord | null)?.access_level, bucket);
+
+  collectRoles(user?.app_metadata, bucket);
+  collectRoles(user?.user_metadata, bucket);
+
+  collectRoles(membership?.role, bucket);
+  collectRoles(membership?.roles, bucket);
+  collectRoles(membership?.access_level, bucket);
+
+  const privileged = new Set(['admin', 'administrator', 'superadmin', 'owner', 'editor', 'staff']);
+  for (const role of bucket) {
+    if (privileged.has(role)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function computeMetrics(client: ReturnType<typeof createClient>, runId: string): Promise<Stage3Metrics> {
+  const { data, error } = await client.rpc('run_stage3_summary', { p_run_id: runId }).maybeSingle();
+  if (error) throw error;
+  return {
+    finalists: Number(data?.total_finalists ?? data?.finalists ?? 0),
+    pending: Number(data?.pending ?? 0),
+    completed: Number(data?.completed ?? 0),
+    failed: Number(data?.failed ?? 0)
+  };
+}
+
+async function fetchTickerMeta(client: ReturnType<typeof createClient>, ticker: string) {
+  const { data } = await client
+    .from('tickers')
+    .select('name, exchange, country, sector, industry')
+    .eq('ticker', ticker)
+    .maybeSingle();
+  return data ?? {};
+}
+
+async function fetchStageAnswer(
+  client: ReturnType<typeof createClient>,
+  runId: string,
+  ticker: string,
+  stage: number
+): Promise<JsonRecord | null> {
+  const { data } = await client
+    .from('answers')
+    .select('answer_json')
+    .eq('run_id', runId)
+    .eq('ticker', ticker)
+    .eq('stage', stage)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return (data?.answer_json ?? null) as JsonRecord | null;
+}
+
+async function fetchDocChunks(client: ReturnType<typeof createClient>, ticker: string, limit = 6) {
+  const { data, error } = await client
+    .from('doc_chunks')
+    .select('source, chunk')
+    .eq('ticker', ticker)
+    .order('id', { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return (data ?? []) as DocChunk[];
+}
+
+function formatStage1Summary(answer: JsonRecord | null) {
+  if (!answer) return 'Stage 1 output unavailable.';
+  const label = answer.label ?? answer.classification;
+  const reasons = Array.isArray(answer.reasons) ? answer.reasons : [];
+  const formattedReasons = reasons
+    .slice(0, 4)
+    .map((reason: unknown, index: number) => `${index + 1}. ${String(reason)}`)
+    .join('\n');
+  return `Stage 1 label: ${label ?? 'n/a'}\n${formattedReasons ? `Key reasons:\n${formattedReasons}` : ''}`.trim();
+}
+
+function formatStage2Summary(answer: JsonRecord | null) {
+  if (!answer) return 'Stage 2 verdict unavailable.';
+  const verdict = (answer.verdict as JsonRecord | undefined) ?? {};
+  const scores = (answer.scores as JsonRecord | undefined) ?? {};
+  const lines: string[] = [];
+  if (typeof verdict.summary === 'string' && verdict.summary.trim()) {
+    lines.push(`Verdict: ${verdict.summary.trim()}`);
+  }
+  if (typeof verdict.go_deep !== 'undefined') {
+    const goDeep = typeof verdict.go_deep === 'boolean' ? verdict.go_deep : String(verdict.go_deep).toLowerCase() === 'true';
+    lines.push(`Go deep: ${goDeep ? 'yes' : 'no'}`);
+  }
+  for (const [key, value] of Object.entries(scores)) {
+    if (!value || typeof value !== 'object') continue;
+    const score = (value as JsonRecord).score;
+    const rationale = (value as JsonRecord).rationale;
+    if (typeof score !== 'undefined' || typeof rationale === 'string') {
+      lines.push(`${key}: ${typeof score === 'number' ? `${score}/10` : 'n/a'} – ${rationale ?? 'n/a'}`);
+    }
+  }
+  return lines.length ? lines.join('\n') : 'Stage 2 scores unavailable.';
+}
+
+function formatDocSnippets(chunks: DocChunk[]) {
+  if (!chunks.length) return 'No external excerpts supplied.';
+  return chunks
+    .map((chunk, index) => {
+      const source = chunk.source ? String(chunk.source) : 'Unknown source';
+      const text = (chunk.chunk ?? '').toString().slice(0, 800);
+      return `Snippet ${index + 1} — ${source}:\n${text}`;
+    })
+    .join('\n---\n');
+}
+
+function buildGroupPrompts(context: {
+  ticker: string;
+  meta: Record<string, unknown>;
+  stage1: string;
+  stage2: string;
+  docs: string;
+}) {
+  const header = [
+    `Ticker: ${context.ticker}`,
+    `Name: ${context.meta.name ?? 'Unknown'}`,
+    `Exchange: ${context.meta.exchange ?? 'n/a'}`,
+    `Country: ${context.meta.country ?? 'n/a'}`,
+    `Sector: ${context.meta.sector ?? 'n/a'}`,
+    `Industry: ${context.meta.industry ?? 'n/a'}`,
+    '',
+    context.stage1,
+    '',
+    context.stage2,
+    '',
+    `Document excerpts:`,
+    context.docs
+  ].join('\n');
+
+  return [
+    {
+      key: 'business',
+      system:
+        'You are a buy-side equity analyst. Return strict JSON matching {"business_model": string, "moat": {"score": int, "rationale": string}, "customer_lock_in": string, "growth_drivers": [string]}.' +
+        ' Scores must be 0-10. Keep rationales under 160 characters and ground commentary in supplied facts.',
+      user: `${header}\n\nFocus: describe the business model, moat durability, customer lock-in dynamics, and near-term growth drivers.`
+    },
+    {
+      key: 'financials',
+      system:
+        'You are evaluating unit economics and capital allocation. Return JSON {"unit_economics": {"score": int, "rationale": string}, "capital_allocation": {"score": int, "rationale": string}, "balance_sheet": {"score": int, "rationale": string}, "kpis": [string]}.' +
+        ' Scores must be 0-10. Summaries must be concise and factual.',
+      user: `${header}\n\nFocus: comment on unit economics resilience, capital allocation discipline, balance sheet flexibility, and standout KPIs.`
+    },
+    {
+      key: 'risks',
+      system:
+        'You are cataloguing risk and timing. Return JSON {"principal_risks": [string], "catalysts": [string], "timing_window": string, "monitoring_flags": [string]}.' +
+        ' Keep lists to a maximum of 5 items and ensure each item is specific.',
+      user: `${header}\n\nFocus: enumerate principal risks, catalysts, the likely timing window (e.g., 3-6 months) and monitoring flags for follow-up.`
+    }
+  ];
+}
+
+function buildSummaryPrompt(
+  context: { ticker: string; meta: Record<string, unknown>; stage1: string; stage2: string; docs: string },
+  groupOutputs: JsonRecord[]
+) {
+  const base = [
+    `Ticker: ${context.ticker}`,
+    `Name: ${context.meta.name ?? 'Unknown'}`,
+    '',
+    context.stage1,
+    '',
+    context.stage2,
+    '',
+    'Deep dive findings:',
+    JSON.stringify(groupOutputs)
+  ].join('\n');
+
+  return {
+    system:
+      'You are preparing an investment memo. Return JSON {"verdict": string, "confidence": int, "thesis": string, "watch_items": [string], "next_actions": [string]}.' +
+      ' Confidence must be 0-100. Thesis should be < 200 words and evidence-backed. Watch items/next actions max 5 each.',
+    user: `${base}\n\nCompose the final verdict, conviction score, thesis paragraph, key watch items, and next actions.`
+  };
+}
+
+async function callOpenAIJson(
+  apiKey: string,
+  model: string,
+  systemPrompt: string,
+  userPrompt: string
+): Promise<{ parsed: JsonRecord; usage: { prompt_tokens?: number; completion_tokens?: number } }> {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0.1,
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt }
+      ]
+    })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`OpenAI error ${response.status}: ${text}`);
+  }
+
+  const payload = await response.json();
+  const message = payload?.choices?.[0]?.message?.content ?? '{}';
+  let parsed: JsonRecord;
+  try {
+    parsed = JSON.parse(message);
+  } catch (error) {
+    throw new Error(`Failed to parse OpenAI JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  return { parsed, usage: payload?.usage ?? { prompt_tokens: 0, completion_tokens: 0 } };
+}
+
+function computeCost(modelKey: string, usage: { prompt_tokens?: number; completion_tokens?: number }) {
+  const price = PRICE_LOOKUP[modelKey] ?? PRICE_LOOKUP['5'];
+  const promptTokens = usage.prompt_tokens ?? 0;
+  const completionTokens = usage.completion_tokens ?? 0;
+  const inCost = (promptTokens / 1_000_000) * price.in;
+  const outCost = (completionTokens / 1_000_000) * price.out;
+  return {
+    cost: inCost + outCost,
+    promptTokens,
+    completionTokens
+  };
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+  const openaiKey = Deno.env.get('OPENAI_API_KEY');
+
+  if (!supabaseUrl || !serviceRoleKey || !openaiKey) {
+    console.error('Missing required environment configuration for stage3-consume');
+    return jsonResponse(500, { error: 'Server misconfigured' });
+  }
+
+  let payload: any;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error('Invalid JSON payload', error);
+    return jsonResponse(400, { error: 'Invalid JSON payload' });
+  }
+
+  const limit = clamp(asNumber(payload?.limit, 2), 1, 6);
+  const requestedRunId = typeof payload?.run_id === 'string' ? payload.run_id.trim() : '';
+  const runId = isUuid(requestedRunId) ? requestedRunId : null;
+  if (!runId) {
+    return jsonResponse(400, { error: 'Invalid or missing run_id' });
+  }
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+  const accessToken = tokenMatch?.[1]?.trim();
+  if (!accessToken) {
+    return jsonResponse(401, { error: 'Missing bearer token' });
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, { auth: { persistSession: false } });
+
+  const { data: userData, error: userError } = await supabaseAdmin.auth.getUser(accessToken);
+  if (userError || !userData?.user) {
+    console.error('Invalid session token', userError);
+    return jsonResponse(401, { error: 'Invalid or expired session token' });
+  }
+
+  const [profileResult, membershipResult] = await Promise.all([
+    supabaseAdmin.from('profiles').select('*').eq('id', userData.user.id).maybeSingle(),
+    supabaseAdmin.from('memberships').select('*').eq('user_id', userData.user.id).maybeSingle()
+  ]);
+
+  if (profileResult.error) {
+    console.error('Failed to load profile', profileResult.error);
+  }
+  if (membershipResult.error) {
+    console.error('Failed to load membership', membershipResult.error);
+  }
+
+  const isAdmin = isAdminContext({
+    user: userData.user,
+    profile: profileResult.data ?? null,
+    membership: membershipResult.data ?? null
+  });
+
+  if (!isAdmin) {
+    return jsonResponse(403, { error: 'Admin privileges required' });
+  }
+
+  const { data: runRow, error: runError } = await supabaseAdmin
+    .from('runs')
+    .select('id, status, stop_requested, notes')
+    .eq('id', runId)
+    .maybeSingle();
+
+  if (runError) {
+    console.error('Failed to load run', runError);
+    return jsonResponse(500, { error: 'Failed to load run' });
+  }
+  if (!runRow) {
+    return jsonResponse(404, { error: 'Run not found' });
+  }
+
+  if (runRow.stop_requested) {
+    const metrics = await computeMetrics(supabaseAdmin, runRow.id);
+    return jsonResponse(409, {
+      error: 'Run flagged to stop',
+      run_id: runRow.id,
+      metrics
+    });
+  }
+
+  const modelKeyRaw = ((): string => {
+    try {
+      const notes = typeof runRow.notes === 'string' ? JSON.parse(runRow.notes) : runRow.notes;
+      return notes?.planner?.stage3?.model ?? '5';
+    } catch {
+      return '5';
+    }
+  })();
+
+  const modelKey = PRICE_LOOKUP[modelKeyRaw] ? modelKeyRaw : '5';
+  const openaiModel = MODEL_ALIASES[modelKey] ?? MODEL_ALIASES['5'];
+
+  const { data: pending, error: pendingError } = await supabaseAdmin
+    .from('run_items')
+    .select('ticker, stage, status, spend_est_usd')
+    .eq('run_id', runRow.id)
+    .eq('status', 'ok')
+    .eq('stage2_go_deep', true)
+    .lt('stage', 3)
+    .order('updated_at', { ascending: true })
+    .limit(limit);
+
+  if (pendingError) {
+    console.error('Failed to load Stage 3 finalists', pendingError);
+    return jsonResponse(500, { error: 'Failed to load Stage 3 finalists', details: pendingError.message });
+  }
+
+  const items = pending ?? [];
+  if (!items.length) {
+    const metrics = await computeMetrics(supabaseAdmin, runRow.id);
+    const message = metrics.pending === 0
+      ? 'Stage 3 complete or no finalists marked go-deep.'
+      : 'No eligible Stage 3 finalists pending.';
+    return jsonResponse(200, {
+      run_id: runRow.id,
+      processed: 0,
+      failed: 0,
+      model: modelKey,
+      metrics,
+      results: [],
+      message
+    });
+  }
+
+  const results: Stage3Result[] = [];
+  let processed = 0;
+  let failures = 0;
+
+  for (const item of items) {
+    const ticker = item.ticker;
+    const startedAt = new Date().toISOString();
+
+    try {
+      const [meta, stage1Answer, stage2Answer, docChunks] = await Promise.all([
+        fetchTickerMeta(supabaseAdmin, ticker),
+        fetchStageAnswer(supabaseAdmin, runRow.id, ticker, 1),
+        fetchStageAnswer(supabaseAdmin, runRow.id, ticker, 2),
+        fetchDocChunks(supabaseAdmin, ticker)
+      ]);
+
+      const context = {
+        ticker,
+        meta,
+        stage1: formatStage1Summary(stage1Answer),
+        stage2: formatStage2Summary(stage2Answer),
+        docs: formatDocSnippets(docChunks)
+      };
+
+      const prompts = buildGroupPrompts(context);
+      const groupOutputs: JsonRecord[] = [];
+      let totalCost = 0;
+
+      for (const prompt of prompts) {
+        const { parsed, usage } = await callOpenAIJson(openaiKey, openaiModel, prompt.system, prompt.user);
+        const { cost, promptTokens, completionTokens } = computeCost(modelKey, usage);
+        totalCost += cost;
+
+        await supabaseAdmin.from('answers').insert({
+          run_id: runRow.id,
+          ticker,
+          stage: 3,
+          question_group: prompt.key,
+          answer_json: parsed,
+          tokens_in: promptTokens,
+          tokens_out: completionTokens,
+          cost_usd: cost,
+          created_at: startedAt
+        });
+
+        await supabaseAdmin.from('cost_ledger').insert({
+          run_id: runRow.id,
+          stage: 3,
+          model: modelKey,
+          tokens_in: promptTokens,
+          tokens_out: completionTokens,
+          cost_usd: cost,
+          created_at: startedAt
+        });
+
+        groupOutputs.push({ key: prompt.key, data: parsed });
+      }
+
+      const summaryPrompt = buildSummaryPrompt(context, groupOutputs);
+      const { parsed: summaryJson, usage: summaryUsage } = await callOpenAIJson(
+        openaiKey,
+        openaiModel,
+        summaryPrompt.system,
+        summaryPrompt.user
+      );
+      const { cost: summaryCost, promptTokens: summaryPromptTokens, completionTokens: summaryCompletionTokens } = computeCost(
+        modelKey,
+        summaryUsage
+      );
+      totalCost += summaryCost;
+
+      const thesisText =
+        typeof summaryJson.thesis === 'string'
+          ? summaryJson.thesis
+          : typeof summaryJson.narrative === 'string'
+            ? summaryJson.narrative
+            : null;
+
+      await supabaseAdmin.from('answers').insert({
+        run_id: runRow.id,
+        ticker,
+        stage: 3,
+        question_group: 'summary',
+        answer_json: summaryJson,
+        answer_text: thesisText,
+        tokens_in: summaryPromptTokens,
+        tokens_out: summaryCompletionTokens,
+        cost_usd: summaryCost,
+        created_at: startedAt
+      });
+
+      await supabaseAdmin.from('cost_ledger').insert({
+        run_id: runRow.id,
+        stage: 3,
+        model: modelKey,
+        tokens_in: summaryPromptTokens,
+        tokens_out: summaryCompletionTokens,
+        cost_usd: summaryCost,
+        created_at: startedAt
+      });
+
+      await supabaseAdmin
+        .from('run_items')
+        .update({
+          stage: 3,
+          status: 'ok',
+          spend_est_usd: Number(item.spend_est_usd ?? 0) + totalCost,
+          updated_at: new Date().toISOString()
+        })
+        .eq('run_id', runRow.id)
+        .eq('ticker', ticker);
+
+      results.push({
+        ticker,
+        verdict: typeof summaryJson.verdict === 'string' ? summaryJson.verdict : summaryJson.rating?.toString() ?? null,
+        summary: thesisText ?? (typeof summaryJson.summary === 'string' ? summaryJson.summary : '—'),
+        updated_at: startedAt,
+        status: 'ok'
+      });
+      processed += 1;
+    } catch (error) {
+      console.error(`Stage 3 processing failed for ${ticker}`, error);
+      failures += 1;
+      const message = error instanceof Error ? error.message : String(error);
+
+      await supabaseAdmin
+        .from('run_items')
+        .update({ stage: 3, status: 'failed', updated_at: new Date().toISOString() })
+        .eq('run_id', runRow.id)
+        .eq('ticker', ticker);
+
+      results.push({
+        ticker,
+        verdict: null,
+        summary: message,
+        updated_at: new Date().toISOString(),
+        status: 'failed'
+      });
+    }
+  }
+
+  const metrics = await computeMetrics(supabaseAdmin, runRow.id);
+  let spend = 0;
+  try {
+    const { data: breakdown } = await supabaseAdmin.rpc('run_cost_breakdown', { p_run_id: runRow.id });
+    if (Array.isArray(breakdown)) {
+      spend = breakdown
+        .filter((row: any) => Number(row.stage) === 3)
+        .reduce((acc: number, row: any) => acc + Number(row.cost_usd ?? 0), 0);
+    }
+  } catch (error) {
+    console.error('Failed to compute Stage 3 spend', error);
+  }
+  const metricsWithSpend: Stage3Metrics = { ...metrics, spend };
+
+  const message = processed > 0
+    ? `Processed ${processed} finalist${processed === 1 ? '' : 's'}. Pending deep dives: ${metrics.pending}.`
+    : 'No finalists processed.';
+
+  return jsonResponse(200, {
+    run_id: runRow.id,
+    processed,
+    failed: failures,
+    model: modelKey,
+    metrics: metricsWithSpend,
+    results,
+    message
+  });
+});

--- a/ticker.html
+++ b/ticker.html
@@ -1,0 +1,273 @@
+<!doctype html>
+<html lang="en" data-lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>FutureFunds — Ticker Deep Dive</title>
+<link rel="stylesheet" href="/assets/styles.css"/>
+<style>
+  :root {
+    --panel-bg: var(--panel, #ffffff);
+    --panel-border: var(--border, #e2e8f0);
+    --panel-shadow: var(--shadow, 0 12px 30px rgba(15, 23, 42, 0.08));
+  }
+
+  .wrap { max-width: 1100px; margin: 32px auto; padding: 0 18px; }
+  .hero { padding: 32px 0 12px; margin-top: 18px; }
+  .hero h1 { margin: 0 0 12px; font-size: clamp(2rem, 4vw, 2.6rem); }
+  .hero p { margin: 0; color: var(--muted, #64748b); max-width: 720px; }
+
+  .gate { border: 1px solid var(--panel-border); border-radius: 18px; padding: 32px; background: var(--panel-bg); text-align: center; box-shadow: var(--panel-shadow); }
+  .gate h2 { margin: 0 0 12px; }
+  .gate p { margin: 0 0 16px; color: var(--muted, #64748b); }
+  .gate .actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+
+  .context-card { background: var(--panel-bg); border: 1px solid var(--panel-border); border-radius: 18px; padding: 24px; box-shadow: var(--panel-shadow); display: grid; gap: 18px; }
+  .context-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; }
+  .context-metric { display: grid; gap: 4px; }
+  .context-label { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted, #64748b); }
+  .context-value { font-size: 1.1rem; font-weight: 600; }
+  .controls-row { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
+  .controls-row select { min-width: 220px; padding: 10px 14px; border-radius: 12px; border: 1px solid var(--panel-border); background: var(--bg, #f8fafc); font-size: 0.95rem; }
+  .controls-row button { padding: 10px 16px; border-radius: 999px; border: 1px solid var(--panel-border); background: var(--panel-bg); cursor: pointer; font-size: 0.9rem; }
+  .controls-row button.primary { background: var(--accent, #2563eb); border-color: var(--accent, #2563eb); color: #fff; }
+
+  .panel { background: var(--panel-bg); border: 1px solid var(--panel-border); border-radius: 18px; padding: 24px; box-shadow: var(--panel-shadow); display: grid; gap: 16px; }
+  .panel h2 { margin: 0; font-size: 1.4rem; }
+  .panel h3 { margin: 16px 0 8px; font-size: 1rem; }
+  .panel p { margin: 0; line-height: 1.5; }
+  .pill { display: inline-flex; align-items: center; gap: 6px; border-radius: 999px; padding: 4px 12px; background: color-mix(in srgb, var(--accent, #2563eb) 12%, var(--panel-bg) 88%); color: var(--accent-contrast, #0f172a); font-size: 0.8rem; font-weight: 600; }
+  .badge { font-size: 0.75rem; letter-spacing: 0.06em; text-transform: uppercase; border-radius: 999px; padding: 4px 10px; border: 1px solid currentColor; display: inline-flex; align-items: center; gap: 6px; }
+  .badge.pending { color: #0ea5e9; }
+  .badge.ok { color: #16a34a; }
+  .badge.failed { color: #dc2626; }
+
+  .list { display: grid; gap: 8px; }
+  .list li { margin-left: 18px; }
+
+  .group-card { border: 1px solid var(--panel-border); border-radius: 14px; padding: 16px; background: color-mix(in srgb, var(--panel-bg) 88%, var(--bg, #f8fafc) 12%); display: grid; gap: 8px; }
+  .group-card h4 { margin: 0; font-size: 1rem; }
+  .group-card pre { margin: 0; padding: 12px; background: var(--bg, #f1f5f9); border-radius: 12px; overflow: auto; font-size: 0.85rem; }
+
+  .muted { color: var(--muted, #64748b); }
+
+  .layout { display: grid; gap: 24px; }
+
+  @media (max-width: 780px) {
+    .controls-row { flex-direction: column; align-items: stretch; }
+    .controls-row select, .controls-row button { width: 100%; }
+  }
+</style>
+</head>
+<body>
+<header class="site-header">
+  <a class="brand" href="/">
+    <img src="/images/logo.webp" alt="FutureFunds.ai logo" class="logo" />
+    <span>FutureFunds.ai</span>
+  </a>
+  <button class="nav-toggle" id="navToggle" type="button" aria-expanded="false" aria-controls="siteNav">
+    <span class="sr-only">Menu</span>
+    <span class="nav-toggle__bar"></span>
+  </button>
+  <nav class="nav" id="siteNav" aria-label="Primary navigation">
+    <div class="nav-links">
+      <div class="nav-item nav-item--team">
+        <a href="/team.html" class="nav-link" data-i18n="nav.team">Experiment</a>
+      </div>
+      <div class="nav-item nav-item--has-panel nav-item--tools">
+        <a href="/tools.html" class="nav-link" data-i18n="nav.investmentTools">Investment Tools</a>
+        <div class="nav-panel nav-panel--tools" role="group" aria-label="Investment tools">
+          <div class="nav-panel__header">
+            <span class="nav-panel__title">Featured tools</span>
+            <a class="nav-panel__cta" href="/tools.html">Explore tools →</a>
+          </div>
+          <div class="nav-panel__content nav-panel__content--tools">
+            <a class="nav-tool" href="/tool.html?id=ff-pms">
+              <span class="chip membership">Member</span>
+              <h4>Portfolio OS</h4>
+              <p>Run strategies end-to-end with sheets + AI copilots.</p>
+            </a>
+            <a class="nav-tool" href="/tool.html?id=stockalpha-journal">
+              <span class="chip free">Free</span>
+              <h4>StockAlpha Journal</h4>
+              <p>Track theses, catalysts, and behavioral loops.</p>
+            </a>
+            <a class="nav-tool" href="/tool.html?id=valuebot">
+              <span class="chip paid">Paid</span>
+              <h4>ValueBot Valuation</h4>
+              <p>Get sourced, step-by-step valuations on demand.</p>
+            </a>
+          </div>
+        </div>
+      </div>
+      <div class="nav-item nav-item--has-panel nav-item--ai">
+        <a href="/ai-economy.html" class="nav-link" data-i18n="nav.aiEconomy">The AI Economy</a>
+        <div class="nav-panel nav-panel--ai" role="group" aria-label="AI economy preview">
+          <div class="nav-panel__header">
+            <span class="nav-panel__title">AI economy brief</span>
+            <a class="nav-panel__cta" href="/ai-economy.html">Dive in →</a>
+          </div>
+          <div class="nav-ai">
+            <p class="nav-ai__pitch">Weekly signals on how automation, capital, and policy collide. Built from filings, expert transcripts, and on-chain data.</p>
+            <form class="nav-ai__signup newsletter-form" action="/ai-economy.html#newsletter" method="get">
+              <label class="sr-only" for="nav-ai-email">Email address</label>
+              <input id="nav-ai-email" type="email" name="email" placeholder="you@example.com" autocomplete="email" />
+              <button type="submit" class="btn primary">Get the brief</button>
+              <p class="nav-ai__status newsletter-status muted" aria-live="polite"></p>
+            </form>
+          </div>
+        </div>
+      </div>
+      <a href="/portfolio.html" class="nav-link" data-i18n="nav.portfolios">Portfolios</a>
+      <a href="/universe.html" class="nav-link" data-i18n="nav.universe">Universe</a>
+    </div>
+    <div class="nav-actions">
+      <button id="langBtn" class="btn small">EN ▾</button>
+      <button id="themeToggle" class="btn small ghost theme-toggle" aria-label="Toggle theme">
+        <span class="theme-toggle__icon" aria-hidden="true">🌗</span>
+        <span class="theme-toggle__label" data-i18n="nav.themeToggle">Theme</span>
+      </button>
+      <a id="membershipLogin" class="btn danger" href="/membership.html" data-i18n="cta.membership">Membership</a>
+    </div>
+  </nav>
+</header>
+
+<section class="wrap hero">
+  <h1 id="tickerTitle">Ticker deep dive</h1>
+  <p id="tickerSubtitle" class="muted">Loading report…</p>
+</section>
+
+<main class="wrap layout">
+  <section id="tickerGate" class="gate" hidden>
+    <h2>Members-only dossier</h2>
+    <p>This page surfaces raw Stage 1–3 outputs. Sign in with an analyst account to continue.</p>
+    <div class="actions">
+      <a class="btn primary" href="/login.html">Sign in</a>
+      <a class="btn" href="/membership.html">Request access</a>
+    </div>
+  </section>
+
+  <section id="tickerContent" hidden>
+    <article class="context-card">
+      <div class="controls-row">
+        <label for="runPicker" class="sr-only">Select run</label>
+        <select id="runPicker"></select>
+        <button id="exportJson" type="button">Download JSON</button>
+        <button id="copySummary" type="button" class="primary">Copy thesis</button>
+      </div>
+      <div class="context-grid">
+        <div class="context-metric">
+          <span class="context-label">Status</span>
+          <span class="context-value" id="metaStatus">—</span>
+        </div>
+        <div class="context-metric">
+          <span class="context-label">Stage</span>
+          <span class="context-value" id="metaStage">—</span>
+        </div>
+        <div class="context-metric">
+          <span class="context-label">Stage 1 label</span>
+          <span class="context-value" id="metaLabel">—</span>
+        </div>
+        <div class="context-metric">
+          <span class="context-label">Go-deep</span>
+          <span class="context-value" id="metaGoDeep">—</span>
+        </div>
+        <div class="context-metric">
+          <span class="context-label">Run spend</span>
+          <span class="context-value" id="metaSpend">—</span>
+        </div>
+        <div class="context-metric">
+          <span class="context-label">Last updated</span>
+          <span class="context-value" id="metaUpdated">—</span>
+        </div>
+      </div>
+    </article>
+
+    <article class="panel" id="stage1Panel">
+      <header>
+        <h2>Stage 1 — Triage</h2>
+      </header>
+      <div id="stage1Body">
+        <p class="muted">No triage output captured for this run.</p>
+      </div>
+    </article>
+
+    <article class="panel" id="stage2Panel">
+      <header>
+        <h2>Stage 2 — Thematic scoring</h2>
+      </header>
+      <div id="stage2Scores"></div>
+      <div id="stage2Verdict"></div>
+      <div id="stage2Next"></div>
+    </article>
+
+    <article class="panel" id="stage3Panel">
+      <header>
+        <h2>Stage 3 — Deep dive report</h2>
+      </header>
+      <p id="stage3Summary" class="muted">Deep dive not yet available.</p>
+      <div id="stage3Groups" class="layout"></div>
+    </article>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <div class="footer-inner">
+    <div class="footer-col footer-about">
+      <a class="brand" href="/">
+        <img src="/images/logo.webp" alt="FutureFunds.ai logo" class="logo" />
+        <span>FutureFunds.ai</span>
+      </a>
+      <p class="muted">Researching how AI can run the investment process in public. Educational only.</p>
+    </div>
+
+    <div class="footer-col footer-links">
+      <h3 class="footer-heading">Explore</h3>
+      <ul class="footer-links-list">
+        <li><a href="/team.html">Experiment</a></li>
+        <li><a href="/tools.html">Investment Tools</a></li>
+        <li><a href="/ai-economy.html">The AI Economy</a></li>
+        <li><a href="/portfolio.html">Portfolios</a></li>
+        <li><a href="/blog.html">Commentary</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col footer-links">
+      <h3 class="footer-heading">Legal &amp; Access</h3>
+      <ul class="footer-links-list">
+        <li><a href="/disclaimer.html">Disclaimer &amp; Disclosures</a></li>
+        <li><a href="/membership.html">Membership</a></li>
+        <li><a href="/login.html">Member Login</a></li>
+        <li><a href="/editor.html">Editor (admin)</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col footer-newsletter">
+      <h3 class="footer-heading">Stay in the loop</h3>
+      <p class="muted">Sign up for updates on new research drops and product releases.</p>
+      <form class="newsletter-form" novalidate>
+        <label class="sr-only" for="newsletter-email">Email address</label>
+        <input id="newsletter-email" type="email" name="email" placeholder="you@example.com" autocomplete="email" required />
+        <button type="submit" class="btn primary">Join the list</button>
+      </form>
+      <p class="newsletter-status muted" aria-live="polite"></p>
+    </div>
+  </div>
+
+  <div class="footer-bottom">
+    <small>© <span id="year"></span> FutureFunds.ai. Educational experiment. Not investment advice.</small>
+    <div class="footer-legal">
+      <a href="/disclaimer.html">Disclaimer</a>
+      <a href="/sitemap.xml">Sitemap</a>
+      <a href="/editor.html">Editor</a>
+    </div>
+  </div>
+</footer>
+
+<script src="/assets/app.js" defer></script>
+<script src="/assets/i18n.js" defer></script>
+<script src="/assets/paywall.js" defer></script>
+<script type="module" src="/assets/auth.js"></script>
+<script type="module" src="/assets/ticker.js"></script>
+</body>
+</html>

--- a/universe.html
+++ b/universe.html
@@ -3,70 +3,90 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>FutureFunds — Universe</title>
+<title>FutureFunds — Analyst Universe</title>
 
-<!-- Site styles -->
 <link rel="stylesheet" href="/assets/styles.css"/>
 
 <style>
-  /* Page-local styles (keeps your global tokens) */
-  .wrap{max-width:1200px;margin:32px auto;padding:0 16px}
-  .hero{padding:32px 0 12px;text-align:left;background:none}
-  .hero h1{margin:.2rem 0 .35rem}
-  .hero p{margin:0;color:var(--muted,#64748b)}
+  :root {
+    --card-bg: var(--panel, #ffffff);
+    --card-border: var(--border, #e2e8f0);
+    --card-shadow: var(--shadow, 0 12px 30px rgba(15, 23, 42, 0.08));
+  }
 
-  .universe-toolbar{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin:8px 0 16px}
-  .universe-search{flex:1 1 260px}
-  .universe-search input{width:100%;padding:10px 14px;border:1px solid var(--border,#e5e7eb);border-radius:999px;background:var(--panel,#fff);box-shadow:inset 0 0 0 1px transparent;transition:border .2s ease,box-shadow .2s ease}
-  .universe-search input:focus{outline:none;border-color:var(--accent,#1a73e8);box-shadow:0 0 0 3px color-mix(in srgb, var(--accent,#1a73e8) 18%, transparent)}
-  .universe-actions{display:flex;gap:8px;flex-wrap:wrap}
-  .universe-actions .btn{padding:8px 12px;border:1px solid var(--border,#e5e7eb);border-radius:999px;background:var(--panel,#fff);cursor:pointer;font-size:.85rem}
-  .universe-actions .btn:hover{border-color:var(--accent,#1a73e8)}
+  .wrap { max-width: 1200px; margin: 32px auto; padding: 0 18px; }
+  .hero { padding: 32px 0 12px; margin-top: 18px; }
+  .hero h1 { margin: 0 0 10px; font-size: clamp(2rem, 4vw, 2.6rem); }
+  .hero p { margin: 0; color: var(--muted, #64748b); max-width: 720px; }
 
-  .view-switcher{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 18px}
-  .view-switcher button{padding:8px 14px;border:1px solid var(--border,#e5e7eb);border-radius:999px;background:var(--panel,#fff);color:var(--text,#1f2937);font-size:.9rem;font-weight:500;cursor:pointer;transition:border .2s ease,background .2s ease,color .2s ease}
-  .view-switcher button.active{border-color:var(--accent,#1a73e8);background:color-mix(in srgb, var(--accent,#1a73e8) 12%, var(--panel,#fff) 88%);color:var(--accent-contrast,#0f172a)}
-  .view-switcher button:focus{outline:none;border-color:var(--accent,#1a73e8)}
+  .universe-shell { display: grid; gap: 24px; }
 
-  .table-wrap{background:var(--panel,#fff);border:1px solid var(--border,#e5e7eb);border-radius:16px;box-shadow:var(--shadow,0 12px 34px rgba(0,0,0,.06));overflow:hidden}
-  table.grid{width:100%;border-collapse:collapse}
-  .grid th,.grid td{padding:12px 14px;border-bottom:1px solid var(--border,#e5e7eb);vertical-align:top}
-  .grid thead th{position:sticky;top:62px;background:var(--bg,#f6f7fb);z-index:5;text-align:left;font-size:.85rem;text-transform:uppercase;letter-spacing:.05em;color:var(--muted,#64748b)}
-  .grid tbody tr:hover{background:#f8fafc}
-  .company-cell{font-weight:600;line-height:1.35}
-  .metric-cell{font-variant-numeric:tabular-nums}
-  .link-btn{background:none;border:none;padding:0;color:var(--accent,#1a73e8);font-size:.85rem;text-decoration:underline;cursor:pointer}
-  .link-btn:hover{color:#0b4dd8}
-  .link-btn:focus{outline:none;text-decoration:none;color:#0b4dd8}
-  .modal-actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:8px}
-  .analysis-full{display:grid;gap:14px}
-  .analysis-full__meta{color:var(--muted,#64748b);font-size:.9rem}
-  .analysis-full__body{white-space:pre-wrap;background:var(--bg,#f6f7fb);border:1px solid var(--border,#e5e7eb);border-radius:12px;padding:14px;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;margin:0;max-height:60vh;overflow:auto}
+  .gate { border: 1px solid var(--card-border); border-radius: 18px; padding: 32px; background: var(--card-bg); text-align: center; box-shadow: var(--card-shadow); }
+  .gate h2 { margin: 0 0 12px; }
+  .gate p { margin: 0 0 16px; color: var(--muted, #64748b); }
+  .gate .actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
 
-  .empty{padding:32px;text-align:center;color:var(--muted,#64748b)}
+  .controls-card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: 18px; padding: 20px; display: grid; gap: 16px; box-shadow: var(--card-shadow); }
+  .controls-grid { display: flex; flex-wrap: wrap; gap: 14px; align-items: center; }
+  .controls-grid label { font-size: 0.85rem; font-weight: 600; color: var(--muted, #64748b); }
+  .controls-grid select, .controls-grid input[type="search"] { min-width: 220px; padding: 10px 14px; border-radius: 12px; border: 1px solid var(--card-border); background: var(--bg, #f8fafc); font-size: 0.95rem; }
+  .controls-grid button { padding: 10px 16px; border-radius: 999px; border: 1px solid var(--card-border); background: var(--card-bg); cursor: pointer; font-size: 0.9rem; }
+  .controls-grid button.primary { background: var(--accent, #2563eb); border-color: var(--accent, #2563eb); color: #fff; }
+  .controls-grid button.primary:hover { filter: brightness(1.05); }
 
-  .locked-row td{background:color-mix(in srgb, var(--bg,#f6f7fb) 85%, var(--panel,#fff) 15%);padding:28px 16px;text-align:center}
-  .locked-paywall{display:grid;gap:12px;justify-items:center}
-  .locked-paywall p{margin:0;color:var(--muted,#64748b);max-width:520px}
-  .locked-paywall .actions{display:flex;gap:10px;flex-wrap:wrap;justify-content:center}
-  .locked-note{font-size:13px;color:var(--muted,#64748b)}
+  .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 16px; }
+  .metric-card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: 16px; padding: 18px; box-shadow: var(--card-shadow); display: grid; gap: 6px; }
+  .metric-label { font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted, #64748b); }
+  .metric-value { font-size: 1.6rem; font-weight: 600; }
+  .metric-sub { font-size: 0.85rem; color: var(--muted, #64748b); }
 
-  /* Modal */
-  .modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.4);display:none;align-items:center;justify-content:center;padding:16px}
-  .modal{max-width:900px;width:100%;background:var(--panel,#fff);border-radius:18px;box-shadow:var(--shadow,0 12px 34px rgba(0,0,0,.18));border:1px solid var(--border,#e5e7eb)}
-  .modal header{display:flex;justify-content:space-between;align-items:center;padding:16px 18px;border-bottom:1px solid var(--border,#e5e7eb)}
-  .modal .body{padding:16px 18px;max-height:70vh;overflow:auto}
-  .kbd{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;background:#eef2ff;border:1px solid #c7d2fe;border-radius:6px;padding:1px 6px;font-size:12px}
+  .filters-card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: 18px; padding: 16px 20px; box-shadow: var(--card-shadow); display: grid; gap: 14px; }
+  .chip-row { display: flex; flex-wrap: wrap; gap: 10px; }
+  .chip { border-radius: 999px; border: 1px solid var(--card-border); padding: 8px 14px; background: var(--bg, #f8fafc); cursor: pointer; font-size: 0.85rem; display: inline-flex; align-items: center; gap: 6px; }
+  .chip[data-active="true"] { background: color-mix(in srgb, var(--accent, #2563eb) 18%, var(--card-bg) 82%); border-color: var(--accent, #2563eb); color: var(--accent-contrast, #0f172a); }
+  .chip-count { font-variant-numeric: tabular-nums; font-weight: 600; }
+  .filters-card select { min-width: 200px; padding: 8px 12px; border-radius: 12px; border: 1px solid var(--card-border); background: var(--bg, #f8fafc); font-size: 0.9rem; }
 
-  /* Small screens */
-  @media (max-width: 740px){
-    .grid th:nth-child(n+5), .grid td:nth-child(n+5){display:none}
+  .table-card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: 18px; box-shadow: var(--card-shadow); overflow: hidden; }
+  table { width: 100%; border-collapse: collapse; }
+  th, td { padding: 14px 16px; border-bottom: 1px solid var(--card-border); vertical-align: top; }
+  thead th { position: sticky; top: 70px; background: var(--bg, #f8fafc); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted, #64748b); z-index: 5; }
+  tbody tr:hover { background: color-mix(in srgb, var(--accent, #2563eb) 6%, var(--card-bg) 94%); }
+  .ticker-cell { font-weight: 600; font-size: 1rem; }
+  .ticker-meta { font-size: 0.85rem; color: var(--muted, #64748b); margin-top: 2px; }
+  .stage-badge { display: inline-flex; align-items: center; gap: 6px; border-radius: 999px; padding: 4px 10px; font-size: 0.75rem; border: 1px solid currentColor; text-transform: uppercase; letter-spacing: 0.05em; }
+  .stage-0 { color: #64748b; }
+  .stage-1 { color: #0ea5e9; }
+  .stage-2 { color: #6366f1; }
+  .stage-3 { color: #16a34a; }
+  .label-pill { display: inline-flex; align-items: center; gap: 6px; border-radius: 999px; padding: 4px 10px; background: color-mix(in srgb, var(--accent, #2563eb) 12%, var(--card-bg) 88%); color: var(--accent-contrast, #0f172a); font-size: 0.8rem; font-weight: 600; }
+  .score-stack { display: grid; gap: 4px; font-size: 0.85rem; }
+  .score-stack span { display: flex; justify-content: space-between; gap: 8px; font-variant-numeric: tabular-nums; }
+  .summary-cell { font-size: 0.9rem; line-height: 1.4; }
+  .summary-cell p { margin: 0 0 4px; }
+  .summary-cell small { color: var(--muted, #64748b); }
+  .actions-cell { display: grid; gap: 8px; }
+  .actions-cell a { text-decoration: none; color: var(--accent, #2563eb); font-weight: 600; }
+  .actions-cell a:hover { text-decoration: underline; }
+
+  .table-empty { padding: 40px 16px; text-align: center; color: var(--muted, #64748b); }
+
+  .table-footer { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; }
+  .table-footer button { padding: 10px 18px; border-radius: 999px; border: 1px solid var(--card-border); background: var(--card-bg); cursor: pointer; font-size: 0.9rem; }
+  .table-footer button[disabled] { opacity: 0.4; cursor: not-allowed; }
+  .status-text { font-size: 0.85rem; color: var(--muted, #64748b); }
+
+  @media (max-width: 900px) {
+    thead { display: none; }
+    table, tbody, tr, td { display: block; width: 100%; }
+    tr { border-bottom: 1px solid var(--card-border); }
+    td { border-bottom: none; padding: 12px 16px; }
+    .actions-cell { justify-content: flex-start; }
+    .table-footer { flex-direction: column; gap: 12px; align-items: stretch; }
   }
 </style>
 </head>
 <body>
-
-<!-- Top bar -->
 <header class="site-header">
   <a class="brand" href="/">
     <img src="/images/logo.webp" alt="FutureFunds.ai logo" class="logo" />
@@ -139,59 +159,117 @@
   </nav>
 </header>
 
-<!-- Hero -->
-<section class="wrap hero" style="margin-top:18px">
-  <h1>Universe — Daily Deep Dives</h1>
-  <p>Auto-generated research via OpenRouter. Filter, explore, export. Tip: press <span class="kbd">/</span> to search.</p>
+<section class="wrap hero">
+  <h1>Automated Analyst Universe</h1>
+  <p>Inspect the latest multi-stage equity runs. Filter by stage, label, or sector, export reports, and jump into full dossiers for any ticker.</p>
 </section>
 
-<!-- Controls -->
-<main class="wrap">
-  <div class="universe-toolbar">
-    <div class="universe-search">
-      <input id="q" type="search" placeholder="Search the universe…" aria-label="Search the universe" />
+<main class="wrap universe-shell">
+  <section id="gate" class="gate" hidden>
+    <h2>Members-only research cockpit</h2>
+    <p>This dashboard exposes raw pipeline outputs and costs. Please sign in with an analyst or admin account to continue.</p>
+    <div class="actions">
+      <a class="btn primary" href="/login.html">Sign in</a>
+      <a class="btn" href="/membership.html">Request access</a>
     </div>
-    <div class="universe-actions">
-      <button id="btnExportCsv" class="btn" type="button" title="Export current view to CSV">Export CSV</button>
-      <button id="btnCopyJson" class="btn" type="button" title="Copy current view as JSON">Copy JSON</button>
-      <button id="btnRefresh" class="btn" type="button" title="Reload data">Refresh</button>
+  </section>
+
+  <section id="universeContent" hidden>
+    <div class="controls-card">
+      <div class="controls-grid">
+        <label for="runSelect">Run</label>
+        <select id="runSelect"></select>
+        <label for="q" class="sr-only">Search tickers</label>
+        <input id="q" type="search" placeholder="Search tickers or names…" autocomplete="off" />
+        <button id="refreshBtn" type="button">Refresh</button>
+        <button id="exportCsvBtn" type="button">Export CSV</button>
+        <button id="copyJsonBtn" type="button">Copy JSON</button>
+      </div>
     </div>
-  </div>
 
-  <div class="view-switcher" role="tablist" aria-label="Universe view modes">
-    <button type="button" class="toggle active" data-mode="tags" aria-pressed="true">Tags</button>
-    <button type="button" class="toggle" data-mode="strategies" aria-pressed="false">Strategies</button>
-    <button type="button" class="toggle" data-mode="metrics" aria-pressed="false">Metrics</button>
-    <button type="button" class="toggle" data-mode="placeholder1" aria-pressed="false">Placeholder1</button>
-    <button type="button" class="toggle" data-mode="placeholder2" aria-pressed="false">Placeholder2</button>
-  </div>
+    <div class="metrics">
+      <article class="metric-card" data-metric="tickers">
+        <span class="metric-label">Universe size</span>
+        <span class="metric-value" id="metricTickers">—</span>
+        <span class="metric-sub" id="metricTickersSub">Pending update…</span>
+      </article>
+      <article class="metric-card" data-metric="go-deep">
+        <span class="metric-label">Go-deep approvals</span>
+        <span class="metric-value" id="metricGoDeep">—</span>
+        <span class="metric-sub" id="metricGoDeepSub">Stage 2 verdicts</span>
+      </article>
+      <article class="metric-card" data-metric="reports">
+        <span class="metric-label">Deep-dive reports</span>
+        <span class="metric-value" id="metricReports">—</span>
+        <span class="metric-sub" id="metricReportsSub">Stage 3 completions</span>
+      </article>
+      <article class="metric-card" data-metric="spend">
+        <span class="metric-label">Spend (USD)</span>
+        <span class="metric-value" id="metricSpend">—</span>
+        <span class="metric-sub" id="metricSpendSub">Across all stages</span>
+      </article>
+    </div>
 
-  <div class="table-wrap">
-    <table class="grid" id="grid">
-      <thead>
-        <tr id="headerRow"></tr>
-      </thead>
-      <tbody id="tbody">
-        <tr><td class="empty" colspan="6">Loading…</td></tr>
-      </tbody>
-    </table>
-  </div>
+    <div class="filters-card">
+      <div>
+        <strong>Stage</strong>
+        <div class="chip-row" id="stageFilters">
+          <button type="button" class="chip" data-stage="" data-active="true">All</button>
+          <button type="button" class="chip" data-stage="1">Stage 1</button>
+          <button type="button" class="chip" data-stage="2">Stage 2</button>
+          <button type="button" class="chip" data-stage="3">Stage 3</button>
+        </div>
+      </div>
+      <div>
+        <strong>Label</strong>
+        <div class="chip-row" id="labelFilters">
+          <button type="button" class="chip" data-label="" data-active="true">All</button>
+          <button type="button" class="chip" data-label="consider">Consider</button>
+          <button type="button" class="chip" data-label="borderline">Borderline</button>
+          <button type="button" class="chip" data-label="uninvestible">Uninvestible</button>
+        </div>
+      </div>
+      <div>
+        <strong>Go deep</strong>
+        <div class="chip-row" id="goDeepFilters">
+          <button type="button" class="chip" data-go="" data-active="true">All</button>
+          <button type="button" class="chip" data-go="true">Approved</button>
+          <button type="button" class="chip" data-go="false">Not approved</button>
+        </div>
+      </div>
+      <div>
+        <label for="sectorSelect"><strong>Sector</strong></label>
+        <select id="sectorSelect">
+          <option value="">All sectors</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="table-card">
+      <table aria-live="polite">
+        <thead>
+          <tr>
+            <th scope="col">Ticker</th>
+            <th scope="col">Stage</th>
+            <th scope="col">Label</th>
+            <th scope="col">Stage 2 scores</th>
+            <th scope="col">Deep dive summary</th>
+            <th scope="col">Spend</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody id="tableBody">
+          <tr><td class="table-empty" colspan="7">Select a run to load the universe.</td></tr>
+        </tbody>
+      </table>
+      <div class="table-footer">
+        <button id="loadMoreBtn" type="button">Load more</button>
+        <span class="status-text" id="tableStatus">—</span>
+      </div>
+    </div>
+  </section>
 </main>
 
-<!-- Modal -->
-<div id="modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-hidden="true">
-  <div class="modal">
-    <header>
-      <strong id="mTitle">Details</strong>
-      <button id="mClose" class="btn" style="border:none;background:transparent;font-size:22px;cursor:pointer" aria-label="Close">×</button>
-    </header>
-    <div class="body" id="mBody">
-      <!-- filled dynamically -->
-    </div>
-  </div>
-</div>
-
-<!-- Footer -->
 <footer class="site-footer">
   <div class="footer-inner">
     <div class="footer-col footer-about">


### PR DESCRIPTION
## Summary
- replace the Universe page with an authenticated automation dashboard that surfaces live run metrics, filters, and exports via new Supabase RPCs
- add an admin-only ticker deep-dive page that assembles Stage 1–3 outputs, downloadable JSON, and clipboard helpers per symbol
- introduce reusable SQL helpers for universe pagination, filter facets, and ticker dossiers while updating roadmap/docs to mark the views complete

## Testing
- node --test tests/editor-support.test.mjs
- node --test tests/supabase-connection.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e15c8f4f04832d9ade0a7cb73884a3