### PR TITLE
Fix planner stage card inputs overflowing

### DIFF
--- a/planner.html
+++ b/planner.html
@@ -97,6 +97,8 @@
       font: inherit;
       background: rgba(255,255,255,.92);
       transition: border-color .2s ease, box-shadow .2s ease;
+      width: 100%;
+      box-sizing: border-box;
     }
     .field input[type="number"]:focus,
     .field input[type="text"]:focus,


### PR DESCRIPTION
## Summary
- ensure planner form fields stretch to their container so stage cards stay aligned

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e29da6700c832d96669d9c0a637189