### PR TITLE
Fix API registry access handling and styling

### DIFF
--- a/assets/planner.js
+++ b/assets/planner.js
@@ -1551,6 +1551,18 @@ function initCredentialManager() {
   const testBtn = modal.querySelector('#credentialTest');
   const closeButtons = Array.from(modal.querySelectorAll('[data-credential-close]'));
 
+  if (lockedLoginEl && typeof window !== 'undefined') {
+    try {
+      const loginUrl = new URL('/login.html', window.location.origin);
+      const basePath = `${window.location.pathname}${window.location.search}` || '/planner.html';
+      const redirectTarget = basePath.startsWith('/planner') ? `${basePath}#api-registry` : '/planner.html#api-registry';
+      loginUrl.searchParams.set('redirect', redirectTarget);
+      lockedLoginEl.href = `${loginUrl.pathname}${loginUrl.search}`;
+    } catch (error) {
+      console.warn('Unable to prepare credential login redirect', error);
+    }
+  }
+
   let credentials = [];
   let activeId = null;
   let isOpen = false;
@@ -2169,6 +2181,25 @@ function initCredentialManager() {
   modal.ffCredentialManager = manager;
   if (typeof window !== 'undefined') {
     window.ffCredentialManager = manager;
+    const maybeOpenFromHash = () => {
+      if (window.location.hash === '#api-registry') {
+        setTimeout(() => {
+          manager.open();
+          try {
+            if (history.replaceState) {
+              history.replaceState(null, '', `${window.location.pathname}${window.location.search}`);
+            } else {
+              window.location.hash = '';
+            }
+          } catch (error) {
+            console.warn('Unable to clear api registry hash', error);
+          }
+        }, 80);
+      }
+    };
+
+    maybeOpenFromHash();
+    window.addEventListener('hashchange', maybeOpenFromHash, { once: true });
   }
 
   return manager;

--- a/assets/supabase.js
+++ b/assets/supabase.js
@@ -65,7 +65,9 @@ function normalizeRole(value) {
     return Object.values(value).flatMap((entry) => normalizeRole(entry));
   }
   return String(value ?? '')
-    .split(/[\s,]+/)
+    .replace(/[\u2013\u2014]/g, '-')
+    .split(/[\s,;]+/)
+    .flatMap((part) => part.split(/[-_/|]+/))
     .map((part) => part.trim().toLowerCase())
     .filter(Boolean);
 }
@@ -161,6 +163,9 @@ function hasAdminRole(context = {}) {
     'builder'
   ]);
   for (const role of buckets) {
+    if (role.includes('admin')) {
+      return true;
+    }
     if (role === 'admin' || elevated.has(role)) {
       return true;
     }

--- a/login.html
+++ b/login.html
@@ -150,7 +150,20 @@
   );
 
   const status = document.getElementById("status");
-  const redirectTo = `${location.origin}/login.html`; // make sure this is whitelisted in Supabase Auth → URL Configuration
+  const urlParams = new URLSearchParams(location.search);
+  const sanitizeRedirect = (value) => {
+    if (!value) return "/universe.html";
+    try {
+      const target = new URL(value, location.origin);
+      if (target.origin !== location.origin) return "/universe.html";
+      const path = `${target.pathname}${target.search}${target.hash}` || "/universe.html";
+      return path.startsWith("/") ? path : "/universe.html";
+    } catch (_error) {
+      return "/universe.html";
+    }
+  };
+  const redirectTarget = sanitizeRedirect(urlParams.get("redirect"));
+  const redirectTo = `${location.origin}${location.pathname}${location.search}`; // maintain query params for magic link callbacks
 
   // --- Magic link ---
   document.getElementById("ml-send").onclick = async () => {
@@ -172,7 +185,6 @@
     if (error) status.textContent = `Error: ${error.message}`;
     else {
       status.textContent = `Logged in as ${data.user.email}. Redirecting…`;
-      location.href = "/universe.html";
     }
   };
 
@@ -207,11 +219,17 @@
     }
   })();
 
-  sb.auth.onAuthStateChange((_event, session) => {
+  sb.auth.onAuthStateChange((event, session) => {
     if (session) {
-      status.textContent = `Logged in as ${session.user.email}. Redirecting…`;
-      // Send them to members area
-      setTimeout(()=> location.href = "/universe.html", 500);
+      const message = event === "INITIAL_SESSION"
+        ? `Logged in as ${session.user.email}.`
+        : `Logged in as ${session.user.email}. Redirecting…`;
+      status.textContent = message;
+      if (event === "SIGNED_IN" || event === "TOKEN_REFRESHED") {
+        setTimeout(() => { location.href = redirectTarget; }, 500);
+      }
+    } else {
+      status.textContent = "Signed out.";
     }
   });
 </script>

--- a/planner.html
+++ b/planner.html
@@ -14,6 +14,18 @@
       margin: 0;
       background: var(--page,#f8fafc);
       color: var(--text,#0f172a);
+      --text: #0f172a;
+      --muted: #475569;
+      --muted-strong: #1e293b;
+      --border: #d4deeb;
+      --page: #f8fafc;
+      --panel: #ffffff;
+      --panel-muted: #f8fafc;
+      --accent: #2563eb;
+      --accent-strong: #1d4ed8;
+      --danger: #ef4444;
+      --success: #16a34a;
+      --warning: #f59e0b;
     }
     body.modal-open {
       overflow: hidden;


### PR DESCRIPTION
## Summary
- restore light theme token values on the planner so API registry text remains legible
- harden Supabase admin role detection and provide return-link targeting for the credential manager
- update the login flow to honor redirect targets without bouncing existing sessions to the universe immediately

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e40d7d3104832da3c8c1034f180794