### PR TITLE
Ensure sector manager modal hides loader after iframe loads

### DIFF
--- a/planner.html
+++ b/planner.html
@@ -618,6 +618,9 @@
       font-size: .92rem;
       font-weight: 500;
     }
+    .sector-modal__loader[hidden] {
+      display: none !important;
+    }
     .sector-modal__close {
       position: absolute;
       top: 14px;


### PR DESCRIPTION
## Summary
- ensure the sector manager modal loader is fully hidden once the iframe finishes loading by adding an explicit `[hidden]` style override

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e2a1faa694832dac280db1f1f4437d