### PR TITLE
Reformat dimension seed arrays for clarity

### DIFF
--- a/sql/006_ai_registry.sql
+++ b/sql/006_ai_registry.sql
@@ -68,8 +68,7 @@ values
   ('openai/gpt-4o-mini', 'GPT-4o mini (OpenAI)', 'openai', 'gpt-4o-mini', 'https://api.openai.com/v1', 'standard', 0.1500, 0.6000, 'Direct OpenAI endpoint.'),
   ('openai/gpt-4o', 'GPT-4o (OpenAI)', 'openai', 'gpt-4o', 'https://api.openai.com/v1', 'premium', 2.5000, 10.0000, 'Direct OpenAI endpoint.'),
   ('openai/gpt-5-mini', 'GPT-5 mini (OpenAI)', 'openai', 'gpt-5-mini', 'https://api.openai.com/v1', 'premium', 0.2500, 2.0000, 'Direct OpenAI endpoint.'),
-  ('openai/gpt-5-preview', 'GPT-5 preview (OpenAI)', 'openai', 'gpt-5-preview', 'https://api.openai.com/v1', 'premium', 1.2500, 10.0000, 'Direct OpenAI endpoint. For highest quality deep dives.');
-
+  ('openai/gpt-5-preview', 'GPT-5 preview (OpenAI)', 'openai', 'gpt-5-preview', 'https://api.openai.com/v1', 'premium', 1.2500, 10.0000, 'Direct OpenAI endpoint. For highest quality deep dives.')
 on conflict (slug) do update
 set label = excluded.label,
     provider = excluded.provider,

--- a/sql/007_question_registry.sql
+++ b/sql/007_question_registry.sql
@@ -94,11 +94,51 @@ create index if not exists analysis_dimension_scores_run_idx
 -- Seed canonical dimensions (safe upsert)
 insert into public.analysis_dimensions (slug, name, description, stage, order_index, weight, metadata)
 values
-  ('financial_resilience', 'Financial Resilience', 'Liquidity, leverage, and capital discipline including debt servicing and capital allocation flex.', 3, 10, 1.2, jsonb_build_object('signals', ['leverage', 'cash_flow', 'credit'])),
-  ('market_positioning', 'Market Positioning', 'Competitive moat, segment leadership, and hyperscale or cannibal dynamics vs. direct peers.', 3, 20, 1.1, jsonb_build_object('signals', ['moat', 'share', 'hyperscale'])),
-  ('leadership_competency', 'Leadership & Governance', 'Quality of leadership, board oversight, capital deployment judgement, and track record.', 3, 30, 1.0, jsonb_build_object('signals', ['track_record', 'governance', 'execution'])),
-  ('product_relevance', 'Product & Innovation Fitness', 'Product velocity, customer love, roadmap relevance, and alignment to secular demand shifts.', 3, 40, 1.0, jsonb_build_object('signals', ['innovation', 'differentiation'])),
-  ('resilience_risk', 'Resilience & Macro Readiness', 'Operational resilience, supply chain, macro sensitivity, and situational awareness (pandemics, shocks).', 3, 50, 0.9, jsonb_build_object('signals', ['macro', 'supply_chain', 'scenario']))
+  (
+    'financial_resilience',
+    'Financial Resilience',
+    'Liquidity, leverage, and capital discipline including debt servicing and capital allocation flex.',
+    3,
+    10,
+    1.2,
+    jsonb_build_object('signals', jsonb_build_array('leverage', 'cash_flow', 'credit'))
+  ),
+  (
+    'market_positioning',
+    'Market Positioning',
+    'Competitive moat, segment leadership, and hyperscale or cannibal dynamics vs. direct peers.',
+    3,
+    20,
+    1.1,
+    jsonb_build_object('signals', jsonb_build_array('moat', 'share', 'hyperscale'))
+  ),
+  (
+    'leadership_competency',
+    'Leadership & Governance',
+    'Quality of leadership, board oversight, capital deployment judgement, and track record.',
+    3,
+    30,
+    1.0,
+    jsonb_build_object('signals', jsonb_build_array('track_record', 'governance', 'execution'))
+  ),
+  (
+    'product_relevance',
+    'Product & Innovation Fitness',
+    'Product velocity, customer love, roadmap relevance, and alignment to secular demand shifts.',
+    3,
+    40,
+    1.0,
+    jsonb_build_object('signals', jsonb_build_array('innovation', 'differentiation'))
+  ),
+  (
+    'resilience_risk',
+    'Resilience & Macro Readiness',
+    'Operational resilience, supply chain, macro sensitivity, and situational awareness (pandemics, shocks).',
+    3,
+    50,
+    0.9,
+    jsonb_build_object('signals', jsonb_build_array('macro', 'supply_chain', 'scenario'))
+  )
 on conflict (slug) do update
   set name = excluded.name,
       description = excluded.description,


### PR DESCRIPTION
## Summary
- expand the analysis dimension seed tuples onto multiple lines for readability
- keep each metadata signal list expressed with jsonb_build_array to avoid bracket syntax errors during migration

## Testing
- not run (Supabase CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e27c751c24832da064387fe28153ca