### PR TITLE
Fix planner dropdown option contrast

### DIFF
--- a/planner.html
+++ b/planner.html
@@ -96,9 +96,14 @@
       border: 1px solid var(--border,#cbd5f5);
       font: inherit;
       background: rgba(255,255,255,.92);
+      color: var(--text,#0f172a);
       transition: border-color .2s ease, box-shadow .2s ease;
       width: 100%;
       box-sizing: border-box;
+    }
+    .field select option {
+      color: var(--text,#0f172a);
+      background: var(--panel,#fff);
     }
     .field input[type="number"]:focus,
     .field input[type="text"]:focus,


### PR DESCRIPTION
## Summary
- ensure planner form controls explicitly inherit the page text color so dropdown selections remain readable
- set option backgrounds to the panel color to avoid white-on-white menus

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e2a106cd60832dbfe6715176468b7e