### PR TITLE
Improve planner run scope UI and custom ticker input

### DIFF
--- a/assets/planner.js
+++ b/assets/planner.js
@@ -484,7 +484,13 @@ function updateScopeUI({ fromSettings = false } = {}) {
     inputs.refreshWatchlistsBtn.disabled = watchlistLoading;
   }
   if (inputs.customTickers) {
-    inputs.customTickers.disabled = mode !== 'custom';
+    const isCustom = mode === 'custom';
+    inputs.customTickers.readOnly = !isCustom;
+    if (isCustom) {
+      inputs.customTickers.removeAttribute('aria-disabled');
+    } else {
+      inputs.customTickers.setAttribute('aria-disabled', 'true');
+    }
   }
 
   if (inputs.universe) {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1545,7 +1545,7 @@ body.theme-light table.grid pre{
   border-radius:16px;
   padding:16px 18px;
   display:grid;
-  gap:12px;
+  gap:16px;
   background:rgba(37,99,235,.04);
 }
 .scope-field legend{
@@ -1555,39 +1555,48 @@ body.theme-light table.grid pre{
 }
 .scope-options{
   display:grid;
-  gap:14px;
+  gap:18px;
 }
 .scope-option{
   display:grid;
-  gap:6px;
-  align-items:flex-start;
+  gap:10px;
   border-bottom:1px solid rgba(148,163,184,.3);
-  padding-bottom:12px;
+  padding-bottom:16px;
 }
 .scope-option:last-child{border-bottom:none;padding-bottom:0}
-.scope-option > label,
-.scope-option{
+.scope-option__choice{
+  display:flex;
+  align-items:flex-start;
+  gap:10px;
   font-size:.95rem;
   color:var(--text,#0f172a);
+  font-weight:600;
+  cursor:pointer;
 }
-.scope-option input[type="radio"]{
-  margin-right:8px;
+.scope-option__choice input[type="radio"]{
+  cursor:pointer;
+  margin-top:2px;
   accent-color:var(--accent,#2563eb);
 }
-.scope-option small,
+.scope-option__label{display:block;line-height:1.4}
 .scope-option p{
   margin:0;
   color:var(--muted,#475569);
   font-size:.85rem;
 }
-.scope-option__control{
+.scope-option__body{
   display:flex;
   gap:10px;
   align-items:center;
+  flex-wrap:wrap;
 }
-.scope-option__control select{
-  flex:1 1 auto;
+.scope-option__body select{
+  flex:1 1 220px;
   min-width:200px;
+}
+.scope-option--custom .scope-option__body{
+  flex-direction:column;
+  align-items:stretch;
 }
 #customTickersInput{
   resize:vertical;
@@ -1598,8 +1607,13 @@ body.theme-light table.grid pre{
   font:inherit;
   background:rgba(255,255,255,.92);
   color:var(--text,#0f172a);
+  width:100%;
+  transition:border-color .2s ease,box-shadow .2s ease,opacity .2s ease;
 }
-#customTickersInput:disabled{opacity:.65}
+#customTickersInput[aria-disabled="true"]{
+  opacity:.6;
+  pointer-events:none;
+}
 
 .watchlist-manager{
   border:1px solid var(--border,#e2e8f0);

--- a/planner.html
+++ b/planner.html
@@ -1832,17 +1832,19 @@
           <fieldset class="scope-field" id="runScopeFieldset">
             <legend>Run scope</legend>
             <div class="scope-options">
-              <label class="scope-option">
-                <input type="radio" name="runScope" value="universe" checked />
-                <span>Entire ticker universe</span>
-                <small id="scopeUniverseSummary">Use the universe slider to cap Stage 1 intake.</small>
-              </label>
-              <div class="scope-option scope-option--watchlist">
-                <label>
-                  <input type="radio" name="runScope" value="watchlist" />
-                  <span>Watchlist</span>
+              <div class="scope-option scope-option--universe">
+                <label class="scope-option__choice">
+                  <input type="radio" name="runScope" value="universe" checked />
+                  <span class="scope-option__label">Entire ticker universe</span>
                 </label>
-                <div class="scope-option__control">
+                <p class="muted" id="scopeUniverseSummary">Use the universe slider to cap Stage 1 intake.</p>
+              </div>
+              <div class="scope-option scope-option--watchlist">
+                <label class="scope-option__choice">
+                  <input type="radio" name="runScope" value="watchlist" />
+                  <span class="scope-option__label">Watchlist</span>
+                </label>
+                <div class="scope-option__body">
                   <label class="sr-only" for="watchlistSelect">Watchlist</label>
                   <select id="watchlistSelect" disabled>
                     <option value="">Select watchlist…</option>
@@ -1852,11 +1854,18 @@
                 <p class="muted" id="watchlistSummary" aria-live="polite">Choose a watchlist to see membership and size.</p>
               </div>
               <div class="scope-option scope-option--custom">
-                <label>
+                <label class="scope-option__choice">
                   <input type="radio" name="runScope" value="custom" />
-                  <span>Custom symbols</span>
+                  <span class="scope-option__label">Custom symbols</span>
                 </label>
-                <textarea id="customTickersInput" rows="2" placeholder="AAPL, MSFT, 0700.HK" disabled></textarea>
+                <div class="scope-option__body">
+                  <textarea
+                    id="customTickersInput"
+                    rows="2"
+                    placeholder="AAPL, MSFT, 0700.HK"
+                    aria-disabled="true"
+                  ></textarea>
+                </div>
               </div>
               <p class="muted" id="scopeStatus" aria-live="polite"></p>
             </div>


### PR DESCRIPTION
## Summary
- restyle the run scope card so each option aligns consistently and readably
- replace the disabled custom symbol textarea with an accessible variant that unlocks when the mode is set to custom
- tweak planner scope scripts to toggle the new textarea state instead of disabling it outright

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e3ee239e00832d943cd3255f35c2e8