### PR TITLE
Fix AI registry seed upsert syntax

### DIFF
--- a/sql/006_ai_registry.sql
+++ b/sql/006_ai_registry.sql
@@ -68,8 +68,7 @@ values
   ('openai/gpt-4o-mini', 'GPT-4o mini (OpenAI)', 'openai', 'gpt-4o-mini', 'https://api.openai.com/v1', 'standard', 0.1500, 0.6000, 'Direct OpenAI endpoint.'),
   ('openai/gpt-4o', 'GPT-4o (OpenAI)', 'openai', 'gpt-4o', 'https://api.openai.com/v1', 'premium', 2.5000, 10.0000, 'Direct OpenAI endpoint.'),
   ('openai/gpt-5-mini', 'GPT-5 mini (OpenAI)', 'openai', 'gpt-5-mini', 'https://api.openai.com/v1', 'premium', 0.2500, 2.0000, 'Direct OpenAI endpoint.'),
-  ('openai/gpt-5-preview', 'GPT-5 preview (OpenAI)', 'openai', 'gpt-5-preview', 'https://api.openai.com/v1', 'premium', 1.2500, 10.0000, 'Direct OpenAI endpoint. For highest quality deep dives.');
-
+  ('openai/gpt-5-preview', 'GPT-5 preview (OpenAI)', 'openai', 'gpt-5-preview', 'https://api.openai.com/v1', 'premium', 1.2500, 10.0000, 'Direct OpenAI endpoint. For highest quality deep dives.')
 on conflict (slug) do update
 set label = excluded.label,
     provider = excluded.provider,


### PR DESCRIPTION
## Summary
- attach the ON CONFLICT handler directly to the ai_model_profiles seed insert

## Testing
- supabase db reset *(fails: supabase CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e27c751c24832da064387fe28153ca