### PR TITLE
Fix tickers_admin_write insert policy definition

### DIFF
--- a/sql/013_watchlists.sql
+++ b/sql/013_watchlists.sql
@@ -89,8 +89,7 @@ create policy tickers_read on public.tickers
 drop policy if exists tickers_admin_write on public.tickers;
 create policy tickers_admin_write on public.tickers
   for insert
-  with check (public.is_admin(auth.uid()))
-  using (public.is_admin(auth.uid()));
+  with check (public.is_admin(auth.uid()));
 
 drop policy if exists tickers_admin_update on public.tickers;
 create policy tickers_admin_update on public.tickers


### PR DESCRIPTION
## Summary
- update the `tickers_admin_write` policy to rely solely on `WITH CHECK` for inserts so it matches PostgreSQL semantics

## Testing
- not run (Supabase CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3b7c753dc832d81f7d04976ddd8a9