### PR TITLE
Gate analyst dashboards for members and add run quotas

### DIFF
--- a/assets/docs-admin.js
+++ b/assets/docs-admin.js
@@ -1,0 +1,366 @@
+// /assets/docs-admin.js
+import { supabase } from './supabase.js';
+import { onAuthReady, requireRole, getAccountState, refreshAuthState } from './auth.js';
+
+const els = {
+  gate: document.getElementById('docsGate'),
+  console: document.getElementById('docsConsole'),
+  status: document.getElementById('docsStatus'),
+  form: document.getElementById('docsUploadForm'),
+  refreshBtn: document.getElementById('docsRefreshBtn'),
+  tickerSelect: document.getElementById('docsTicker'),
+  tableBody: document.getElementById('docsTableBody')
+};
+
+const state = {
+  isAdmin: false,
+  loading: false,
+  token: null,
+  docs: []
+};
+
+function setConsoleBusy(flag) {
+  state.loading = flag;
+  if (els.console) {
+    els.console.setAttribute('aria-busy', flag ? 'true' : 'false');
+  }
+}
+
+function setStatus(message, tone = 'default') {
+  if (!els.status) return;
+  els.status.textContent = message || '';
+  els.status.dataset.tone = tone;
+}
+
+function slugify(value) {
+  return (value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '')
+    .slice(0, 80) || 'doc';
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString([], { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function formatRelative(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  const delta = Date.now() - date.getTime();
+  const days = Math.floor(delta / 86_400_000);
+  if (days <= 0) {
+    const hours = Math.floor(delta / 3_600_000);
+    if (hours <= 0) {
+      const minutes = Math.floor(delta / 60_000);
+      return minutes <= 1 ? 'Just now' : `${minutes}m ago`;
+    }
+    return `${hours}h ago`;
+  }
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  return `${weeks}w ago`;
+}
+
+async function refreshSessionToken() {
+  const { data } = await supabase.auth.getSession();
+  state.token = data?.session?.access_token || null;
+  return state.token;
+}
+
+function requireAuthorizedUI() {
+  if (els.gate) {
+    els.gate.hidden = state.isAdmin;
+  }
+  if (els.console) {
+    els.console.hidden = !state.isAdmin;
+  }
+}
+
+async function populateTickers() {
+  if (!els.tickerSelect) return;
+  const { data, error } = await supabase
+    .from('tickers')
+    .select('ticker, name')
+    .order('ticker', { ascending: true })
+    .limit(500);
+  if (error) {
+    console.warn('Failed to load tickers', error);
+    return;
+  }
+  const select = els.tickerSelect;
+  const existing = new Set(Array.from(select.options).map((option) => option.value));
+  if (!existing.has('')) {
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Select ticker';
+    select.append(placeholder);
+  }
+  (data || []).forEach((row) => {
+    const ticker = (row.ticker || '').toUpperCase();
+    if (!ticker || existing.has(ticker)) return;
+    const option = document.createElement('option');
+    option.value = ticker;
+    option.textContent = row.name ? `${ticker} — ${row.name}` : ticker;
+    select.append(option);
+  });
+}
+
+function renderDocs() {
+  if (!els.tableBody) return;
+  const tbody = els.tableBody;
+  tbody.innerHTML = '';
+
+  if (!state.docs.length) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 8;
+    cell.className = 'docs-empty';
+    cell.textContent = 'No documents uploaded yet.';
+    row.append(cell);
+    tbody.append(row);
+    return;
+  }
+
+  state.docs.forEach((doc) => {
+    const row = document.createElement('tr');
+
+    const titleCell = document.createElement('td');
+    if (doc.source_url) {
+      const link = document.createElement('a');
+      link.href = doc.source_url;
+      link.target = '_blank';
+      link.rel = 'noreferrer noopener';
+      link.textContent = doc.title || 'Untitled document';
+      titleCell.append(link);
+    } else {
+      titleCell.textContent = doc.title || 'Untitled document';
+    }
+    row.append(titleCell);
+
+    const tickerCell = document.createElement('td');
+    tickerCell.textContent = doc.ticker || '—';
+    row.append(tickerCell);
+
+    const typeCell = document.createElement('td');
+    typeCell.textContent = doc.source_type || '—';
+    row.append(typeCell);
+
+    const publishedCell = document.createElement('td');
+    publishedCell.textContent = formatDate(doc.published_at);
+    row.append(publishedCell);
+
+    const chunkCell = document.createElement('td');
+    const chunks = Number(doc.chunk_count || 0);
+    const tokens = Number(doc.token_count || 0);
+    chunkCell.textContent = chunks ? `${chunks} · ${tokens.toLocaleString()} tok` : '—';
+    row.append(chunkCell);
+
+    const statusCell = document.createElement('td');
+    const badge = document.createElement('span');
+    const status = (doc.status || 'pending').toLowerCase();
+    badge.className = `badge ${status}`;
+    badge.textContent = status;
+    statusCell.append(badge);
+    row.append(statusCell);
+
+    const uploadedCell = document.createElement('td');
+    uploadedCell.textContent = formatRelative(doc.created_at);
+    row.append(uploadedCell);
+
+    const actionsCell = document.createElement('td');
+    actionsCell.className = 'actions';
+    const processBtn = document.createElement('button');
+    processBtn.type = 'button';
+    processBtn.className = 'btn ghost';
+    processBtn.dataset.action = 'process';
+    processBtn.dataset.docId = doc.id;
+    processBtn.textContent = 'Process';
+    actionsCell.append(processBtn);
+    if (doc.status === 'failed' && doc.last_error) {
+      const note = document.createElement('span');
+      note.className = 'docs-note';
+      note.textContent = doc.last_error.slice(0, 140);
+      actionsCell.append(note);
+    }
+    row.append(actionsCell);
+
+    tbody.append(row);
+  });
+}
+
+async function loadDocs() {
+  setConsoleBusy(true);
+  try {
+    const { data, error } = await supabase
+      .from('docs')
+      .select(
+        'id, title, ticker, source_type, published_at, source_url, storage_path, status, chunk_count, token_count, processed_at, last_error, created_at, updated_at'
+      )
+      .order('created_at', { ascending: false })
+      .limit(100);
+    if (error) throw error;
+    state.docs = data || [];
+    renderDocs();
+  } catch (error) {
+    console.error('Failed to load docs', error);
+    setStatus('Failed to load documents.', 'error');
+  } finally {
+    setConsoleBusy(false);
+  }
+}
+
+async function processDoc(docId) {
+  if (!docId) return;
+  setStatus('Processing document…');
+  const { data, error } = await supabase.functions.invoke('docs-process', {
+    body: { docId }
+  });
+  if (error) {
+    console.error('docs-process invocation failed', error);
+    const serverMessage = (error?.context && typeof error.context === 'object' && error.context.error)
+      ? String(error.context.error)
+      : error?.message;
+    setStatus(serverMessage || 'Processing failed. Check error logs.', 'error');
+    return;
+  }
+  if (data && data.error) {
+    setStatus(data.error, 'error');
+  } else {
+    setStatus('Document processed successfully.', 'success');
+  }
+  await loadDocs();
+}
+
+async function handleUpload(event) {
+  event.preventDefault();
+  if (!els.form) return;
+
+  const formData = new FormData(els.form);
+  const title = String(formData.get('title') || '').trim();
+  const tickerRaw = String(formData.get('ticker') || '').trim();
+  const ticker = tickerRaw ? tickerRaw.toUpperCase() : null;
+  const sourceType = String(formData.get('source_type') || '').trim() || null;
+  const sourceUrlRaw = String(formData.get('source_url') || '').trim();
+  const sourceUrl = sourceUrlRaw || null;
+  const publishedRaw = String(formData.get('published_at') || '').trim();
+  const file = formData.get('file');
+
+  if (!title) {
+    setStatus('Provide a document title.', 'error');
+    return;
+  }
+  if (!(file instanceof File) || !file.size) {
+    setStatus('Attach a document before uploading.', 'error');
+    return;
+  }
+
+  setConsoleBusy(true);
+  setStatus('Uploading file…');
+
+  try {
+    await refreshSessionToken();
+    const slug = slugify(title);
+    const ext = (file.name.split('.').pop() || 'txt').toLowerCase();
+    const prefix = ticker ? `${ticker}/` : 'misc/';
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const storagePath = `raw/${prefix}${timestamp}-${slug}.${ext}`;
+
+    const { error: uploadError } = await supabase.storage.from('docs').upload(storagePath, file, {
+      cacheControl: '86400',
+      upsert: false,
+      contentType: file.type || undefined
+    });
+    if (uploadError) throw uploadError;
+
+    const payload = {
+      title,
+      ticker,
+      source_type: sourceType,
+      source_url: sourceUrl,
+      published_at: publishedRaw ? new Date(publishedRaw).toISOString() : null,
+      storage_path: storagePath
+    };
+
+    const account = getAccountState();
+    const inserted = await supabase
+      .from('docs')
+      .insert({
+        ...payload,
+        uploaded_by: account?.user?.id || null
+      })
+      .select('*')
+      .single();
+
+    if (inserted.error) throw inserted.error;
+
+    setStatus('Upload complete. Triggering chunking job…');
+    await processDoc(inserted.data.id);
+    els.form.reset();
+    if (els.tickerSelect) {
+      els.tickerSelect.value = ticker || '';
+    }
+  } catch (error) {
+    console.error('Document upload failed', error);
+    const message = error?.message || 'Upload failed.';
+    setStatus(message, 'error');
+  } finally {
+    setConsoleBusy(false);
+  }
+}
+
+function bindEvents() {
+  if (els.form) {
+    els.form.addEventListener('submit', handleUpload);
+  }
+  if (els.refreshBtn) {
+    els.refreshBtn.addEventListener('click', () => {
+      loadDocs();
+    });
+  }
+  if (els.tableBody) {
+    els.tableBody.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-action="process"]');
+      if (!button) return;
+      const docId = button.getAttribute('data-doc-id');
+      if (!docId) return;
+      processDoc(docId);
+    });
+  }
+}
+
+async function bootstrap() {
+  await onAuthReady();
+  try {
+    const user = await requireRole('admin');
+    state.isAdmin = Boolean(user);
+  } catch (error) {
+    state.isAdmin = false;
+    requireAuthorizedUI();
+    setStatus('Admin session required.', 'error');
+    return;
+  }
+
+  await refreshSessionToken();
+  requireAuthorizedUI();
+  bindEvents();
+  await Promise.all([populateTickers(), loadDocs()]);
+  setStatus('Ready. Upload a filing to begin.');
+}
+
+window.addEventListener('focus', () => {
+  if (!state.isAdmin) return;
+  refreshAuthState().catch(() => {});
+  refreshSessionToken().catch(() => {});
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  bootstrap().catch((error) => {
+    console.error('Docs console failed to initialise', error);
+    setStatus('Failed to initialise admin console.', 'error');
+  });
+});

--- a/assets/planner.js
+++ b/assets/planner.js
@@ -62,6 +62,9 @@ const inputs = {
   runRemaining: $('runRemainingValue'),
   runRemainingStat: $('runRemainingStat'),
   runMetaStatus: $('runMetaStatus'),
+  autoContinueToggle: $('autoContinueToggle'),
+  autoContinueInterval: $('autoContinueInterval'),
+  autoContinueStatus: $('autoContinueStatus'),
   stageSpendSection: $('stageSpendSection'),
   stageSpendChart: $('stageSpendChart'),
   stageSpendTotal: $('stageSpendTotal'),
@@ -87,6 +90,8 @@ const inputs = {
   stage2Completed: $('stage2Completed'),
   stage2Failed: $('stage2Failed'),
   stage2GoDeep: $('stage2GoDeep'),
+  stage2ContextHits: $('stage2ContextHits'),
+  stage2ContextTokens: $('stage2ContextTokens'),
   stage2RecentBody: $('stage2RecentBody'),
   stage3Btn: $('processStage3Btn'),
   stage3RefreshBtn: $('refreshStage3Btn'),
@@ -96,6 +101,8 @@ const inputs = {
   stage3Completed: $('stage3Completed'),
   stage3Spend: $('stage3Spend'),
   stage3Failed: $('stage3Failed'),
+  stage3ContextHits: $('stage3ContextHits'),
+  stage3ContextTokens: $('stage3ContextTokens'),
   stage3RecentBody: $('stage3RecentBody'),
   sectorNotesList: $('sectorNotesList'),
   sectorNotesEmpty: $('sectorNotesEmpty'),
@@ -113,6 +120,7 @@ const STAGE1_CONSUME_ENDPOINT = `${FUNCTIONS_BASE}/stage1-consume`;
 const STAGE2_CONSUME_ENDPOINT = `${FUNCTIONS_BASE}/stage2-consume`;
 const STAGE3_CONSUME_ENDPOINT = `${FUNCTIONS_BASE}/stage3-consume`;
 const RUNS_STOP_ENDPOINT = `${FUNCTIONS_BASE}/runs-stop`;
+const RUNS_CONTINUE_ENDPOINT = `${FUNCTIONS_BASE}/runs-continue`;
 const RUN_STORAGE_KEY = 'ff-active-run-id';
 
 let authContext = {
@@ -143,6 +151,11 @@ const STAGE_LABELS = {
   2: 'Stage 2 · Scoring',
   3: 'Stage 3 · Deep dive'
 };
+const AUTO_CONTINUE_LIMITS = { stage1: 8, stage2: 4, stage3: 2 };
+const AUTO_CONTINUE_DEFAULT_SECONDS = 30;
+let autoContinueTimer = null;
+let autoContinueActive = false;
+let autoContinueInFlight = false;
 
 function loadSettings() {
   try {
@@ -1449,6 +1462,276 @@ async function toggleRunStop(stopRequested) {
   }
 }
 
+function updateAutoContinueStatus(message) {
+  if (inputs.autoContinueStatus) {
+    inputs.autoContinueStatus.textContent = message;
+  }
+}
+
+function getAutoContinueIntervalMs() {
+  const rawValue = Number(inputs.autoContinueInterval?.value ?? AUTO_CONTINUE_DEFAULT_SECONDS);
+  const seconds = Number.isFinite(rawValue) && rawValue > 0 ? rawValue : AUTO_CONTINUE_DEFAULT_SECONDS;
+  const clamped = Math.min(Math.max(Math.round(seconds), 5), 600);
+  return clamped * 1000;
+}
+
+function clearAutoContinueTimer() {
+  if (autoContinueTimer) {
+    window.clearTimeout(autoContinueTimer);
+    autoContinueTimer = null;
+  }
+}
+
+function disableAutoContinue(message = 'Auto continue paused.') {
+  clearAutoContinueTimer();
+  autoContinueActive = false;
+  autoContinueInFlight = false;
+  if (inputs.autoContinueToggle) {
+    inputs.autoContinueToggle.checked = false;
+  }
+  updateAutoContinueStatus(message);
+}
+
+function scheduleAutoContinue({ immediate = false } = {}) {
+  clearAutoContinueTimer();
+  if (!autoContinueActive) return;
+
+  if (immediate) {
+    runAutoContinue().catch((error) => {
+      console.error('Auto continue execution failed', error);
+    });
+    return;
+  }
+
+  const delay = getAutoContinueIntervalMs();
+  autoContinueTimer = window.setTimeout(() => {
+    autoContinueTimer = null;
+    runAutoContinue().catch((error) => {
+      console.error('Auto continue execution failed', error);
+    });
+  }, delay);
+}
+
+function updateAutoContinueAvailability() {
+  const toggle = inputs.autoContinueToggle;
+  const intervalSelect = inputs.autoContinueInterval;
+  const halted = currentRunMeta?.stop_requested
+    ? 'stop'
+    : currentRunMeta?.budget_exhausted
+      ? 'budget'
+      : null;
+  const hasAuth = Boolean(authContext.user && authContext.isAdmin && authContext.token);
+  const ready = Boolean(activeRunId && hasAuth && !halted);
+
+  if (!ready && autoContinueActive) {
+    clearAutoContinueTimer();
+    autoContinueActive = false;
+    autoContinueInFlight = false;
+    if (toggle) toggle.checked = false;
+    if (halted === 'budget') {
+      updateAutoContinueStatus('Auto continue halted — budget reached.');
+    } else if (halted === 'stop') {
+      updateAutoContinueStatus('Auto continue halted — stop requested.');
+    } else if (!authContext.user) {
+      updateAutoContinueStatus('Sign in to enable auto continue.');
+    } else if (!authContext.isAdmin) {
+      updateAutoContinueStatus('Admin access required for auto continue.');
+    } else if (!activeRunId) {
+      updateAutoContinueStatus('Select a run to enable auto continue.');
+    } else {
+      updateAutoContinueStatus('Auto continue paused.');
+    }
+  }
+
+  if (toggle) {
+    toggle.disabled = !ready && !autoContinueActive;
+  }
+
+  if (intervalSelect) {
+    intervalSelect.disabled = !ready || autoContinueInFlight;
+  }
+
+  if (!autoContinueActive) {
+    if (!activeRunId) {
+      updateAutoContinueStatus('Select a run to enable auto continue.');
+    } else if (!authContext.user) {
+      updateAutoContinueStatus('Sign in to enable auto continue.');
+    } else if (!authContext.isAdmin) {
+      updateAutoContinueStatus('Admin access required for auto continue.');
+    } else if (halted === 'stop') {
+      updateAutoContinueStatus('Auto continue halted — stop requested.');
+    } else if (halted === 'budget') {
+      updateAutoContinueStatus('Auto continue halted — budget reached.');
+    } else if (!autoContinueInFlight && (!inputs.autoContinueStatus || !inputs.autoContinueStatus.textContent)) {
+      updateAutoContinueStatus('Auto continue idle.');
+    }
+  }
+}
+
+async function runAutoContinue() {
+  if (!autoContinueActive || autoContinueInFlight) return;
+
+  if (!activeRunId) {
+    disableAutoContinue('Select a run to enable auto continue.');
+    updateAutoContinueAvailability();
+    return;
+  }
+
+  if (!authContext.token) {
+    await syncAccess({ preserveStatus: true });
+  }
+
+  if (!authContext.token) {
+    disableAutoContinue('Session expired. Sign in again to continue.');
+    updateAutoContinueAvailability();
+    return;
+  }
+
+  autoContinueInFlight = true;
+  updateAutoContinueStatus('Auto continue running…');
+
+  try {
+    const response = await fetch(RUNS_CONTINUE_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authContext.token}`
+      },
+      body: JSON.stringify({
+        run_id: activeRunId,
+        stage_limits: AUTO_CONTINUE_LIMITS,
+        cycles: 1,
+        client_meta: {
+          origin: window.location.origin,
+          triggered_at: new Date().toISOString()
+        }
+      })
+    });
+
+    const raw = await response.text();
+    let payload = {};
+    if (raw) {
+      try {
+        payload = JSON.parse(raw);
+      } catch (error) {
+        console.warn('Unable to parse runs-continue response JSON', error);
+        payload = {};
+      }
+    }
+
+    if (!response.ok) {
+      const message = payload?.error || `Auto continue failed (${response.status})`;
+      updateAutoContinueStatus(message);
+      logStatus(`[Auto] ${message}`);
+      disableAutoContinue('Auto continue stopped due to error.');
+      updateAutoContinueAvailability();
+      return;
+    }
+
+    const message = typeof payload?.message === 'string' ? payload.message : 'Auto continue cycle completed.';
+    updateAutoContinueStatus(message);
+    logStatus(`[Auto] ${message}`);
+
+    if (Array.isArray(payload?.operations)) {
+      payload.operations.forEach((operation) => {
+        if (!operation || typeof operation !== 'object') return;
+        const stageNumber = Number(operation.stage);
+        const stageLabel = STAGE_LABELS[stageNumber] ?? `Stage ${stageNumber}`;
+        const opMessage = operation.message || 'Stage call completed.';
+        logStatus(`[Auto] ${stageLabel}: ${opMessage}`);
+      });
+    }
+
+    if (payload?.halted) {
+      const haltMessage = typeof payload.halted.message === 'string'
+        ? payload.halted.message
+        : 'Auto continue halted.';
+      logStatus(`[Auto] ${haltMessage}`);
+      disableAutoContinue(haltMessage);
+    }
+
+    await Promise.all([
+      fetchStage1Summary({ silent: true }),
+      fetchStage2Summary({ silent: true }),
+      fetchStage3Summary({ silent: true }),
+      fetchRunMeta({ silent: true })
+    ]).catch((error) => {
+      console.error('Auto continue refresh failed', error);
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Auto continue error', error);
+    updateAutoContinueStatus(`Auto continue error: ${message}`);
+    logStatus(`Auto continue error: ${message}`);
+    disableAutoContinue('Auto continue stopped due to error.');
+  } finally {
+    autoContinueInFlight = false;
+    updateAutoContinueAvailability();
+    if (autoContinueActive) {
+      scheduleAutoContinue();
+    }
+  }
+}
+
+async function handleAutoContinueToggle(event) {
+  const checked = Boolean(event?.target?.checked);
+
+  if (checked) {
+    await syncAccess({ preserveStatus: true });
+
+    if (!authContext.user) {
+      updateAutoContinueStatus('Sign in to enable auto continue.');
+      if (inputs.autoContinueToggle) inputs.autoContinueToggle.checked = false;
+      updateAutoContinueAvailability();
+      return;
+    }
+
+    if (!authContext.isAdmin) {
+      updateAutoContinueStatus('Admin access required for auto continue.');
+      if (inputs.autoContinueToggle) inputs.autoContinueToggle.checked = false;
+      updateAutoContinueAvailability();
+      return;
+    }
+
+    if (!authContext.token) {
+      updateAutoContinueStatus('Session expired. Sign in again to continue.');
+      if (inputs.autoContinueToggle) inputs.autoContinueToggle.checked = false;
+      updateAutoContinueAvailability();
+      return;
+    }
+
+    if (!activeRunId) {
+      updateAutoContinueStatus('Select a run to enable auto continue.');
+      if (inputs.autoContinueToggle) inputs.autoContinueToggle.checked = false;
+      updateAutoContinueAvailability();
+      return;
+    }
+
+    if (currentRunMeta?.stop_requested) {
+      updateAutoContinueStatus('Auto continue halted — stop requested.');
+      if (inputs.autoContinueToggle) inputs.autoContinueToggle.checked = false;
+      updateAutoContinueAvailability();
+      return;
+    }
+
+    if (currentRunMeta?.budget_exhausted) {
+      updateAutoContinueStatus('Auto continue halted — budget reached.');
+      if (inputs.autoContinueToggle) inputs.autoContinueToggle.checked = false;
+      updateAutoContinueAvailability();
+      return;
+    }
+
+    autoContinueActive = true;
+    logStatus('Auto continue enabled.');
+    updateAutoContinueAvailability();
+    scheduleAutoContinue({ immediate: true });
+  } else {
+    disableAutoContinue('Auto continue paused.');
+    logStatus('Auto continue paused by operator.');
+    updateAutoContinueAvailability();
+  }
+}
+
 function updateStage1Metrics(metrics = null) {
   const formatter = (value) => {
     if (value == null || Number.isNaN(value)) return '—';
@@ -1490,7 +1773,7 @@ function renderRecentClassifications(entries = []) {
   });
 }
 
-function updateStage2Metrics(metrics = null) {
+function updateStage2Metrics(metrics = null, retrieval = null) {
   const formatter = (value) => {
     if (value == null || Number.isNaN(value)) return '—';
     return Number(value).toLocaleString();
@@ -1501,6 +1784,14 @@ function updateStage2Metrics(metrics = null) {
   if (inputs.stage2Completed) inputs.stage2Completed.textContent = formatter(metrics?.completed);
   if (inputs.stage2Failed) inputs.stage2Failed.textContent = formatter(metrics?.failed);
   if (inputs.stage2GoDeep) inputs.stage2GoDeep.textContent = formatter(metrics?.goDeep);
+  if (inputs.stage2ContextHits) {
+    const hits = retrieval?.total_hits ?? retrieval?.hits ?? retrieval?.average_hits ?? null;
+    inputs.stage2ContextHits.textContent = formatter(hits);
+  }
+  if (inputs.stage2ContextTokens) {
+    const tokens = retrieval?.embedding_tokens ?? retrieval?.tokens ?? null;
+    inputs.stage2ContextTokens.textContent = formatter(tokens);
+  }
 }
 
 function renderStage2Insights(entries = []) {
@@ -1532,7 +1823,7 @@ function renderStage2Insights(entries = []) {
   });
 }
 
-function updateStage3Metrics(metrics = null) {
+function updateStage3Metrics(metrics = null, retrieval = null) {
   const formatter = (value) => {
     if (value == null || Number.isNaN(value)) return '—';
     return Number(value).toLocaleString();
@@ -1546,6 +1837,14 @@ function updateStage3Metrics(metrics = null) {
     inputs.stage3Spend.textContent = spend == null || Number.isNaN(spend) ? '—' : formatCurrency(Number(spend));
   }
   if (inputs.stage3Failed) inputs.stage3Failed.textContent = formatter(metrics?.failed);
+  if (inputs.stage3ContextHits) {
+    const hits = retrieval?.total_hits ?? retrieval?.hits ?? null;
+    inputs.stage3ContextHits.textContent = formatter(hits);
+  }
+  if (inputs.stage3ContextTokens) {
+    const tokens = retrieval?.embedding_tokens ?? retrieval?.tokens ?? null;
+    inputs.stage3ContextTokens.textContent = formatter(tokens);
+  }
 }
 
 function renderStage3Reports(entries = []) {
@@ -1826,6 +2125,10 @@ function setActiveRunId(value, { announce = true, silent = false } = {}) {
   activeRunId = normalized || null;
   const changed = previous !== activeRunId;
 
+  if (changed && autoContinueActive) {
+    disableAutoContinue('Auto continue paused while switching runs.');
+  }
+
   if (activeRunId) {
     localStorage.setItem(RUN_STORAGE_KEY, activeRunId);
   } else {
@@ -2055,13 +2358,16 @@ async function processStage2Batch() {
     }
 
     if (payload.metrics) {
-      updateStage2Metrics({
-        total: Number(payload.metrics.total_survivors ?? payload.metrics.total ?? 0),
-        pending: Number(payload.metrics.pending ?? 0),
-        completed: Number(payload.metrics.completed ?? 0),
-        failed: Number(payload.metrics.failed ?? 0),
-        goDeep: Number(payload.metrics.go_deep ?? payload.metrics.goDeep ?? 0)
-      });
+      updateStage2Metrics(
+        {
+          total: Number(payload.metrics.total_survivors ?? payload.metrics.total ?? 0),
+          pending: Number(payload.metrics.pending ?? 0),
+          completed: Number(payload.metrics.completed ?? 0),
+          failed: Number(payload.metrics.failed ?? 0),
+          goDeep: Number(payload.metrics.go_deep ?? payload.metrics.goDeep ?? 0)
+        },
+        payload.retrieval ?? null
+      );
     }
 
     const message = payload.message || `Processed ${results.length} ticker${results.length === 1 ? '' : 's'}.`;
@@ -2155,13 +2461,16 @@ async function processStage3Batch() {
     }
 
     if (payload.metrics) {
-      updateStage3Metrics({
-        finalists: Number(payload.metrics.total_finalists ?? payload.metrics.finalists ?? payload.metrics.total ?? 0),
-        pending: Number(payload.metrics.pending ?? 0),
-        completed: Number(payload.metrics.completed ?? 0),
-        failed: Number(payload.metrics.failed ?? 0),
-        spend: Number(payload.metrics.spend ?? payload.metrics.total_spend ?? 0)
-      });
+      updateStage3Metrics(
+        {
+          finalists: Number(payload.metrics.total_finalists ?? payload.metrics.finalists ?? payload.metrics.total ?? 0),
+          pending: Number(payload.metrics.pending ?? 0),
+          completed: Number(payload.metrics.completed ?? 0),
+          failed: Number(payload.metrics.failed ?? 0),
+          spend: Number(payload.metrics.spend ?? payload.metrics.total_spend ?? 0)
+        },
+        payload.retrieval ?? null
+      );
     }
 
     const message = payload.message || `Processed ${reports.length} finalist${reports.length === 1 ? '' : 's'}.`;
@@ -2353,9 +2662,13 @@ function applyAccessState({ preserveStatus = false } = {}) {
     ? 'signed-out'
     : authContext.isAdmin
       ? 'admin-ok'
-      : 'no-admin';
+      : authContext.membershipActive
+        ? 'member'
+        : 'no-membership';
 
   const haltRequested = (currentRunMeta?.stop_requested ?? false) || (currentRunMeta?.budget_exhausted ?? false);
+
+  updateAutoContinueAvailability();
 
   if (state === 'admin-ok' && previousState !== 'admin-ok') {
     subscribeSectorNotes();
@@ -2414,6 +2727,8 @@ function applyAccessState({ preserveStatus = false } = {}) {
     if (!preserveStatus) {
       if (state === 'admin-ok') inputs.status.textContent = 'Ready';
       else if (state === 'signed-out') inputs.status.textContent = 'Sign in required';
+      else if (state === 'member') inputs.status.textContent = 'Read-only member access';
+      else if (state === 'no-membership') inputs.status.textContent = 'Membership required';
       else inputs.status.textContent = 'Admin access required';
     }
 
@@ -2421,7 +2736,11 @@ function applyAccessState({ preserveStatus = false } = {}) {
       ? 'Authenticated as admin. Automation ready to launch.'
       : state === 'signed-out'
         ? 'Sign in to launch automated runs.'
-        : 'Current user lacks admin privileges. Contact an administrator to continue.';
+        : state === 'member'
+          ? 'Read-only mode: membership active. Contact an administrator to run the automation.'
+          : state === 'no-membership'
+            ? 'Launch blocked: activate a FutureFunds.ai membership to access automation.'
+            : 'Current user lacks admin privileges. Contact an administrator to continue.';
     logStatus(logMessage);
     lastAccessState = state;
   }
@@ -2650,6 +2969,13 @@ function bindEvents() {
     updateCostOutput();
     logStatus('Registry refreshed.');
     inputs.status.textContent = 'Registry updated';
+  });
+  inputs.autoContinueToggle?.addEventListener('change', handleAutoContinueToggle);
+  inputs.autoContinueInterval?.addEventListener('change', () => {
+    if (!autoContinueActive) return;
+    if (autoContinueInFlight) return;
+    scheduleAutoContinue();
+    updateAutoContinueStatus(`Auto continue interval set to ${inputs.autoContinueInterval.value || AUTO_CONTINUE_DEFAULT_SECONDS} seconds.`);
   });
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1244,6 +1244,27 @@ body.theme-light table.grid pre{
   border-top: 1px solid var(--border, #e6e9ee);
   backdrop-filter: blur(3px);
 }
+.gate-cta__inner{
+  width: min(520px, 100%);
+  display: grid;
+  gap: 12px;
+  justify-items: center;
+  text-align: center;
+}
+.gate-cta__inner strong{
+  font-size: 1rem;
+}
+.gate-cta__inner p{
+  margin: 0;
+  font-size: .9rem;
+  color: var(--muted, #475569);
+}
+.gate-cta__actions{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
 .theme-dark .gate-cta{ background: rgba(15,23,42,.6); }
 
 /* ===== Auth modal ===== */

--- a/assets/ticker.js
+++ b/assets/ticker.js
@@ -1,4 +1,4 @@
-import { supabase, getUser, getProfile, getMembership, hasAdminRole } from './supabase.js';
+import { supabase, getUser, getProfile, getMembership, hasAdminRole, isMembershipActive } from './supabase.js';
 
 const params = new URLSearchParams(window.location.search);
 const state = {
@@ -10,6 +10,7 @@ const state = {
 
 const elements = {
   gate: document.getElementById('tickerGate'),
+  gateMessage: document.getElementById('tickerGateMessage'),
   content: document.getElementById('tickerContent'),
   title: document.getElementById('tickerTitle'),
   subtitle: document.getElementById('tickerSubtitle'),
@@ -26,7 +27,11 @@ const elements = {
   stage2Scores: document.getElementById('stage2Scores'),
   stage2Verdict: document.getElementById('stage2Verdict'),
   stage2Next: document.getElementById('stage2Next'),
+  stage2Citations: document.getElementById('stage2Citations'),
+  stage2CitationList: document.getElementById('stage2CitationList'),
   stage3Summary: document.getElementById('stage3Summary'),
+  stage3Citations: document.getElementById('stage3Citations'),
+  stage3CitationList: document.getElementById('stage3CitationList'),
   stage3Scorecard: document.getElementById('stage3Scorecard'),
   stage3Questions: document.getElementById('stage3Questions')
 };
@@ -49,6 +54,13 @@ function formatDate(value) {
   return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
 }
 
+function formatDateOnly(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
 function titleCase(value) {
   if (!value) return '';
   return value
@@ -59,6 +71,123 @@ function titleCase(value) {
 }
 
 const questionMemory = (window.equityQuestionCache = window.equityQuestionCache || new Map());
+
+function extractHostname(url) {
+  if (!url) return '';
+  try {
+    const host = new URL(url).hostname;
+    return host.replace(/^www\./i, '');
+  } catch (error) {
+    console.warn('Failed to parse citation URL', error);
+    return '';
+  }
+}
+
+function normalizeCitations(value) {
+  if (!value) return [];
+  const array = Array.isArray(value) ? value : [];
+  const seen = new Set();
+  const results = [];
+  array.forEach((entry, index) => {
+    if (!entry || typeof entry !== 'object') return;
+    const record = entry;
+    let ref = record.ref ?? record.reference ?? `D${index + 1}`;
+    if (typeof ref !== 'string') ref = String(ref ?? `D${index + 1}`);
+    ref = ref.replace(/[\[\]]/g, '').trim().toUpperCase();
+    if (!ref) ref = `D${results.length + 1}`;
+    const title = record.title != null ? String(record.title) : null;
+    const sourceType = record.source_type != null ? String(record.source_type) : null;
+    const publishedAt = record.published_at != null ? String(record.published_at) : null;
+    const sourceUrl = record.source_url != null ? String(record.source_url) : null;
+    const similarity = record.similarity != null ? Number(record.similarity) : null;
+    const key = `${ref}|${sourceUrl || ''}|${title || ''}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    results.push({
+      ref,
+      title,
+      source_type: sourceType,
+      published_at: publishedAt,
+      source_url: sourceUrl,
+      similarity: Number.isFinite(similarity) ? similarity : null
+    });
+  });
+  return results;
+}
+
+function formatCitationMeta(citation) {
+  const parts = [];
+  if (citation.source_type) parts.push(citation.source_type);
+  const dateLabel = formatDateOnly(citation.published_at);
+  if (dateLabel) parts.push(dateLabel);
+  const host = extractHostname(citation.source_url);
+  if (host) parts.push(host);
+  if (typeof citation.similarity === 'number') {
+    const similarity = citation.similarity >= 0 && citation.similarity <= 1
+      ? citation.similarity.toFixed(2)
+      : citation.similarity.toString();
+    parts.push(`sim ${similarity}`);
+  }
+  return parts.join(' · ');
+}
+
+function createCitationItem(citation) {
+  const li = document.createElement('li');
+  li.className = 'citation-item';
+  li.dataset.ref = citation.ref;
+
+  const refSpan = document.createElement('span');
+  refSpan.className = 'citation-ref';
+  refSpan.textContent = `[${citation.ref}]`;
+  li.append(refSpan);
+
+  const body = document.createElement('div');
+  body.className = 'citation-body';
+
+  const titleLine = document.createElement('div');
+  titleLine.className = 'citation-title';
+  if (citation.source_url) {
+    const link = document.createElement('a');
+    link.href = citation.source_url;
+    link.target = '_blank';
+    link.rel = 'noreferrer noopener';
+    link.textContent = citation.title || citation.source_url;
+    titleLine.append(link);
+  } else {
+    titleLine.textContent = citation.title || 'Untitled source';
+  }
+  body.append(titleLine);
+
+  const meta = formatCitationMeta(citation);
+  if (meta) {
+    const metaLine = document.createElement('div');
+    metaLine.className = 'citation-meta';
+    metaLine.textContent = meta;
+    body.append(metaLine);
+  }
+
+  li.append(body);
+  return li;
+}
+
+function populateCitationList(listEl, citations) {
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  citations.forEach((citation) => {
+    listEl.append(createCitationItem(citation));
+  });
+}
+
+function renderCitationSection(section, listEl, citations) {
+  if (!section || !listEl) return;
+  if (!citations.length) {
+    listEl.innerHTML = '';
+    section.hidden = true;
+    return;
+  }
+  section.hidden = false;
+  populateCitationList(listEl, citations);
+}
 
 function normalizeArray(value) {
   if (!value) return [];
@@ -96,20 +225,30 @@ function recallQuestionGraph() {
   return questionMemory.get(cacheKey()) ?? { dimension_scores: [], question_results: [] };
 }
 
+function setGate(message) {
+  if (elements.gateMessage) {
+    elements.gateMessage.textContent = message;
+  }
+  elements.gate.hidden = false;
+  elements.content.hidden = true;
+}
+
 async function ensureAccess() {
   const user = await getUser();
   if (!user) {
-    elements.gate.hidden = false;
-    elements.content.hidden = true;
+    setGate('Sign in with your FutureFunds.ai membership to open the full Stage 1–3 dossier.');
     return false;
   }
+
   const [profile, membership] = await Promise.all([getProfile(), getMembership()]);
-  if (!hasAdminRole({ user, profile, membership })) {
-    elements.gate.hidden = false;
-    elements.gate.querySelector('p').textContent = 'Only analyst operators and admins can view raw stage outputs. Contact the FutureFunds team to request access.';
-    elements.content.hidden = true;
+  const admin = hasAdminRole({ user, profile, membership });
+  const memberActive = isMembershipActive(membership, { profile, user });
+
+  if (!admin && !memberActive) {
+    setGate('An active FutureFunds.ai membership unlocks raw analyst dossiers and citations.');
     return false;
   }
+
   elements.gate.hidden = true;
   elements.content.hidden = false;
   return true;
@@ -207,8 +346,20 @@ function clearPanels() {
   elements.stage2Scores.textContent = '';
   elements.stage2Verdict.textContent = '';
   elements.stage2Next.textContent = '';
+  if (elements.stage2Citations) {
+    elements.stage2Citations.hidden = true;
+  }
+  if (elements.stage2CitationList) {
+    elements.stage2CitationList.innerHTML = '';
+  }
   elements.stage3Summary.classList.add('muted');
   elements.stage3Summary.textContent = 'Deep dive not yet available.';
+  if (elements.stage3Citations) {
+    elements.stage3Citations.hidden = true;
+  }
+  if (elements.stage3CitationList) {
+    elements.stage3CitationList.innerHTML = '';
+  }
   if (elements.stage3Scorecard) {
     elements.stage3Scorecard.hidden = true;
     elements.stage3Scorecard.innerHTML = '';
@@ -276,6 +427,7 @@ function renderStage2(stage2) {
 
   if (!stage2 || typeof stage2 !== 'object') {
     elements.stage2Scores.innerHTML = '<p class="muted">Stage 2 scoring has not run yet.</p>';
+    renderCitationSection(elements.stage2Citations, elements.stage2CitationList, []);
     return;
   }
 
@@ -340,10 +492,15 @@ function renderStage2(stage2) {
     });
     elements.stage2Next.append(list);
   }
+
+  const stage2Citations = normalizeCitations(
+    stage2.context_citations ?? stage2.verdict?.context_citations ?? []
+  );
+  renderCitationSection(elements.stage2Citations, elements.stage2CitationList, stage2Citations);
 }
 
 function renderStage3(detail) {
-  const summaryJson = detail?.stage3_summary ?? null;
+  const summaryJson = detail?.stage3_summary && typeof detail.stage3_summary === 'object' ? detail.stage3_summary : null;
   const summaryText = detail?.stage3_text ?? null;
   const summary = summaryText || summaryJson?.summary || summaryJson?.thesis || summaryJson?.narrative;
   if (summary) {
@@ -353,6 +510,9 @@ function renderStage3(detail) {
     elements.stage3Summary.classList.add('muted');
     elements.stage3Summary.textContent = 'Deep dive not yet available.';
   }
+
+  const summaryCitations = normalizeCitations(summaryJson?.context_citations ?? []);
+  renderCitationSection(elements.stage3Citations, elements.stage3CitationList, summaryCitations);
 
   const currentDimensions = Array.isArray(detail?.dimension_scores) ? detail.dimension_scores : [];
   const currentQuestions = Array.isArray(detail?.question_results) ? detail.question_results : [];
@@ -512,6 +672,20 @@ function renderQuestionGrid(results = []) {
       details.append(pre);
       rawBlock.append(details);
       card.append(rawBlock);
+    }
+
+    const questionCitations = normalizeCitations(entry?.answer?.context_citations ?? entry?.context_citations ?? []);
+    if (questionCitations.length) {
+      const citeBlock = document.createElement('div');
+      citeBlock.className = 'question-citations';
+      const heading = document.createElement('strong');
+      heading.textContent = 'Sources';
+      citeBlock.append(heading);
+      const list = document.createElement('ol');
+      list.className = 'citation-list citation-list--compact';
+      populateCitationList(list, questionCitations);
+      citeBlock.append(list);
+      card.append(citeBlock);
     }
 
     elements.stage3Questions.append(card);

--- a/docs/equity-analyst-roadmap.md
+++ b/docs/equity-analyst-roadmap.md
@@ -68,18 +68,18 @@ incrementally.
 - [x] Add sparkline / bar chart for stage-level spend (client-side or lightweight chart lib).
 
 ## 9. Automation Loop (Week 6)
-- [ ] `/api/runs/continue` endpoint to sequentially trigger Stage 1 → 3 until batch limit / stop.
-- [ ] Planner toggle for **Auto continue** that polls the endpoint every N seconds.
+- [x] `/api/runs/continue` endpoint to sequentially trigger Stage 1 → 3 until batch limit / stop.
+- [x] Planner toggle for **Auto continue** that polls the endpoint every N seconds.
 - [ ] Optional: schedule nightly cron (Supabase Edge) to run small watchlists.
 
 ## 10. Retrieval Augmentation (Week 6–7)
-- [ ] `docs` uploader UI to add filings, transcripts, letters; chunk + embed into `doc_chunks`.
-- [ ] Retrieval helper RPC (e.g., `match_doc_chunks`) returning top-k snippets per query.
-- [ ] Integrate retrieved snippets into Stage 2 & 3 prompts with citation metadata.
+- [x] `docs` uploader UI to add filings, transcripts, letters; chunk + embed into `doc_chunks`.
+- [x] Retrieval helper RPC (e.g., `match_doc_chunks`) returning top-k snippets per query.
+- [x] Integrate retrieved snippets into Stage 2 & 3 prompts with citation metadata.
 
 ## 11. Member Experience & Auth (Week 7)
-- [ ] Gate analyst pages behind Supabase Auth; provide onboarding flow for new members.
-- [ ] Track per-user quotas (e.g., runs per day) using Supabase policies or server logic.
+- [x] Gate analyst pages behind Supabase Auth; provide onboarding flow for new members.
+- [x] Track per-user quotas (e.g., runs per day) using Supabase policies or server logic.
 - [ ] Post-run feedback widget so members can trigger manual follow-up questions (optional).
 
 ## 12. Observability & Safety (Week 8)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,193 @@
+<!doctype html>
+<html lang="en" data-lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>FutureFunds — Document Corpus Console</title>
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <style>
+    :root { color-scheme: light dark; }
+    body { font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; background: var(--page,#f8fafc); color: var(--text,#0f172a); }
+    body.modal-open { overflow: hidden; }
+    .docs-wrap { max-width: 1080px; margin: 0 auto; padding: 32px 20px 96px; display: grid; gap: 28px; }
+    .docs-headline { display: grid; gap: 8px; }
+    .docs-headline h1 { margin: 0; font-size: clamp(1.8rem, 2.6vw, 2.4rem); font-weight: 700; }
+    .docs-headline p { margin: 0; max-width: 720px; color: var(--muted,#475569); font-size: .98rem; }
+    .docs-gate { border: 1px solid var(--border,#e2e8f0); border-radius: 24px; padding: 40px 32px; background: var(--panel,#fff); box-shadow: 0 18px 36px rgba(15,23,42,.08); text-align: center; }
+    .docs-gate h2 { margin: 0 0 12px; font-size: 1.6rem; }
+    .docs-gate p { margin: 0 0 18px; color: var(--muted,#475569); }
+    .docs-console { display: grid; gap: 28px; }
+    .docs-panel { border: 1px solid var(--border,#e2e8f0); border-radius: 22px; background: var(--panel,#fff); box-shadow: 0 18px 36px rgba(15,23,42,.08); padding: 24px; display: grid; gap: 22px; }
+    .docs-panel header { display: grid; gap: 8px; }
+    .docs-panel h2 { margin: 0; font-size: 1.4rem; font-weight: 600; }
+    .docs-panel p { margin: 0; color: var(--muted,#475569); font-size: .95rem; }
+    .docs-form { display: grid; gap: 18px; }
+    .docs-grid { display: grid; gap: 18px; }
+    @media (min-width: 760px) { .docs-grid { grid-template-columns: repeat(2,minmax(0,1fr)); } }
+    .docs-field { display: grid; gap: 6px; }
+    .docs-field label { font-size: .88rem; font-weight: 600; color: var(--text,#0f172a); }
+    .docs-field input, .docs-field select { height: 44px; padding: 0 14px; border-radius: 12px; border: 1px solid var(--border,#cbd5f5); font: inherit; background: rgba(255,255,255,.94); color: inherit; transition: border-color .2s ease, box-shadow .2s ease; }
+    .docs-field input:focus, .docs-field select:focus { outline: none; border-color: var(--accent,#2563eb); box-shadow: 0 0 0 3px rgba(37,99,235,.2); }
+    .docs-field input[type="file"] { padding: 10px 14px; height: auto; }
+    .docs-actions { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
+    .docs-actions button { padding: 12px 20px; border-radius: 999px; border: none; font-weight: 600; cursor: pointer; }
+    .docs-actions button.primary { background: var(--accent,#2563eb); color: #fff; }
+    .docs-actions button.secondary { background: rgba(148,163,184,.18); color: var(--text,#0f172a); }
+    .docs-status { font-size: .88rem; color: var(--muted,#475569); }
+    .docs-table { width: 100%; border-collapse: collapse; }
+    .docs-table th, .docs-table td { padding: 12px 14px; border-bottom: 1px solid rgba(148,163,184,.24); text-align: left; font-size: .9rem; }
+    .docs-table th { font-size: .78rem; letter-spacing: .08em; text-transform: uppercase; color: var(--muted,#475569); }
+    .docs-table tbody tr:hover { background: rgba(37,99,235,.06); }
+    .docs-table td.actions { display: flex; gap: 8px; align-items: center; }
+    .badge { display: inline-flex; align-items: center; gap: 6px; padding: 2px 10px; border-radius: 999px; font-size: .75rem; font-weight: 600; text-transform: uppercase; letter-spacing: .06em; }
+    .badge.pending { background: rgba(59,130,246,.14); color: #1d4ed8; }
+    .badge.processed { background: rgba(16,185,129,.16); color: #047857; }
+    .badge.failed { background: rgba(239,68,68,.16); color: #b91c1c; }
+    .docs-empty { padding: 28px; text-align: center; color: var(--muted,#64748b); font-size: .95rem; }
+    .docs-note { font-size: .82rem; color: var(--muted,#64748b); margin: -8px 0 0; }
+    .docs-pill { padding: 4px 10px; border-radius: 999px; background: rgba(37,99,235,.12); color: var(--accent,#2563eb); font-size: .78rem; font-weight: 600; }
+    .docs-console[aria-busy="true"] { opacity: .55; pointer-events: none; }
+  </style>
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="/">
+      <img src="/images/logo.webp" alt="FutureFunds.ai logo" class="logo" />
+      <span>FutureFunds.ai</span>
+    </a>
+    <button class="nav-toggle" id="navToggle" type="button" aria-expanded="false" aria-controls="siteNav">
+      <span class="sr-only">Menu</span>
+      <span class="nav-toggle__bar"></span>
+    </button>
+    <nav class="nav" id="siteNav" aria-label="Primary navigation">
+      <div class="nav-links">
+        <div class="nav-item nav-item--team">
+          <a href="/team.html" class="nav-link" data-i18n="nav.team">Experiment</a>
+        </div>
+        <div class="nav-item nav-item--has-panel nav-item--tools">
+          <a href="/tools.html" class="nav-link" data-i18n="nav.investmentTools">Investment Tools</a>
+          <div class="nav-panel nav-panel--tools" role="group" aria-label="Investment tools">
+            <div class="nav-panel__header">
+              <span class="nav-panel__title">Featured tools</span>
+              <a class="nav-panel__cta" href="/tools.html">Explore tools →</a>
+            </div>
+            <div class="nav-panel__content nav-panel__content--tools">
+              <a class="nav-tool" href="/tool.html?id=ff-pms">
+                <span class="chip membership">Member</span>
+                <h4>Portfolio OS</h4>
+                <p>Run strategies end-to-end with sheets + AI copilots.</p>
+              </a>
+              <a class="nav-tool" href="/tool.html?id=stockalpha-journal">
+                <span class="chip free">Free</span>
+                <h4>StockAlpha Journal</h4>
+                <p>Track theses, catalysts, and behavioral loops.</p>
+              </a>
+              <a class="nav-tool" href="/tool.html?id=smart-watchlist">
+                <span class="chip beta">Beta</span>
+                <h4>Smart Watchlist</h4>
+                <p>Daily signals on upgrades, downgrades, and trend shifts.</p>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div class="nav-item nav-item--has-panel nav-item--analysis">
+          <a href="/universe.html" class="nav-link" data-i18n="nav.research">Research</a>
+        </div>
+      </div>
+      <div class="nav-actions">
+        <button class="btn" type="button" data-open-auth="signin">Sign in</button>
+      </div>
+    </nav>
+  </header>
+
+  <main class="docs-wrap" id="docsRoot">
+    <section class="docs-headline">
+      <h1>Document corpus console</h1>
+      <p>Upload filings, transcripts, or letters, then trigger the chunking worker to embed them for retrieval-augmented Stage 2 and Stage 3 prompts.</p>
+    </section>
+
+    <section class="docs-gate" id="docsGate" hidden>
+      <h2>Admin access required</h2>
+      <p>Sign in with an administrator account to manage the retrieval corpus.</p>
+      <button class="btn" type="button" data-open-auth="signin">Open sign-in</button>
+    </section>
+
+    <section class="docs-console" id="docsConsole" hidden>
+      <section class="docs-panel">
+        <header>
+          <h2>Upload source document</h2>
+          <p>Accepted formats: PDF, HTML, TXT. Files are stored under <span class="docs-pill">docs/raw/…</span> before the edge worker normalises and embeds snippets.</p>
+          <p class="docs-note">If the deployment cannot load the PDF parser you will see a “PDF extraction is not supported” status after processing.</p>
+        </header>
+        <form id="docsUploadForm" class="docs-form">
+          <div class="docs-grid">
+            <div class="docs-field">
+              <label for="docsTicker">Ticker</label>
+              <select id="docsTicker" name="ticker">
+                <option value="">Select ticker</option>
+              </select>
+              <p class="docs-note">Optional for macro or thematic documents.</p>
+            </div>
+            <div class="docs-field">
+              <label for="docsTitle">Title<span aria-hidden="true">*</span></label>
+              <input id="docsTitle" name="title" type="text" required placeholder="Investor letter Q3 2025" />
+            </div>
+            <div class="docs-field">
+              <label for="docsType">Source type</label>
+              <input id="docsType" name="source_type" type="text" placeholder="10-Q, transcript, letter…" />
+            </div>
+            <div class="docs-field">
+              <label for="docsPublished">Published</label>
+              <input id="docsPublished" name="published_at" type="date" />
+            </div>
+            <div class="docs-field">
+              <label for="docsUrl">Source URL</label>
+              <input id="docsUrl" name="source_url" type="url" placeholder="https://example.com/filing.pdf" />
+            </div>
+            <div class="docs-field">
+              <label for="docsFile">Document file<span aria-hidden="true">*</span></label>
+              <input id="docsFile" name="file" type="file" accept=".pdf,.txt,.text,.md,.html,.htm" required />
+            </div>
+          </div>
+          <div class="docs-actions">
+            <button class="primary" type="submit">Upload &amp; process</button>
+            <button class="secondary" type="button" id="docsRefreshBtn">Refresh list</button>
+            <span class="docs-status" id="docsStatus" role="status" aria-live="polite"></span>
+          </div>
+        </form>
+      </section>
+
+      <section class="docs-panel">
+        <header>
+          <h2>Corpus activity</h2>
+          <p>Track processed documents, chunk counts, and retry failed ingestions.</p>
+        </header>
+        <div class="docs-table__wrap">
+          <table class="docs-table">
+            <thead>
+              <tr>
+                <th scope="col">Title</th>
+                <th scope="col">Ticker</th>
+                <th scope="col">Type</th>
+                <th scope="col">Published</th>
+                <th scope="col">Chunks</th>
+                <th scope="col">Status</th>
+                <th scope="col">Uploaded</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody id="docsTableBody">
+              <tr>
+                <td colspan="8" class="docs-empty">No documents uploaded yet.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </section>
+  </main>
+
+  <script type="module" src="/assets/auth.js"></script>
+  <script type="module" src="/assets/docs-admin.js"></script>
+</body>
+</html>

--- a/docs/stage10-retrieval-plan.md
+++ b/docs/stage10-retrieval-plan.md
@@ -1,0 +1,29 @@
+# Stage 10: Retrieval Augmentation Implementation Plan
+
+Stage 10 introduces retrieval-augmented generation so Stage 2 and Stage 3 analyses can cite supporting documents. The following checklist breaks down the work into deployable increments.
+
+## 1. Document ingestion and storage
+- **Uploader UI:** Build an authenticated admin-only page at `/docs/index.html` (or equivalent) where operators can upload filings, transcripts, or letters. Accept PDF, TXT, and HTML inputs; capture metadata such as ticker, source type, publish date, and URL.
+- **Storage strategy:** Save raw files to Supabase Storage under a `docs/raw/` bucket. Persist metadata rows in a new `docs` table (columns: `id`, `ticker`, `title`, `source_type`, `published_at`, `source_url`, `storage_path`, `uploaded_by`, `created_at`).
+- **Chunking job:** Add an Edge Function (e.g., `docs-process`) that reads uploaded files, normalises text, and segments it into ~500 token chunks with 50-token overlap. Store chunks in `doc_chunks` with embeddings, metadata (doc id, chunk index), and a precomputed token length field for budgeting.
+- **Error handling:** Write failures to an `error_logs` table with payloads and stack traces so Stage 12 observability work can reuse the structure.
+
+## 2. Embeddings and retrieval helper
+- **Embedding model config:** Extend the configuration object (or create `config/models.json` if Stage 13 arrives early) with the embedding model name, price, and max tokens. Ensure the Supabase service role key has permission to call the OpenAI embeddings API.
+- **RPC helper:** Implement a Postgres function `match_doc_chunks(query_text text, ticker text, match_limit int default 6)` that performs vector similarity search against the `doc_chunks.embedding` column (using `pgvector`). Return chunk text, doc metadata, similarity score, and token estimate.
+- **Edge function wrapper:** Expose the RPC via a Supabase Edge handler or direct client query so Stage 2/3 workers can request top-k snippets with a latency budget < 1s.
+- **Rate limiting:** Allow the embedding worker to honour a `DOC_EMBED_DELAY_MS` environment variable so deployments can slow down chunk processing when vendor quotas are tight.
+
+## 3. Prompt integration and UI surfacing
+- **Stage 2 prompts:** Update `supabase/functions/stage2` to fetch relevant chunks for each ticker before calling the model. Inject snippets into the prompt template under a clearly marked `Retrieved context` section with citation IDs.
+- **Stage 3 prompts:** Repeat the retrieval step for Stage 3 deep dives; include citations alongside sourced quotes or data points in the rendered HTML.
+- **Planner visibility:** Add retrieval hit counts and token usage to the planner dashboard so operators can monitor how much external context is injected per stage.
+- **Ticker page citations:** Modify `ticker.html` to display citations, linking each snippet back to its original document using the stored metadata.
+
+## 4. Rollout checklist
+- Backfill existing filings for the current watchlist tickers to validate ingestion.
+- Run load tests on the embeddings pipeline (batch of ~50 documents) to size Supabase compute requirements.
+- Update `docs/changelog.md` with schema additions (`docs`, `error_logs`), new functions, and prompt modifications.
+- Document operational runbooks covering how to upload new sources and how to monitor retrieval health.
+
+Following this plan will complete Stage 10 and unblock the member-facing improvements scheduled for Stage 11.

--- a/docs/supabase-schema.md
+++ b/docs/supabase-schema.md
@@ -418,6 +418,12 @@ Seed the table with `/sql/002_seed.sql` for local development when you need samp
 | `status` | `text` | `'queued'` | Allowed values: `queued`, `running`, `done`, `failed`. |
 | `notes` | `text` | `null` | Optional metadata (e.g., user, budget). |
 | `stop_requested` | `boolean` | `false` | Workers should check this before processing the next batch. |
+| `created_by` | `uuid` | `null` | Populated by the `runs-create` edge function to record who launched the batch for quota enforcement.【F:supabase/functions/runs-create/index.ts†L232-L330】 |
+| `created_by_email` | `text` | `null` | Snapshot of the operator’s email for audit trails.【F:supabase/functions/runs-create/index.ts†L232-L330】 |
+
+Indexes on `created_by` and `created_at` support daily quota checks (`sql/009_member_access.sql`).【F:sql/009_member_access.sql†L1-L6】
+
+Set `RUNS_DAILY_LIMIT` (default `5`) in the edge runtime to cap how many batches a user can initiate within a rolling 24‑hour window; exceeding the quota triggers a `429` from `runs-create`.【F:supabase/functions/runs-create/index.ts†L104-L194】
 
 ### `run_items`
 
@@ -463,16 +469,58 @@ Composite primary key: `(run_id, ticker)`.
 | `cost_usd` | `numeric(12,4)` | USD spend at logging time. |
 | `created_at` | `timestamptz` | Timestamp of the ledger entry. |
 
+### `docs`
+
+*Primary key*: `id uuid` generated with `gen_random_uuid()`.
+
+| Column | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `ticker` | `text` | — | References `tickers(ticker)`; nullable for general-market research. |
+| `title` | `text` | — | Human-readable label shown in the uploader and citations. |
+| `source_type` | `text` | `null` | Free-form category (10-K, investor letter, transcript, etc.). |
+| `published_at` | `timestamptz` | `null` | Optional publication timestamp surfaced in the UI. |
+| `source_url` | `text` | `null` | Canonical URL for the underlying document. |
+| `storage_path` | `text` | — | Supabase Storage path (e.g., `raw/MSFT/2024-10-10-letter.pdf`). |
+| `uploaded_by` | `uuid` | `null` | References `auth.users(id)` for audit trails. |
+| `status` | `text` | `'pending'` | Processing lifecycle (`pending`, `processed`, `failed`). |
+| `chunk_count` | `int` | `0` | Populated by the chunking job. |
+| `token_count` | `int` | `0` | Sum of token estimates across stored chunks. |
+| `last_error` | `text` | `null` | Last processing failure captured by the edge worker. |
+| `processed_at` | `timestamptz` | `null` | Timestamp of the most recent successful chunk+embed run. |
+| `created_at` / `updated_at` | `timestamptz` | `now()` | Managed timestamps. |
+
+Uploads are saved to the Supabase Storage bucket `docs` under `raw/<ticker>/...` by the admin console at `/docs/index.html`.
+
 ### `doc_chunks`
 
 | Column | Type | Notes |
 | --- | --- | --- |
 | `id` | `bigserial` | Primary key. |
-| `ticker` | `text` | References `tickers`. |
-| `source` | `text` | Describes the document source (10-K 2024, investor letter, etc.). |
+| `doc_id` | `uuid` | References `docs(id)`; cascades on delete. |
+| `ticker` | `text` | Denormalised symbol for fast filtering. |
+| `source` | `text` | Optional legacy label retained for back-compat. |
+| `chunk_index` | `int` | Sequential index (0-based) assigned by the chunking worker. |
 | `chunk` | `text` | Plain-text snippet used for retrieval-augmented prompts. |
+| `token_length` | `int` | Approximate token count used for budgeting. |
+| `embedding` | `vector(1536)` | pgvector representation generated via `text-embedding-3-small`. |
 
-When enabling pgvector for semantic search, add an `embedding vector` column via a follow-up migration.
+An IVFFlat index on `embedding` accelerates similarity search for the retrieval helper.
+
+### `error_logs`
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `bigserial` | Primary key. |
+| `context` | `text` | Logical component (e.g., `docs-process`). |
+| `message` | `text` | Short description of the failure. |
+| `payload` | `jsonb` | Structured blob (request params, stack traces). |
+| `created_at` | `timestamptz` | Defaults to `now()`. |
+
+Reuse this table for future worker instrumentation (Stages 12–13).
+
+The Postgres RPC `match_doc_chunks(query_embedding double precision[], query_ticker text, match_limit int)` converts an array
+of floats into a `vector(1536)` and returns the top-k snippets ordered by cosine distance alongside document metadata. Workers
+invoke it after computing embeddings so they can inject `[D1]`-style citations into prompts.
 
 ### `analysis_dimensions`
 

--- a/planner.html
+++ b/planner.html
@@ -626,6 +626,52 @@
       gap: 12px;
       align-items: center;
     }
+
+    .auto-continue {
+      border: 1px solid rgba(37,99,235,.18);
+      background: rgba(37,99,235,.05);
+      border-radius: 16px;
+      padding: 14px 16px;
+      display: grid;
+      gap: 8px;
+    }
+
+    .auto-continue__controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+
+    .auto-continue__label {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-weight: 600;
+      font-size: .92rem;
+      color: var(--text,#0f172a);
+    }
+
+    .auto-continue__label input[type="checkbox"] {
+      width: 18px;
+      height: 18px;
+    }
+
+    .auto-continue select {
+      height: 34px;
+      border-radius: 10px;
+      border: 1px solid var(--border,#cbd5f5);
+      background: rgba(255,255,255,.92);
+      font: inherit;
+      padding: 0 12px;
+      color: var(--text,#0f172a);
+    }
+
+    .auto-continue__status {
+      margin: 0;
+      font-size: .85rem;
+      color: var(--muted,#475569);
+    }
     .sector-notes {
       border: 1px solid rgba(37,99,235,.18);
       background: rgba(37,99,235,.05);
@@ -1429,7 +1475,7 @@
     </nav>
   </header>
 
-  <main class="planner-shell planner-wrap">
+  <main class="planner-shell planner-wrap" data-gated="member">
     <header class="planner-headline">
       <a class="inline-link" href="/equity_analyst.html">← Back to analyst blueprint</a>
       <h1>Market Scan Planner & Cost Estimator</h1>
@@ -1692,6 +1738,24 @@
         <span id="stage1Status" role="status" aria-live="polite"></span>
       </div>
 
+      <section class="auto-continue" aria-label="Automation controls">
+        <div class="auto-continue__controls">
+          <label class="auto-continue__label" for="autoContinueToggle">
+            <input type="checkbox" id="autoContinueToggle" />
+            <span>Auto continue</span>
+          </label>
+          <label class="sr-only" for="autoContinueInterval">Auto continue interval</label>
+          <select id="autoContinueInterval">
+            <option value="15">Every 15 seconds</option>
+            <option value="30" selected>Every 30 seconds</option>
+            <option value="60">Every 60 seconds</option>
+          </select>
+        </div>
+        <p class="auto-continue__status" id="autoContinueStatus" role="status" aria-live="polite">
+          Auto continue idle.
+        </p>
+      </section>
+
       <section class="recent-results" aria-live="polite">
         <h3>Latest classifications</h3>
         <table class="recent-table">
@@ -1737,6 +1801,14 @@
         <div class="controller-metrics__item">
           <dt>Failed</dt>
           <dd id="stage2Failed">—</dd>
+        </div>
+        <div class="controller-metrics__item">
+          <dt>Retrieved snippets</dt>
+          <dd id="stage2ContextHits">—</dd>
+        </div>
+        <div class="controller-metrics__item">
+          <dt>Embedding tokens</dt>
+          <dd id="stage2ContextTokens">—</dd>
         </div>
       </dl>
 
@@ -1801,6 +1873,14 @@
       <div class="controller-metrics__item">
         <dt>Failed</dt>
         <dd id="stage3Failed">—</dd>
+      </div>
+      <div class="controller-metrics__item">
+        <dt>Retrieved snippets</dt>
+        <dd id="stage3ContextHits">—</dd>
+      </div>
+      <div class="controller-metrics__item">
+        <dt>Embedding tokens</dt>
+        <dd id="stage3ContextTokens">—</dd>
       </div>
     </dl>
 
@@ -1941,7 +2021,20 @@
       </div>
     </div>
   </div>
-</main>
+
+    <div class="gate-cta">
+      <div class="gate-cta__inner">
+        <div>
+          <strong>Members only</strong>
+          <p>Join FutureFunds.ai or sign in to run automated analyst sweeps.</p>
+        </div>
+        <div class="gate-cta__actions">
+          <button class="btn primary" type="button" data-open-auth="signup">Join membership</button>
+          <button class="btn" type="button" data-open-auth="signin">Sign in</button>
+        </div>
+      </div>
+    </div>
+  </main>
 
 <button type="button" class="guided-fab" id="guidedFab" aria-label="Start guided walkthrough">
   <strong>Need a tour?</strong>

--- a/sql/008_docs_rag.sql
+++ b/sql/008_docs_rag.sql
@@ -1,0 +1,89 @@
+create extension if not exists vector;
+
+create table if not exists public.docs (
+  id uuid primary key default gen_random_uuid(),
+  ticker text references public.tickers(ticker) on delete cascade,
+  title text not null,
+  source_type text,
+  published_at timestamptz,
+  source_url text,
+  storage_path text not null unique,
+  uploaded_by uuid references auth.users(id),
+  status text default 'pending',
+  chunk_count int default 0,
+  token_count int default 0,
+  last_error text,
+  processed_at timestamptz,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+alter table public.doc_chunks
+  add column if not exists doc_id uuid references public.docs(id) on delete cascade,
+  add column if not exists chunk_index int default 0,
+  add column if not exists token_length int default 0,
+  add column if not exists embedding vector(1536),
+  alter column source drop not null;
+
+create index if not exists doc_chunks_doc_id_idx on public.doc_chunks(doc_id);
+create index if not exists doc_chunks_ticker_idx on public.doc_chunks(ticker);
+create index if not exists doc_chunks_embedding_idx on public.doc_chunks using ivfflat (embedding vector_cosine_ops) with (lists = 100);
+
+create table if not exists public.error_logs (
+  id bigserial primary key,
+  context text,
+  message text,
+  payload jsonb,
+  created_at timestamptz default now()
+);
+
+create or replace function public.match_doc_chunks(
+  query_embedding double precision[],
+  query_ticker text,
+  match_limit int default 6
+)
+returns table (
+  doc_id uuid,
+  chunk_index int,
+  chunk text,
+  ticker text,
+  similarity double precision,
+  token_length int,
+  source_type text,
+  title text,
+  published_at timestamptz,
+  source_url text,
+  storage_path text
+)
+language plpgsql
+as $$
+declare
+  embedding vector(1536);
+begin
+  if query_embedding is null then
+    raise exception 'query_embedding is required';
+  end if;
+
+  embedding := query_embedding::vector(1536);
+
+  return query
+    select
+      c.doc_id,
+      c.chunk_index,
+      c.chunk,
+      c.ticker,
+      1 - (c.embedding <=> embedding) as similarity,
+      c.token_length,
+      d.source_type,
+      d.title,
+      d.published_at,
+      d.source_url,
+      d.storage_path
+    from public.doc_chunks c
+    join public.docs d on d.id = c.doc_id
+    where (query_ticker is null or c.ticker = query_ticker)
+      and c.embedding is not null
+    order by c.embedding <=> embedding
+    limit greatest(match_limit, 1);
+end;
+$$;

--- a/sql/009_member_access.sql
+++ b/sql/009_member_access.sql
@@ -1,0 +1,6 @@
+alter table public.runs
+  add column if not exists created_by uuid references auth.users(id),
+  add column if not exists created_by_email text;
+
+create index if not exists runs_created_by_idx on public.runs(created_by);
+create index if not exists runs_created_at_idx on public.runs(created_at);

--- a/supabase/functions/_shared/ai.ts
+++ b/supabase/functions/_shared/ai.ts
@@ -301,3 +301,26 @@ export async function requestChatCompletion(
   }
   return await response.json();
 }
+
+export async function requestEmbedding(
+  model: AIModel,
+  credential: AICredential,
+  input: string | string[]
+) {
+  const baseUrl = mergedBaseUrl(model, credential);
+  const url = `${baseUrl}/embeddings`;
+  const payload = {
+    model: model.model_name,
+    input: Array.isArray(input) ? input : [input]
+  };
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: buildHeaders(model, credential),
+    body: JSON.stringify(payload)
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Embedding request failed (${response.status}): ${text}`);
+  }
+  return await response.json();
+}

--- a/supabase/functions/docs-process/index.ts
+++ b/supabase/functions/docs-process/index.ts
@@ -1,0 +1,410 @@
+import { serve } from 'https://deno.land/std@0.210.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4';
+import {
+  resolveModel,
+  resolveCredential,
+  requestEmbedding
+} from '../_shared/ai.ts';
+
+type PdfJsModule = typeof import('https://esm.sh/pdfjs-dist@3.11.174/legacy/build/pdf.js');
+
+type JsonRecord = Record<string, unknown>;
+
+type DocRow = {
+  id: string;
+  ticker: string | null;
+  title: string;
+  source_type: string | null;
+  storage_path: string;
+  status: string | null;
+};
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS'
+};
+
+const jsonHeaders = {
+  ...corsHeaders,
+  'Content-Type': 'application/json'
+};
+
+const DEFAULT_EMBEDDING_MODEL = 'openai/text-embedding-3-small';
+const TARGET_TOKENS = 500;
+const OVERLAP_TOKENS = 50;
+const EMBED_CHUNK_DELAY_MS = (() => {
+  const raw = Number(Deno.env.get('DOC_EMBED_DELAY_MS') ?? '120');
+  return Number.isFinite(raw) && raw >= 0 ? raw : 120;
+})();
+
+function jsonResponse(status: number, body: JsonRecord) {
+  return new Response(JSON.stringify(body), { status, headers: jsonHeaders });
+}
+
+function isUuid(value: unknown) {
+  if (typeof value !== 'string') return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value.trim());
+}
+
+function collectRoles(source: unknown, bucket: Set<string>) {
+  if (!source) return;
+  if (Array.isArray(source)) {
+    source.forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  if (typeof source === 'object') {
+    Object.values(source as Record<string, unknown>).forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  const parts = String(source)
+    .split(/[\s,]+/)
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+  parts.forEach((role) => bucket.add(role));
+}
+
+function hasAdminMarker(record: Record<string, unknown> | null | undefined) {
+  if (!record) return false;
+  const flagKeys = ['is_admin', 'admin', 'isAdmin', 'is_superadmin', 'superuser', 'staff', 'is_staff'];
+  return flagKeys.some((key) => Boolean((record as Record<string, unknown>)[key]));
+}
+
+function isAdminContext(context: { user: JsonRecord | null; profile: JsonRecord | null; membership: JsonRecord | null }) {
+  const { user, profile, membership } = context;
+  if (hasAdminMarker(profile) || hasAdminMarker(membership) || hasAdminMarker(user ?? undefined)) {
+    return true;
+  }
+
+  const bucket = new Set<string>();
+  collectRoles(profile?.role, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_name, bucket);
+  collectRoles((profile as JsonRecord | null)?.user_role, bucket);
+  collectRoles((profile as JsonRecord | null)?.roles, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_tags, bucket);
+  collectRoles((profile as JsonRecord | null)?.access_level, bucket);
+
+  collectRoles(user?.app_metadata, bucket);
+  collectRoles(user?.user_metadata, bucket);
+
+  collectRoles(membership?.role, bucket);
+  collectRoles(membership?.roles, bucket);
+  collectRoles(membership?.access_level, bucket);
+
+  const privileged = new Set(['admin', 'administrator', 'superadmin', 'owner', 'editor', 'staff']);
+  for (const role of bucket) {
+    if (privileged.has(role)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function logError(client: ReturnType<typeof createClient>, context: string, message: string, payload: JsonRecord) {
+  try {
+    await client.from('error_logs').insert({ context, message, payload });
+  } catch (error) {
+    console.error('Failed to log error', error);
+  }
+}
+
+let pdfjsLibPromise: Promise<PdfJsModule | null> | null = null;
+
+async function getPdfJsModule(): Promise<PdfJsModule | null> {
+  if (!pdfjsLibPromise) {
+    pdfjsLibPromise = import('https://esm.sh/pdfjs-dist@3.11.174/legacy/build/pdf.js')
+      .then((mod) => {
+        const candidate = (mod as { default?: PdfJsModule }).default ?? (mod as PdfJsModule);
+        return candidate ?? null;
+      })
+      .catch((error) => {
+        console.warn('pdf.js module unavailable in docs-process runtime', error);
+        return null;
+      });
+  }
+  return pdfjsLibPromise;
+}
+
+type PdfExtractionResult = { text: string; error?: 'unsupported' | 'failed' };
+
+async function extractPdfText(bytes: Uint8Array): Promise<PdfExtractionResult> {
+  const pdfjsLib = await getPdfJsModule();
+  if (!pdfjsLib || typeof pdfjsLib.getDocument !== 'function') {
+    console.warn('pdf.js getDocument interface unavailable');
+    return { text: '', error: 'unsupported' };
+  }
+  try {
+    const doc = await pdfjsLib.getDocument({ data: bytes }).promise;
+    let text = '';
+    for (let pageNumber = 1; pageNumber <= doc.numPages; pageNumber++) {
+      const page = await doc.getPage(pageNumber);
+      const content = await page.getTextContent();
+      const pageText = content.items
+        .map((item: any) => (typeof item.str === 'string' ? item.str : ''))
+        .join(' ');
+      text += `${pageText}\n`;
+    }
+    return { text };
+  } catch (error) {
+    console.error('PDF extraction failed', error);
+    return { text: '', error: 'failed' };
+  }
+}
+
+function extractHtmlText(html: string) {
+  try {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    return doc?.body?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+  } catch (error) {
+    console.error('HTML extraction failed', error);
+    return html.replace(/<[^>]+>/g, ' ');
+  }
+}
+
+function normalizeWhitespace(text: string) {
+  return text.replace(/\r\n|\r/g, '\n').replace(/\s+/g, ' ').trim();
+}
+
+function chunkText(text: string) {
+  const words = text.split(/\s+/).filter(Boolean);
+  const chunks: { text: string; tokens: number }[] = [];
+  if (!words.length) return chunks;
+
+  const size = TARGET_TOKENS;
+  const overlap = OVERLAP_TOKENS;
+  let start = 0;
+
+  while (start < words.length) {
+    const end = Math.min(words.length, start + size);
+    const segment = words.slice(start, end).join(' ').trim();
+    if (segment.length) {
+      chunks.push({ text: segment, tokens: end - start });
+    }
+    if (end >= words.length) break;
+    start = Math.max(end - overlap, start + 1);
+  }
+
+  return chunks;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error('Missing Supabase configuration for docs-process');
+    return jsonResponse(500, { error: 'Server misconfigured' });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch (error) {
+    console.error('Invalid JSON payload', error);
+    return jsonResponse(400, { error: 'Invalid JSON payload' });
+  }
+
+  const docId = typeof body?.docId === 'string' ? body.docId.trim() : '';
+  if (!isUuid(docId)) {
+    return jsonResponse(400, { error: 'Invalid or missing docId' });
+  }
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+  const accessToken = tokenMatch?.[1]?.trim();
+  if (!accessToken) {
+    return jsonResponse(401, { error: 'Missing bearer token' });
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, { auth: { persistSession: false } });
+
+  const { data: userData, error: userError } = await supabaseAdmin.auth.getUser(accessToken);
+  if (userError || !userData?.user) {
+    console.error('Invalid session token for docs-process', userError);
+    return jsonResponse(401, { error: 'Invalid or expired session token' });
+  }
+
+  const [profileResult, membershipResult] = await Promise.all([
+    supabaseAdmin.from('profiles').select('*').eq('id', userData.user.id).maybeSingle(),
+    supabaseAdmin.from('memberships').select('*').eq('user_id', userData.user.id).maybeSingle()
+  ]);
+
+  const context = {
+    user: userData.user as JsonRecord,
+    profile: (profileResult.data ?? null) as JsonRecord | null,
+    membership: (membershipResult.data ?? null) as JsonRecord | null
+  };
+
+  if (!isAdminContext(context)) {
+    return jsonResponse(403, { error: 'Admin privileges required' });
+  }
+
+  const { data: docRow, error: docError } = await supabaseAdmin
+    .from('docs')
+    .select('id, ticker, title, source_type, storage_path, status')
+    .eq('id', docId)
+    .maybeSingle();
+
+  if (docError) {
+    console.error('Failed to load doc metadata', docError);
+    return jsonResponse(500, { error: 'Failed to load doc metadata' });
+  }
+
+  if (!docRow) {
+    return jsonResponse(404, { error: 'Document not found' });
+  }
+
+  const storagePath = docRow.storage_path;
+  const { data: fileData, error: downloadError } = await supabaseAdmin.storage.from('docs').download(storagePath);
+  if (downloadError || !fileData) {
+    console.error('Failed to download document', downloadError);
+    await supabaseAdmin
+      .from('docs')
+      .update({ status: 'failed', last_error: 'Unable to download source document' })
+      .eq('id', docId);
+    return jsonResponse(500, { error: 'Failed to download document' });
+  }
+
+  const arrayBuffer = await fileData.arrayBuffer();
+  const bytes = new Uint8Array(arrayBuffer);
+
+  const lowerPath = storagePath.toLowerCase();
+  let rawText = '';
+  let pdfError: PdfExtractionResult['error'] | undefined;
+  if (lowerPath.endsWith('.pdf')) {
+    const pdfResult = await extractPdfText(bytes);
+    rawText = pdfResult.text;
+    pdfError = pdfResult.error;
+  } else if (lowerPath.endsWith('.html') || lowerPath.endsWith('.htm')) {
+    rawText = extractHtmlText(new TextDecoder().decode(bytes));
+  } else {
+    rawText = new TextDecoder().decode(bytes);
+  }
+
+  rawText = normalizeWhitespace(rawText);
+
+  if ((!rawText || rawText.length < 40) && pdfError === 'unsupported') {
+    const message = 'PDF extraction is not supported in this deployment';
+    await supabaseAdmin
+      .from('docs')
+      .update({ status: 'failed', last_error: message })
+      .eq('id', docId);
+    await logError(supabaseAdmin, 'docs-process', 'pdf_unsupported', { docId, storagePath });
+    return jsonResponse(501, { error: message });
+  }
+
+  if (!rawText || rawText.length < 40) {
+    await supabaseAdmin
+      .from('docs')
+      .update({ status: 'failed', last_error: 'Document contained no extractable text' })
+      .eq('id', docId);
+    await logError(supabaseAdmin, 'docs-process', 'empty_text', { docId, storagePath });
+    return jsonResponse(422, { error: 'Document contained no extractable text' });
+  }
+
+  const chunks = chunkText(rawText).slice(0, 200);
+  if (!chunks.length) {
+    await supabaseAdmin
+      .from('docs')
+      .update({ status: 'failed', last_error: 'No chunks produced' })
+      .eq('id', docId);
+    await logError(supabaseAdmin, 'docs-process', 'chunking_failed', { docId });
+    return jsonResponse(422, { error: 'Failed to derive chunks from document' });
+  }
+
+  let embeddingModel;
+  try {
+    embeddingModel = await resolveModel(supabaseAdmin, DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_MODEL);
+  } catch (error) {
+    console.error('Embedding model resolution failed', error);
+    return jsonResponse(500, { error: 'Embedding model not configured' });
+  }
+
+  let credential;
+  try {
+    credential = await resolveCredential(supabaseAdmin, {
+      credentialId: null,
+      provider: embeddingModel.provider,
+      preferScopes: ['automation', 'rag', 'editor'],
+      allowEnvFallback: true,
+      envKeys: ['OPENAI_API_KEY']
+    });
+  } catch (error) {
+    console.error('Embedding credential resolution failed', error);
+    return jsonResponse(500, { error: 'Embedding credential not configured' });
+  }
+
+  const embeddingVectors: number[][] = [];
+  let embeddingTokens = 0;
+
+  for (const chunk of chunks) {
+    const response = await requestEmbedding(embeddingModel, credential, chunk.text);
+    const vector = response?.data?.[0]?.embedding as number[] | undefined;
+    if (!vector) {
+      await logError(supabaseAdmin, 'docs-process', 'embedding_failed', { docId, reason: 'missing_vector' });
+      return jsonResponse(500, { error: 'Failed to compute embeddings' });
+    }
+    embeddingVectors.push(vector);
+    const usage = response?.usage as Record<string, unknown> | undefined;
+    const totalTokens = Number(usage?.total_tokens ?? usage?.prompt_tokens ?? 0);
+    if (Number.isFinite(totalTokens)) embeddingTokens += totalTokens;
+    if (EMBED_CHUNK_DELAY_MS > 0) {
+      await new Promise((resolve) => setTimeout(resolve, EMBED_CHUNK_DELAY_MS));
+    }
+  }
+
+  const chunkRows = chunks.map((chunk, index) => ({
+    doc_id: docId,
+    ticker: docRow.ticker,
+    source: docRow.source_type || docRow.title,
+    chunk: chunk.text,
+    chunk_index: index,
+    token_length: chunk.tokens,
+    embedding: embeddingVectors[index]
+  }));
+
+  await supabaseAdmin.from('doc_chunks').delete().eq('doc_id', docId);
+
+  const { error: insertError } = await supabaseAdmin.from('doc_chunks').insert(chunkRows);
+  if (insertError) {
+    console.error('Failed to insert doc chunks', insertError);
+    await supabaseAdmin
+      .from('docs')
+      .update({ status: 'failed', last_error: 'Failed to persist doc chunks' })
+      .eq('id', docId);
+    return jsonResponse(500, { error: 'Failed to persist doc chunks' });
+  }
+
+  const totalTokens = chunks.reduce((acc, chunk) => acc + chunk.tokens, 0);
+
+  const { data: updatedDoc } = await supabaseAdmin
+    .from('docs')
+    .update({
+      status: 'processed',
+      chunk_count: chunkRows.length,
+      token_count: totalTokens,
+      processed_at: new Date().toISOString(),
+      last_error: null
+    })
+    .eq('id', docId)
+    .select('*')
+    .maybeSingle();
+
+  return jsonResponse(200, {
+    ok: true,
+    doc: updatedDoc ?? docRow,
+    chunk_count: chunkRows.length,
+    token_count: totalTokens,
+    embedding_tokens: embeddingTokens
+  });
+});

--- a/supabase/functions/runs-continue/index.ts
+++ b/supabase/functions/runs-continue/index.ts
@@ -1,0 +1,677 @@
+import { serve } from 'https://deno.land/std@0.210.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4';
+
+type JsonRecord = Record<string, unknown>;
+
+type Stage1Metrics = {
+  total: number;
+  pending: number;
+  completed: number;
+  failed: number;
+};
+
+type Stage2Summary = {
+  total_survivors: number;
+  pending: number;
+  completed: number;
+  failed: number;
+  go_deep: number;
+};
+
+type Stage3Summary = {
+  total_finalists: number;
+  pending: number;
+  completed: number;
+  failed: number;
+};
+
+type StageOperation = {
+  stage: 1 | 2 | 3;
+  status: 'invoked' | 'halted';
+  processed: number;
+  failed: number;
+  message: string;
+  metrics: JsonRecord | null;
+  http_status: number;
+};
+
+type InvokeOutcome =
+  | { type: 'ok'; operation: StageOperation; metrics: JsonRecord | null }
+  | { type: 'halt'; operation: StageOperation; metrics: JsonRecord | null; reason: 'stop_requested' }
+  | { type: 'error'; status: number; message: string; details?: JsonRecord | null };
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS'
+};
+
+const jsonHeaders = {
+  ...corsHeaders,
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store'
+};
+
+const DEFAULT_STAGE_LIMITS = { stage1: 8, stage2: 4, stage3: 2 } as const;
+const MAX_STAGE_LIMIT = 25;
+const MAX_CYCLES = 10;
+
+function jsonResponse(status: number, body: JsonRecord) {
+  return new Response(JSON.stringify(body), { status, headers: jsonHeaders });
+}
+
+function clampInteger(value: unknown, min: number, max: number, fallback: number) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  const rounded = Math.floor(num);
+  if (Number.isNaN(rounded)) return fallback;
+  return Math.min(Math.max(rounded, min), max);
+}
+
+function isUuid(value: unknown) {
+  if (typeof value !== 'string') return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value.trim());
+}
+
+function collectRoles(source: unknown, bucket: Set<string>) {
+  if (!source) return;
+  if (Array.isArray(source)) {
+    source.forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  if (typeof source === 'object') {
+    Object.values(source as Record<string, unknown>).forEach((entry) => collectRoles(entry, bucket));
+    return;
+  }
+  const parts = String(source)
+    .split(/[\s,]+/)
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+  parts.forEach((role) => bucket.add(role));
+}
+
+function hasAdminMarker(record: Record<string, unknown> | null | undefined) {
+  if (!record) return false;
+  const flagKeys = ['is_admin', 'admin', 'isAdmin', 'is_superadmin', 'superuser', 'staff', 'is_staff'];
+  return flagKeys.some((key) => Boolean((record as Record<string, unknown>)[key]));
+}
+
+function isAdminContext(context: { user: JsonRecord | null; profile: JsonRecord | null; membership: JsonRecord | null }) {
+  const { user, profile, membership } = context;
+  if (hasAdminMarker(profile) || hasAdminMarker(membership) || hasAdminMarker(user ?? undefined)) {
+    return true;
+  }
+
+  const bucket = new Set<string>();
+  collectRoles(profile?.role, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_name, bucket);
+  collectRoles((profile as JsonRecord | null)?.user_role, bucket);
+  collectRoles((profile as JsonRecord | null)?.roles, bucket);
+  collectRoles((profile as JsonRecord | null)?.role_tags, bucket);
+  collectRoles((profile as JsonRecord | null)?.access_level, bucket);
+
+  collectRoles(user?.app_metadata, bucket);
+  collectRoles(user?.user_metadata, bucket);
+
+  collectRoles(membership?.role, bucket);
+  collectRoles(membership?.roles, bucket);
+  collectRoles(membership?.access_level, bucket);
+
+  const privileged = new Set(['admin', 'administrator', 'superadmin', 'owner', 'editor', 'staff']);
+  for (const role of bucket) {
+    if (privileged.has(role)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function computeStage1Metrics(client: ReturnType<typeof createClient>, runId: string): Promise<Stage1Metrics> {
+  const [totalRes, pendingRes, completedRes, failedRes] = await Promise.all([
+    client.from('run_items').select('*', { count: 'exact', head: true }).eq('run_id', runId),
+    client
+      .from('run_items')
+      .select('*', { count: 'exact', head: true })
+      .eq('run_id', runId)
+      .eq('status', 'pending')
+      .eq('stage', 0),
+    client
+      .from('run_items')
+      .select('*', { count: 'exact', head: true })
+      .eq('run_id', runId)
+      .eq('status', 'ok')
+      .gte('stage', 1),
+    client
+      .from('run_items')
+      .select('*', { count: 'exact', head: true })
+      .eq('run_id', runId)
+      .eq('status', 'failed')
+  ]);
+
+  if (totalRes.error) throw totalRes.error;
+  if (pendingRes.error) throw pendingRes.error;
+  if (completedRes.error) throw completedRes.error;
+  if (failedRes.error) throw failedRes.error;
+
+  return {
+    total: totalRes.count ?? 0,
+    pending: pendingRes.count ?? 0,
+    completed: completedRes.count ?? 0,
+    failed: failedRes.count ?? 0
+  };
+}
+
+async function fetchStage2Summary(client: ReturnType<typeof createClient>, runId: string): Promise<Stage2Summary> {
+  const { data, error } = await client.rpc('run_stage2_summary', { p_run_id: runId }).maybeSingle();
+  if (error) {
+    console.error('run_stage2_summary failed', error);
+    return { total_survivors: 0, pending: 0, completed: 0, failed: 0, go_deep: 0 };
+  }
+
+  return {
+    total_survivors: Number(data?.total_survivors ?? 0),
+    pending: Number(data?.pending ?? 0),
+    completed: Number(data?.completed ?? 0),
+    failed: Number(data?.failed ?? 0),
+    go_deep: Number(data?.go_deep ?? 0)
+  };
+}
+
+async function fetchStage3Summary(client: ReturnType<typeof createClient>, runId: string): Promise<Stage3Summary> {
+  const { data, error } = await client.rpc('run_stage3_summary', { p_run_id: runId }).maybeSingle();
+  if (error) {
+    console.error('run_stage3_summary failed', error);
+    return { total_finalists: 0, pending: 0, completed: 0, failed: 0 };
+  }
+
+  return {
+    total_finalists: Number(data?.total_finalists ?? 0),
+    pending: Number(data?.pending ?? 0),
+    completed: Number(data?.completed ?? 0),
+    failed: Number(data?.failed ?? 0)
+  };
+}
+
+async function fetchCostSummary(client: ReturnType<typeof createClient>, runId: string) {
+  const { data, error } = await client.rpc('run_cost_summary', { p_run_id: runId }).maybeSingle();
+  if (error) {
+    console.error('run_cost_summary failed', error);
+    return { totalCost: 0, totalTokensIn: 0, totalTokensOut: 0 };
+  }
+
+  return {
+    totalCost: Number(data?.total_cost ?? 0),
+    totalTokensIn: Number(data?.total_tokens_in ?? 0),
+    totalTokensOut: Number(data?.total_tokens_out ?? 0)
+  };
+}
+
+function mergeClientMeta(base: Record<string, unknown> | null | undefined, additions: Record<string, unknown>) {
+  if (!base || typeof base !== 'object') {
+    return additions;
+  }
+  try {
+    return { ...base, ...additions };
+  } catch (_error) {
+    return additions;
+  }
+}
+
+async function invokeStage({
+  stage,
+  limit,
+  runId,
+  accessToken,
+  functionsBaseUrl,
+  cycleIndex,
+  clientMeta
+}: {
+  stage: 1 | 2 | 3;
+  limit: number;
+  runId: string;
+  accessToken: string;
+  functionsBaseUrl: string;
+  cycleIndex: number;
+  clientMeta: Record<string, unknown> | null | undefined;
+}): Promise<InvokeOutcome> {
+  const endpoint =
+    stage === 1
+      ? `${functionsBaseUrl}/stage1-consume`
+      : stage === 2
+        ? `${functionsBaseUrl}/stage2-consume`
+        : `${functionsBaseUrl}/stage3-consume`;
+
+  const meta = mergeClientMeta(clientMeta, {
+    orchestrator: 'runs-continue',
+    cycle_index: cycleIndex,
+    triggered_at: new Date().toISOString()
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`
+      },
+      body: JSON.stringify({
+        run_id: runId,
+        limit,
+        client_meta: meta
+      })
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error invoking stage';
+    return { type: 'error', status: 502, message };
+  }
+
+  let payload: JsonRecord | null = null;
+  try {
+    const raw = await response.text();
+    payload = raw ? (JSON.parse(raw) as JsonRecord) : {};
+  } catch (error) {
+    console.warn(`Failed to parse JSON from stage${stage}-consume`, error);
+    payload = null;
+  }
+
+  if (!response.ok) {
+    const message =
+      (payload?.error && typeof payload.error === 'string')
+        ? payload.error
+        : `Stage ${stage} responded with status ${response.status}`;
+
+    if (response.status === 409) {
+      const operation: StageOperation = {
+        stage,
+        status: 'halted',
+        processed: Number(payload?.processed ?? 0),
+        failed: Number(payload?.failed ?? 0),
+        message,
+        metrics: (payload?.metrics as JsonRecord) ?? null,
+        http_status: response.status
+      };
+      return { type: 'halt', operation, metrics: operation.metrics, reason: 'stop_requested' };
+    }
+
+    return { type: 'error', status: response.status, message, details: payload };
+  }
+
+  const operation: StageOperation = {
+    stage,
+    status: 'invoked',
+    processed: Number(payload?.processed ?? 0),
+    failed: Number(payload?.failed ?? 0),
+    message: typeof payload?.message === 'string' ? (payload.message as string) : 'Stage completed.',
+    metrics: (payload?.metrics as JsonRecord) ?? null,
+    http_status: response.status
+  };
+
+  return { type: 'ok', operation, metrics: operation.metrics };
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error('Missing Supabase configuration for runs-continue');
+    return jsonResponse(500, { error: 'Server misconfigured' });
+  }
+
+  let payload: any;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error('Invalid JSON payload for runs-continue', error);
+    return jsonResponse(400, { error: 'Invalid JSON payload' });
+  }
+
+  const requestedRunId = typeof payload?.run_id === 'string' ? payload.run_id.trim() : '';
+  const runIdInput = isUuid(requestedRunId) ? requestedRunId : null;
+
+  const limitPayload = payload?.stage_limits ?? {};
+  const stageLimits = {
+    stage1: clampInteger(limitPayload?.stage1 ?? payload?.stage1_limit ?? payload?.limit, 1, MAX_STAGE_LIMIT, DEFAULT_STAGE_LIMITS.stage1),
+    stage2: clampInteger(limitPayload?.stage2 ?? payload?.stage2_limit ?? payload?.limit, 1, MAX_STAGE_LIMIT, DEFAULT_STAGE_LIMITS.stage2),
+    stage3: clampInteger(limitPayload?.stage3 ?? payload?.stage3_limit ?? payload?.limit, 1, MAX_STAGE_LIMIT, DEFAULT_STAGE_LIMITS.stage3)
+  };
+
+  const cycles = clampInteger(payload?.cycles, 1, MAX_CYCLES, 1);
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  const tokenMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+  const accessToken = tokenMatch?.[1]?.trim();
+
+  if (!accessToken) {
+    return jsonResponse(401, { error: 'Missing bearer token' });
+  }
+
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, { auth: { persistSession: false } });
+
+  const { data: userData, error: userError } = await supabaseAdmin.auth.getUser(accessToken);
+  if (userError || !userData?.user) {
+    console.error('Invalid session token for runs-continue', userError);
+    return jsonResponse(401, { error: 'Invalid or expired session token' });
+  }
+
+  const [profileResult, membershipResult] = await Promise.all([
+    supabaseAdmin.from('profiles').select('*').eq('id', userData.user.id).maybeSingle(),
+    supabaseAdmin.from('memberships').select('*').eq('user_id', userData.user.id).maybeSingle()
+  ]);
+
+  if (profileResult.error) {
+    console.warn('Failed to load profile for runs-continue', profileResult.error);
+  }
+  if (membershipResult.error) {
+    console.warn('Failed to load membership for runs-continue', membershipResult.error);
+  }
+
+  const context = {
+    user: userData.user as JsonRecord,
+    profile: (profileResult.data ?? null) as JsonRecord | null,
+    membership: (membershipResult.data ?? null) as JsonRecord | null
+  };
+
+  if (!isAdminContext(context)) {
+    return jsonResponse(403, { error: 'Admin access required' });
+  }
+
+  const runColumns = 'id, status, stop_requested, notes, budget_usd';
+
+  let runRow: Record<string, unknown> | null = null;
+  let runError: Error | null = null;
+
+  if (runIdInput) {
+    const { data, error } = await supabaseAdmin.from('runs').select(runColumns).eq('id', runIdInput).maybeSingle();
+    if (error && error.message?.toLowerCase().includes('budget_usd')) {
+      const fallback = await supabaseAdmin
+        .from('runs')
+        .select('id, status, stop_requested, notes')
+        .eq('id', runIdInput)
+        .maybeSingle();
+      runRow = fallback.data ?? null;
+      runError = fallback.error ?? null;
+    } else {
+      runRow = data ?? null;
+      runError = error;
+    }
+  } else {
+    const { data, error } = await supabaseAdmin
+      .from('runs')
+      .select(runColumns)
+      .in('status', ['running', 'queued'])
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error && error.message?.toLowerCase().includes('budget_usd')) {
+      const fallback = await supabaseAdmin
+        .from('runs')
+        .select('id, status, stop_requested, notes')
+        .in('status', ['running', 'queued'])
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      runRow = fallback.data ?? null;
+      runError = fallback.error ?? null;
+    } else {
+      runRow = data ?? null;
+      runError = error;
+    }
+  }
+
+  if (runError) {
+    console.error('Failed to load run for runs-continue', runError);
+    return jsonResponse(500, { error: 'Failed to load run', details: runError.message });
+  }
+
+  if (!runRow) {
+    return jsonResponse(404, { error: 'Run not found' });
+  }
+
+  const runId = String(runRow.id);
+  const runStatus = typeof runRow.status === 'string' ? (runRow.status as string) : null;
+
+  const budgetValue = Number(runRow?.budget_usd ?? NaN);
+  const budgetConfigured = Number.isFinite(budgetValue) && budgetValue > 0;
+
+  const initialCost = await fetchCostSummary(supabaseAdmin, runId);
+  let totalCost = initialCost.totalCost;
+
+  const budgetExceededInitially = budgetConfigured && totalCost >= budgetValue - 0.0005;
+
+  let stopRequested = Boolean(runRow?.stop_requested ?? false);
+  let haltedReason: 'stop_requested' | 'budget_exhausted' | null = null;
+
+  if (stopRequested) {
+    haltedReason = 'stop_requested';
+  } else if (budgetExceededInitially) {
+    haltedReason = 'budget_exhausted';
+    const { data: updated, error: updateError } = await supabaseAdmin
+      .from('runs')
+      .update({ stop_requested: true })
+      .eq('id', runId)
+      .select('stop_requested')
+      .maybeSingle();
+    if (updateError) {
+      console.warn('Failed to set stop_requested after budget exhaustion', updateError);
+    } else if (updated) {
+      stopRequested = Boolean(updated.stop_requested);
+    }
+  }
+
+  const functionsBaseUrl = supabaseUrl.replace(/\.supabase\.co$/, '.functions.supabase.co');
+
+  let stage1Metrics = await computeStage1Metrics(supabaseAdmin, runId);
+  let stage2Summary = await fetchStage2Summary(supabaseAdmin, runId);
+  let stage3Summary = await fetchStage3Summary(supabaseAdmin, runId);
+
+  const operations: StageOperation[] = [];
+  let cyclesCompleted = 0;
+
+  if (!haltedReason) {
+    for (let cycle = 0; cycle < cycles; cycle += 1) {
+      let cycleDidWork = false;
+
+      if (stage1Metrics.pending > 0) {
+        const outcome = await invokeStage({
+          stage: 1,
+          limit: stageLimits.stage1,
+          runId,
+          accessToken,
+          functionsBaseUrl,
+          cycleIndex: cycle,
+          clientMeta: payload?.client_meta
+        });
+
+        if (outcome.type === 'error') {
+          return jsonResponse(outcome.status, {
+            error: outcome.message,
+            details: outcome.details ?? null,
+            operations,
+            stage_status: {
+              stage1: stage1Metrics,
+              stage2: stage2Summary,
+              stage3: stage3Summary
+            }
+          });
+        }
+
+        operations.push(outcome.operation);
+        stage1Metrics = await computeStage1Metrics(supabaseAdmin, runId);
+        stage2Summary = await fetchStage2Summary(supabaseAdmin, runId);
+        cycleDidWork = true;
+
+        if (outcome.type === 'halt') {
+          haltedReason = outcome.reason;
+          break;
+        }
+      }
+
+      if (haltedReason) break;
+
+      if (stage2Summary.pending > 0) {
+        const outcome = await invokeStage({
+          stage: 2,
+          limit: stageLimits.stage2,
+          runId,
+          accessToken,
+          functionsBaseUrl,
+          cycleIndex: cycle,
+          clientMeta: payload?.client_meta
+        });
+
+        if (outcome.type === 'error') {
+          return jsonResponse(outcome.status, {
+            error: outcome.message,
+            details: outcome.details ?? null,
+            operations,
+            stage_status: {
+              stage1: stage1Metrics,
+              stage2: stage2Summary,
+              stage3: stage3Summary
+            }
+          });
+        }
+
+        operations.push(outcome.operation);
+        stage2Summary = await fetchStage2Summary(supabaseAdmin, runId);
+        stage3Summary = await fetchStage3Summary(supabaseAdmin, runId);
+        cycleDidWork = true;
+
+        if (outcome.type === 'halt') {
+          haltedReason = outcome.reason;
+          break;
+        }
+      }
+
+      if (haltedReason) break;
+
+      if (stage3Summary.pending > 0) {
+        const outcome = await invokeStage({
+          stage: 3,
+          limit: stageLimits.stage3,
+          runId,
+          accessToken,
+          functionsBaseUrl,
+          cycleIndex: cycle,
+          clientMeta: payload?.client_meta
+        });
+
+        if (outcome.type === 'error') {
+          return jsonResponse(outcome.status, {
+            error: outcome.message,
+            details: outcome.details ?? null,
+            operations,
+            stage_status: {
+              stage1: stage1Metrics,
+              stage2: stage2Summary,
+              stage3: stage3Summary
+            }
+          });
+        }
+
+        operations.push(outcome.operation);
+        stage3Summary = await fetchStage3Summary(supabaseAdmin, runId);
+        cycleDidWork = true;
+
+        if (outcome.type === 'halt') {
+          haltedReason = outcome.reason;
+          break;
+        }
+      }
+
+      if (!cycleDidWork) {
+        break;
+      }
+
+      cyclesCompleted += 1;
+    }
+  }
+
+  // Refresh metrics after potential changes.
+  stage1Metrics = await computeStage1Metrics(supabaseAdmin, runId);
+  stage2Summary = await fetchStage2Summary(supabaseAdmin, runId);
+  stage3Summary = await fetchStage3Summary(supabaseAdmin, runId);
+
+  const finalCost = await fetchCostSummary(supabaseAdmin, runId);
+  totalCost = finalCost.totalCost;
+
+  let budgetExceeded = budgetConfigured && totalCost >= budgetValue - 0.0005;
+
+  if (budgetExceeded && !stopRequested) {
+    const { data: updated, error: updateError } = await supabaseAdmin
+      .from('runs')
+      .update({ stop_requested: true })
+      .eq('id', runId)
+      .select('stop_requested')
+      .maybeSingle();
+    if (updateError) {
+      console.warn('Failed to set stop_requested after final budget check', updateError);
+    } else if (updated) {
+      stopRequested = Boolean(updated.stop_requested);
+    }
+  }
+
+  if (!haltedReason && stopRequested) {
+    haltedReason = budgetExceeded ? 'budget_exhausted' : 'stop_requested';
+  }
+
+  if (!budgetExceeded) {
+    budgetExceeded = budgetExceededInitially;
+  }
+
+  const processedTotal = operations.reduce((acc, op) => acc + (Number.isFinite(op.processed) ? Number(op.processed) : 0), 0);
+
+  let message: string;
+  if (haltedReason === 'budget_exhausted') {
+    message = 'Budget exhausted. Auto continue halted.';
+  } else if (haltedReason === 'stop_requested') {
+    message = 'Run flagged to stop. Auto continue halted.';
+  } else if (operations.length === 0) {
+    message = 'No pending work for any stage.';
+  } else {
+    message = `Auto continue processed ${processedTotal} item${processedTotal === 1 ? '' : 's'} across ${cyclesCompleted || 1} cycle${cyclesCompleted === 1 ? '' : 's'}.`;
+  }
+
+  const halted = haltedReason
+    ? {
+        reason: haltedReason,
+        message
+      }
+    : null;
+
+  return jsonResponse(200, {
+    run_id: runId,
+    run_status: runStatus,
+    stop_requested: stopRequested,
+    cycles_requested: cycles,
+    cycles_completed: cyclesCompleted,
+    operations,
+    stage_status: {
+      stage1: stage1Metrics,
+      stage2: stage2Summary,
+      stage3: stage3Summary
+    },
+    cost: {
+      total_cost: totalCost,
+      budget_usd: budgetConfigured ? budgetValue : null,
+      budget_exhausted: budgetExceeded,
+      total_tokens_in: finalCost.totalTokensIn,
+      total_tokens_out: finalCost.totalTokensOut
+    },
+    halted,
+    message,
+    timestamp: new Date().toISOString()
+  });
+});

--- a/ticker.html
+++ b/ticker.html
@@ -36,6 +36,18 @@
   .panel h2 { margin: 0; font-size: 1.4rem; }
   .panel h3 { margin: 16px 0 8px; font-size: 1rem; }
   .panel p { margin: 0; line-height: 1.5; }
+  .citation-panel { border-top: 1px solid rgba(148, 163, 184, 0.24); padding-top: 12px; display: grid; gap: 10px; }
+  .citation-panel h3 { margin: 0; font-size: 0.95rem; letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted, #64748b); }
+  .citation-panel[hidden] { display: none; }
+  .citation-list { margin: 0; padding-left: 1.2em; display: grid; gap: 12px; font-size: 0.9rem; }
+  .citation-list--compact { gap: 8px; font-size: 0.82rem; }
+  .citation-item { display: grid; gap: 4px; }
+  .citation-ref { font-weight: 600; }
+  .citation-body { display: grid; gap: 2px; }
+  .citation-title { font-weight: 600; }
+  .citation-title a { color: inherit; text-decoration: underline; text-decoration-color: rgba(37, 99, 235, 0.45); }
+  .citation-meta { font-size: 0.78rem; color: var(--muted, #64748b); }
+  .citation-list--compact .citation-meta { font-size: 0.72rem; }
   .pill { display: inline-flex; align-items: center; gap: 6px; border-radius: 999px; padding: 4px 12px; background: color-mix(in srgb, var(--accent, #2563eb) 12%, var(--panel-bg) 88%); color: var(--accent-contrast, #0f172a); font-size: 0.8rem; font-weight: 600; }
   .badge { font-size: 0.75rem; letter-spacing: 0.06em; text-transform: uppercase; border-radius: 999px; padding: 4px 10px; border: 1px solid currentColor; display: inline-flex; align-items: center; gap: 6px; }
   .badge.pending { color: #0ea5e9; }
@@ -68,6 +80,8 @@
   .question-meta { font-size: 0.8rem; color: var(--muted, #64748b); }
   .question-raw details { border: 1px solid var(--panel-border); border-radius: 12px; padding: 8px 12px; background: var(--bg, #f1f5f9); font-size: 0.8rem; }
   .question-raw pre { margin: 8px 0 0; white-space: pre-wrap; word-break: break-word; }
+  .question-citations { display: grid; gap: 6px; border-top: 1px solid rgba(148, 163, 184, 0.28); padding-top: 10px; }
+  .question-citations strong { font-size: 0.78rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted, #64748b); }
 
   .list { display: grid; gap: 8px; }
   .list li { margin-left: 18px; }
@@ -166,15 +180,15 @@
 
 <main class="wrap layout">
   <section id="tickerGate" class="gate" hidden>
-    <h2>Members-only dossier</h2>
-    <p>This page surfaces raw Stage 1–3 outputs. Sign in with an analyst account to continue.</p>
+    <h2>Member access required</h2>
+    <p id="tickerGateMessage">Sign in with your FutureFunds.ai membership to open the full Stage 1–3 dossier.</p>
     <div class="actions">
-      <a class="btn primary" href="/login.html">Sign in</a>
-      <a class="btn" href="/membership.html">Request access</a>
+      <button class="btn primary" type="button" data-open-auth="signin">Sign in</button>
+      <button class="btn" type="button" data-open-auth="signup">Join membership</button>
     </div>
   </section>
 
-  <section id="tickerContent" hidden>
+  <section id="tickerContent" data-gated="member" hidden>
     <article class="context-card">
       <div class="controls-row">
         <label for="runPicker" class="sr-only">Select run</label>
@@ -226,6 +240,10 @@
       <div id="stage2Scores"></div>
       <div id="stage2Verdict"></div>
       <div id="stage2Next"></div>
+      <section id="stage2Citations" class="citation-panel" hidden>
+        <h3>Stage 2 sources</h3>
+        <ol id="stage2CitationList" class="citation-list"></ol>
+      </section>
     </article>
 
     <article class="panel" id="stage3Panel">
@@ -233,9 +251,26 @@
         <h2>Stage 3 — Deep dive report</h2>
       </header>
       <p id="stage3Summary" class="muted">Deep dive not yet available.</p>
+      <section id="stage3Citations" class="citation-panel" hidden>
+        <h3>Sources cited</h3>
+        <ol id="stage3CitationList" class="citation-list"></ol>
+      </section>
       <section id="stage3Scorecard" class="scorecard-grid" hidden></section>
       <div id="stage3Questions" class="question-grid"></div>
     </article>
+
+    <div class="gate-cta">
+      <div class="gate-cta__inner">
+        <div>
+          <strong>Members only</strong>
+          <p>Active members can trace every stage output and citation for this ticker.</p>
+        </div>
+        <div class="gate-cta__actions">
+          <button class="btn primary" type="button" data-open-auth="signup">Join membership</button>
+          <button class="btn" type="button" data-open-auth="signin">Sign in</button>
+        </div>
+      </div>
+    </div>
   </section>
 </main>
 

--- a/universe.html
+++ b/universe.html
@@ -165,22 +165,22 @@
   </nav>
 </header>
 
-<section class="wrap hero">
+  <section class="wrap hero">
   <h1>Automated Analyst Universe</h1>
   <p>Inspect the latest multi-stage equity runs. Filter by stage, label, or sector, export reports, and jump into full dossiers for any ticker.</p>
 </section>
 
 <main class="wrap universe-shell">
   <section id="gate" class="gate" hidden>
-    <h2>Members-only research cockpit</h2>
-    <p>This dashboard exposes raw pipeline outputs and costs. Please sign in with an analyst or admin account to continue.</p>
+    <h2>Member access required</h2>
+    <p id="gateMessage">Sign in with your FutureFunds.ai membership to view the analyst universe.</p>
     <div class="actions">
-      <a class="btn primary" href="/login.html">Sign in</a>
-      <a class="btn" href="/membership.html">Request access</a>
+      <button class="btn primary" type="button" data-open-auth="signin">Sign in</button>
+      <button class="btn" type="button" data-open-auth="signup">Join membership</button>
     </div>
   </section>
 
-  <section id="universeContent" hidden>
+  <section id="universeContent" data-gated="member" hidden>
     <div class="controls-card">
       <div class="controls-grid">
         <label for="runSelect">Run</label>
@@ -271,6 +271,19 @@
       <div class="table-footer">
         <button id="loadMoreBtn" type="button">Load more</button>
         <span class="status-text" id="tableStatus">—</span>
+      </div>
+    </div>
+
+    <div class="gate-cta">
+      <div class="gate-cta__inner">
+        <div>
+          <strong>Members only</strong>
+          <p>Unlock the full analyst universe with an active FutureFunds.ai membership.</p>
+        </div>
+        <div class="gate-cta__actions">
+          <button class="btn primary" type="button" data-open-auth="signup">Join membership</button>
+          <button class="btn" type="button" data-open-auth="signin">Sign in</button>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- gate the planner, universe, and ticker dashboards with member-focused call-to-actions and read-only messaging for non-admin accounts
- add styling for the new gate overlay, adjust planner access handling for member sessions, and update roadmap documentation for completed Stage 10/11 tasks
- enforce per-user daily run quotas via `RUNS_DAILY_LIMIT`, record run ownership metadata, and document the new schema migration

## Testing
- not run (frontend/serverless changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e2cbc05c84832d8375f4df63cbd2f9