### PR TITLE
Add assisted guided helper flows across key pages

### DIFF
--- a/equity_analyst.html
+++ b/equity_analyst.html
@@ -215,6 +215,26 @@
     .guided-switch{display:flex;flex-direction:column;gap:6px;font-size:.85rem;color:var(--workspace-muted)}
     .guided-switch a{color:var(--workspace-accent);font-weight:600;text-decoration:none}
     .guided-switch a:hover{text-decoration:underline}
+    .guided-mode-selector{display:grid;gap:14px;margin-top:6px}
+    .guided-mode-selector[hidden]{display:none!important}
+    .guided-mode-card{position:relative;display:grid;gap:6px;padding:16px 18px;border-radius:18px;border:1px solid var(--workspace-border);background:var(--workspace-panel);text-align:left;cursor:pointer;transition:transform .18s ease,box-shadow .18s ease,border-color .18s ease}
+    .guided-mode-card:hover{transform:translateY(-2px);box-shadow:0 24px 60px rgba(15,23,42,.16);border-color:var(--workspace-accent-border)}
+    .guided-mode-card h3{margin:0;font-size:1.06rem;color:var(--workspace-text)}
+    .guided-mode-card p{margin:0;font-size:.88rem;color:var(--workspace-muted);line-height:1.5}
+    @keyframes guided-wiggle{0%,100%{transform:rotate(-1.2deg) translateY(0)}50%{transform:rotate(1.2deg) translateY(-2px)}}
+    .guided-mode-card:nth-child(1){animation:guided-wiggle 2.8s ease-in-out infinite}
+    .guided-mode-card:nth-child(2){animation:guided-wiggle 2.8s ease-in-out infinite .35s}
+    .guided-content[hidden]{display:none!important}
+    .guided-assist{display:grid;gap:10px;padding:10px 0;font-size:.9rem;color:var(--workspace-muted)}
+    .guided-assist[hidden]{display:none!important}
+    .guided-assist__hint{margin:0;font-size:.9rem;line-height:1.5;color:var(--workspace-text)}
+    .guided-assist__feedback{margin:0;font-size:.78rem;color:var(--workspace-danger)}
+    .guided-devbox{border:1px solid var(--workspace-border);border-radius:14px;padding:12px;background:var(--workspace-surface);display:grid;gap:8px}
+    .guided-devbox[hidden]{display:none!important}
+    .guided-devbox__header{display:flex;align-items:center;justify-content:space-between;font-size:.78rem;text-transform:uppercase;letter-spacing:.08em;color:var(--workspace-muted)}
+    .guided-devbox__copy{border:none;border-radius:10px;padding:6px 10px;font-size:.75rem;font-weight:600;background:var(--workspace-accent-softer);color:var(--workspace-accent-strong);cursor:pointer}
+    .guided-devbox__copy:focus-visible{outline:2px solid var(--workspace-accent-border);outline-offset:2px}
+    .guided-devbox pre{margin:0;font-family:var(--workspace-mono);font-size:.78rem;white-space:pre-wrap;word-break:break-word;color:var(--workspace-text-soft)}
     body.guided-active{overflow:hidden}
     @media (max-width:720px){
       .guided-fab{left:16px;right:16px;width:calc(100% - 32px);justify-content:center}
@@ -507,26 +527,49 @@
   <div class="guided-overlay" id="guidedOverlay" aria-hidden="true">
     <div class="guided-panel" role="dialog" aria-modal="true" aria-labelledby="guidedTitle">
       <button class="guided-close" id="guidedClose" aria-label="Close guided helper">×</button>
-      <div class="guided-progress" id="guidedProgress">Step 1 of 1</div>
-      <h2 id="guidedTitle">Guided equity setup</h2>
-      <div class="guided-body" id="guidedBody">Follow the prompts to connect telemetry and start the automated analyst.</div>
-      <div class="guided-summary" id="guidedSummary" hidden>
-        <p><strong>All set!</strong> The dashboard will keep tracking your run in real time.</p>
-        <label>
-          <input type="checkbox" id="guidedUpdates" />
-          Keep me updated with daily run reports via email.
-        </label>
-        <div class="guided-email-row" id="guidedEmailRow" hidden>
-          <input type="email" id="guidedEmail" placeholder="you@example.com" autocomplete="email" />
-          <button type="button" id="guidedEmailSave">Save</button>
+      <div class="guided-mode-selector" id="guidedModeSelector">
+        <button type="button" class="guided-mode-card" data-guided-mode="assisted">
+          <h3>Assisted fill-out</h3>
+          <p>Step through each control and update telemetry in real time.</p>
+        </button>
+        <button type="button" class="guided-mode-card" data-guided-mode="passive">
+          <h3>Passive overview</h3>
+          <p>Follow the high-level tour to understand every dashboard module.</p>
+        </button>
+      </div>
+      <div class="guided-content" id="guidedContent" hidden>
+        <div class="guided-progress" id="guidedProgress">Step 1 of 1</div>
+        <h2 id="guidedTitle">Guided equity setup</h2>
+        <div class="guided-body" id="guidedBody">Follow the prompts to connect telemetry and start the automated analyst.</div>
+        <div class="guided-assist" id="guidedAssist" hidden>
+          <p class="guided-assist__hint" id="guidedAssistHint"></p>
+          <p class="guided-assist__feedback" id="guidedAssistFeedback" hidden></p>
+          <div class="guided-devbox" id="guidedDevbox" hidden>
+            <div class="guided-devbox__header">
+              <span>Developer debug</span>
+              <button type="button" class="guided-devbox__copy" id="guidedDevCopy">Copy</button>
+            </div>
+            <pre id="guidedDevText"></pre>
+          </div>
         </div>
-        <p class="guided-email-hint" id="guidedEmailHint">We only store this preference in your browser so you stay in control.</p>
-        <div class="guided-switch">
-          <span>Need to calibrate the market planner instead?</span>
-          <a href="planner.html#guided-helper">Jump to the planner walkthrough</a>
+        <div class="guided-summary" id="guidedSummary" hidden>
+          <p><strong>All set!</strong> The dashboard will keep tracking your run in real time.</p>
+          <label for="guidedUpdates">
+            <input type="checkbox" id="guidedUpdates" />
+            Keep me updated with daily run reports via email.
+          </label>
+          <div class="guided-email-row" id="guidedEmailRow" hidden>
+            <input type="email" id="guidedEmail" placeholder="you@example.com" autocomplete="email" />
+            <button type="button" id="guidedEmailSave">Save</button>
+          </div>
+          <p class="guided-email-hint" id="guidedEmailHint">We only store this preference in your browser so you stay in control.</p>
+          <div class="guided-switch">
+            <span>Need to calibrate the market planner instead?</span>
+            <a href="planner.html#guided-helper">Jump to the planner walkthrough</a>
+          </div>
         </div>
       </div>
-      <div class="guided-actions">
+      <div class="guided-actions" id="guidedActions" hidden>
         <button type="button" id="guidedPrev">Back</button>
         <button type="button" id="guidedNext" class="primary">Next</button>
       </div>
@@ -553,9 +596,18 @@
       const emailInput = doc.getElementById('guidedEmail');
       const emailSave = doc.getElementById('guidedEmailSave');
       const emailHint = doc.getElementById('guidedEmailHint');
+      const actionsEl = doc.getElementById('guidedActions');
+      const modeSelector = doc.getElementById('guidedModeSelector');
+      const contentEl = doc.getElementById('guidedContent');
+      const assistEl = doc.getElementById('guidedAssist');
+      const assistHint = doc.getElementById('guidedAssistHint');
+      const assistFeedback = doc.getElementById('guidedAssistFeedback');
+      const devBox = doc.getElementById('guidedDevbox');
+      const devText = doc.getElementById('guidedDevText');
+      const devCopy = doc.getElementById('guidedDevCopy');
       const highlightClass = 'guided-focus';
 
-      const steps = [
+      const passiveSteps = [
         {
           title: 'Sign in & refresh telemetry',
           body: 'Use your analyst credentials to sign in. Then hit <strong>Refresh</strong> so the latest Supabase run telemetry appears.',
@@ -583,6 +635,86 @@
         }
       ];
 
+      const assistedSteps = [
+        {
+          title: 'Confirm analyst access',
+          body: 'Log in with an analyst account, then press <strong>Refresh</strong> to hydrate run options.',
+          target: '#refreshRunsBtn',
+          assist: {
+            hint: 'If the refresh button is disabled, sign in via the top navigation first. Once enabled, click it to sync the latest run registry.',
+            focus: '#refreshRunsBtn',
+            devSnippet: `await Promise.all([\n  loadRuns(),\n  loadModelCatalog()\n]);`
+          }
+        },
+        {
+          title: 'Select the run to monitor',
+          body: 'Choose which automation batch to stream into the dashboard.',
+          target: '#runSelect',
+          assist: {
+            hint: 'Pick a run from the dropdown. We\'ll remember your choice and reload telemetry on focus.',
+            focus: '#runSelect',
+            validate: () => {
+              const select = doc.getElementById('runSelect');
+              return select && select.value ? true : 'Select an active run to keep the feed aligned with your operations.';
+            }
+          }
+        },
+        {
+          title: 'Check run vitals',
+          body: 'Review status, stop requests, spend, and queue depth before diving deeper.',
+          target: '.run-meta',
+          assist: {
+            hint: 'These metrics update after every refresh. If you need to clear them, choose a different run or hit refresh again.',
+            focus: '.run-meta'
+          }
+        },
+        {
+          title: 'Monitor pipeline health',
+          body: 'Use the stage cards to verify throughput and catch failures before they compound.',
+          target: '.pipeline-grid',
+          assist: {
+            hint: 'Hover over each card to see completion percentages. Stuck queues usually mean the corresponding worker needs attention.',
+            focus: '.pipeline-grid'
+          }
+        },
+        {
+          title: 'Audit the latest analyst answers',
+          body: 'Spot-check verdicts streaming in from each worker to verify quality.',
+          target: '.activity-table',
+          assist: {
+            hint: 'Click a row to open the underlying note. Keep an eye on timestamps to ensure telemetry is fresh.',
+            focus: '.activity-table',
+            devSnippet: `const { data } = await supabase\n  .from('automation_activity')\n  .select('*')\n  .eq('run_id', state.activeRunId)\n  .order('created_at', { ascending: false })\n  .limit(25);`
+          }
+        },
+        {
+          title: 'Track upcoming engineering work',
+          body: 'Use the operational checklist to communicate the roadmap back to the team.',
+          target: '.analysis-export__fields',
+          assist: {
+            hint: 'Capture notes or send the roadmap link to stakeholders so everyone stays aligned on next upgrades.',
+            focus: '.analysis-export__fields'
+          }
+        }
+      ];
+
+      const modes = {
+        passive: {
+          name: 'Passive overview',
+          steps: passiveSteps,
+          summaryTitle: 'Setup complete',
+          summaryBody: 'Great! Your analyst dashboard will continue updating as new data streams in. You can re-open this helper whenever you need a refresher.'
+        },
+        assisted: {
+          name: 'Assisted fill-out',
+          steps: assistedSteps,
+          summaryTitle: 'Telemetry is live',
+          summaryBody: 'You\'re connected to the latest run. Keep this page open to watch streaming updates and jump into the planner whenever you need fresh batches.'
+        }
+      };
+
+      let currentMode = null;
+      let steps = [];
       let stepIndex = 0;
       let previousTarget = null;
 
@@ -600,6 +732,20 @@
         }
       };
 
+      const showAssistFeedback = message => {
+        if (!assistFeedback) return;
+        if (!message) {
+          assistFeedback.textContent = '';
+          assistFeedback.hidden = true;
+          return;
+        }
+        assistFeedback.textContent = message;
+        assistFeedback.hidden = false;
+        if (assistEl) assistEl.hidden = false;
+      };
+
+      const clearAssistFeedback = () => showAssistFeedback('');
+
       const hideSummary = () => {
         summaryEl.hidden = true;
         summaryEl.setAttribute('hidden', '');
@@ -616,7 +762,66 @@
         }
       };
 
+      const applyAssist = step => {
+        if (!assistEl) return;
+        if (currentMode !== 'assisted') {
+          assistEl.hidden = true;
+          return;
+        }
+        const assist = step?.assist;
+        if (!assist) {
+          assistEl.hidden = true;
+          return;
+        }
+        assistEl.hidden = false;
+        if (assistHint) assistHint.innerHTML = assist.hint || '';
+        clearAssistFeedback();
+        if (devBox) {
+          if (assist.devSnippet) {
+            devBox.hidden = false;
+            devText.textContent = assist.devSnippet;
+          } else {
+            devBox.hidden = true;
+            devText.textContent = '';
+          }
+        }
+        const focusTargetEl = typeof assist.focus === 'function'
+          ? assist.focus()
+          : assist.focus
+            ? doc.querySelector(assist.focus)
+            : null;
+        if (focusTargetEl && typeof focusTargetEl.focus === 'function') {
+          try {
+            focusTargetEl.focus({ preventScroll: true });
+          } catch (error) {
+            focusTargetEl.focus();
+          }
+        }
+      };
+
+      const validateStep = step => {
+        if (currentMode !== 'assisted') return true;
+        const validator = step?.assist?.validate;
+        if (typeof validator !== 'function') {
+          clearAssistFeedback();
+          return true;
+        }
+        const result = validator();
+        if (result === true) {
+          clearAssistFeedback();
+          return true;
+        }
+        const message = typeof result === 'string'
+          ? result
+          : result && typeof result === 'object' && result.message
+            ? result.message
+            : 'Complete this action before moving on.';
+        showAssistFeedback(message);
+        return false;
+      };
+
       const renderStep = () => {
+        if (!Array.isArray(steps) || !steps.length) return;
         const total = steps.length;
         const step = steps[stepIndex];
         progressEl.textContent = `Step ${stepIndex + 1} of ${total}`;
@@ -626,16 +831,43 @@
         nextBtn.textContent = stepIndex + 1 === total ? 'Finish' : 'Next';
         prevBtn.disabled = stepIndex === 0;
         focusTarget(step.target);
+        applyAssist(step);
       };
 
       const renderSummary = () => {
         progressEl.textContent = 'Complete';
-        titleEl.textContent = 'Setup complete';
-        bodyEl.innerHTML = 'Great! Your analyst dashboard will continue updating as new data streams in. You can re-open this helper whenever you need a refresher.';
+        const mode = modes[currentMode] || modes.passive;
+        titleEl.textContent = mode.summaryTitle;
+        bodyEl.innerHTML = mode.summaryBody;
         showSummary();
+        if (assistEl) assistEl.hidden = true;
         focusTarget(null);
         nextBtn.textContent = 'Close';
         prevBtn.disabled = false;
+      };
+
+      const resetToChooser = () => {
+        currentMode = null;
+        steps = [];
+        stepIndex = 0;
+        hideSummary();
+        focusTarget(null);
+        if (assistEl) assistEl.hidden = true;
+        if (actionsEl) actionsEl.hidden = true;
+        if (contentEl) contentEl.hidden = true;
+        if (modeSelector) modeSelector.hidden = false;
+      };
+
+      const activateMode = key => {
+        const mode = modes[key];
+        if (!mode) return;
+        currentMode = key;
+        steps = mode.steps;
+        stepIndex = 0;
+        if (modeSelector) modeSelector.hidden = true;
+        if (contentEl) contentEl.hidden = false;
+        if (actionsEl) actionsEl.hidden = false;
+        renderStep();
       };
 
       const openOverlay = () => {
@@ -643,8 +875,7 @@
         overlay.setAttribute('aria-hidden', 'false');
         fab.classList.add('hidden');
         body.classList.add('guided-active');
-        stepIndex = 0;
-        renderStep();
+        resetToChooser();
       };
 
       const closeOverlay = () => {
@@ -652,8 +883,7 @@
         overlay.setAttribute('aria-hidden', 'true');
         fab.classList.remove('hidden');
         body.classList.remove('guided-active');
-        hideSummary();
-        focusTarget(null);
+        resetToChooser();
       };
 
       fab?.addEventListener('click', openOverlay);
@@ -668,6 +898,14 @@
       });
 
       nextBtn?.addEventListener('click', () => {
+        if (!Array.isArray(steps) || !steps.length) {
+          resetToChooser();
+          return;
+        }
+        const step = steps[stepIndex];
+        if (!validateStep(step)) {
+          return;
+        }
         if (summaryEl.hidden) {
           if (stepIndex + 1 < steps.length) {
             stepIndex += 1;
@@ -681,9 +919,17 @@
       });
 
       prevBtn?.addEventListener('click', () => {
+        if (!Array.isArray(steps) || !steps.length) {
+          resetToChooser();
+          return;
+        }
         if (!summaryEl.hidden) {
           hideSummary();
           renderStep();
+          return;
+        }
+        if (stepIndex === 0) {
+          resetToChooser();
           return;
         }
         if (stepIndex > 0) {
@@ -732,6 +978,40 @@
           : 'We only store this preference in your browser so you stay in control.';
         emailHint.style.color = 'var(--workspace-muted)';
       });
+      modeSelector?.querySelectorAll('[data-guided-mode]')?.forEach(button => {
+        button.addEventListener('click', () => {
+          const modeKey = button.getAttribute('data-guided-mode');
+          activateMode(modeKey);
+        });
+      });
+      if (devCopy) {
+        const defaultLabel = devCopy.textContent || 'Copy';
+        let resetTimer = null;
+        devCopy.addEventListener('click', async () => {
+          const text = devText?.textContent || '';
+          if (!text.trim()) return;
+          try {
+            await navigator.clipboard?.writeText(text);
+            devCopy.textContent = 'Copied!';
+          } catch (error) {
+            devCopy.textContent = 'Press ⌘/Ctrl + C';
+            const selection = window.getSelection();
+            if (selection) {
+              const range = document.createRange();
+              range.selectNodeContents(devText);
+              selection.removeAllRanges();
+              selection.addRange(range);
+            }
+          }
+          clearTimeout(resetTimer);
+          resetTimer = setTimeout(() => {
+            devCopy.textContent = defaultLabel;
+            if (window.getSelection()?.rangeCount) {
+              window.getSelection().removeAllRanges();
+            }
+          }, 1600);
+        });
+      }
       if (window.location.hash === '#guided-helper') {
         setTimeout(() => {
           openOverlay();

--- a/planner.html
+++ b/planner.html
@@ -1834,6 +1834,118 @@
     .guided-switch a:hover {
       text-decoration: underline;
     }
+    .guided-mode-selector {
+      display: grid;
+      gap: 14px;
+      margin-top: 4px;
+    }
+    .guided-mode-selector[hidden] {
+      display: none !important;
+    }
+    .guided-mode-card {
+      position: relative;
+      display: grid;
+      gap: 6px;
+      padding: 16px 18px;
+      border-radius: 18px;
+      border: 1px solid var(--workspace-border);
+      background: var(--workspace-panel);
+      text-align: left;
+      cursor: pointer;
+      transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+    }
+    .guided-mode-card:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 24px 60px var(--workspace-accent-soft);
+      border-color: var(--workspace-accent-border);
+    }
+    .guided-mode-card h3 {
+      margin: 0;
+      font-size: 1.08rem;
+      color: var(--workspace-text);
+    }
+    .guided-mode-card p {
+      margin: 0;
+      font-size: .88rem;
+      color: var(--workspace-muted);
+      line-height: 1.45;
+    }
+    @keyframes guided-wiggle {
+      0%, 100% { transform: rotate(-1.2deg) translateY(0); }
+      50% { transform: rotate(1.2deg) translateY(-2px); }
+    }
+    .guided-mode-card:nth-child(1) {
+      animation: guided-wiggle 2.8s ease-in-out infinite;
+    }
+    .guided-mode-card:nth-child(2) {
+      animation: guided-wiggle 2.8s ease-in-out infinite .35s;
+    }
+    .guided-content[hidden] {
+      display: none !important;
+    }
+    .guided-assist {
+      display: grid;
+      gap: 10px;
+      padding: 10px 0;
+      font-size: .9rem;
+      color: var(--workspace-muted);
+    }
+    .guided-assist[hidden] {
+      display: none !important;
+    }
+    .guided-assist__hint {
+      margin: 0;
+      font-size: .9rem;
+      line-height: 1.5;
+      color: var(--workspace-text);
+    }
+    .guided-assist__feedback {
+      margin: 0;
+      font-size: .8rem;
+      color: var(--workspace-danger-strong);
+    }
+    .guided-devbox {
+      border: 1px solid var(--workspace-border);
+      border-radius: 14px;
+      padding: 12px;
+      background: var(--workspace-surface);
+      display: grid;
+      gap: 8px;
+    }
+    .guided-devbox[hidden] {
+      display: none !important;
+    }
+    .guided-devbox__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: .8rem;
+      text-transform: uppercase;
+      letter-spacing: .1em;
+      color: var(--workspace-muted);
+    }
+    .guided-devbox__copy {
+      border: none;
+      border-radius: 10px;
+      padding: 6px 10px;
+      font-size: .75rem;
+      font-weight: 600;
+      background: var(--workspace-accent-softer);
+      color: var(--workspace-accent-strong);
+      cursor: pointer;
+    }
+    .guided-devbox__copy:focus-visible {
+      outline: 2px solid var(--workspace-accent-border);
+      outline-offset: 2px;
+    }
+    .guided-devbox pre {
+      margin: 0;
+      font-family: var(--workspace-mono);
+      font-size: .78rem;
+      white-space: pre-wrap;
+      word-break: break-word;
+      color: var(--workspace-text-soft);
+    }
     @media (max-width: 640px) {
       .guided-fab {
         left: 16px;
@@ -2988,26 +3100,49 @@
 <div class="guided-overlay" id="guidedOverlay" aria-hidden="true">
   <div class="guided-panel" role="dialog" aria-modal="true" aria-labelledby="guidedTitle">
     <button class="guided-close" id="guidedClose" aria-label="Close guided helper">×</button>
-    <div class="guided-progress" id="guidedProgress">Step 1 of 1</div>
-    <h2 id="guidedTitle">Guided planner setup</h2>
-    <div class="guided-body" id="guidedBody">We'll walk through calibrating the market scan planner before you launch the analyst.</div>
-    <div class="guided-summary" id="guidedSummary" hidden>
-      <p><strong>Planner ready!</strong> Launch your next market scan, then open the equity dashboard to monitor progress.</p>
-      <label>
-        <input type="checkbox" id="guidedUpdates" />
-        Keep me updated with daily run reports via email.
-      </label>
-      <div class="guided-email-row" id="guidedEmailRow" hidden>
-        <input type="email" id="guidedEmail" placeholder="you@example.com" autocomplete="email" />
-        <button type="button" id="guidedEmailSave">Save</button>
+    <div class="guided-mode-selector" id="guidedModeSelector">
+      <button type="button" class="guided-mode-card" data-guided-mode="assisted">
+        <h3>Assisted fill-out</h3>
+        <p>Learn by doing while we guide you through each planner input.</p>
+      </button>
+      <button type="button" class="guided-mode-card" data-guided-mode="passive">
+        <h3>Passive overview</h3>
+        <p>Watch the high-level tour and explore the planner at your own pace.</p>
+      </button>
+    </div>
+    <div class="guided-content" id="guidedContent" hidden>
+      <div class="guided-progress" id="guidedProgress">Step 1 of 1</div>
+      <h2 id="guidedTitle">Guided planner setup</h2>
+      <div class="guided-body" id="guidedBody">We'll walk through calibrating the market scan planner before you launch the analyst.</div>
+      <div class="guided-assist" id="guidedAssist" hidden>
+        <p class="guided-assist__hint" id="guidedAssistHint"></p>
+        <p class="guided-assist__feedback" id="guidedAssistFeedback" hidden></p>
+        <div class="guided-devbox" id="guidedDevbox" hidden>
+          <div class="guided-devbox__header">
+            <span>Developer debug</span>
+            <button type="button" class="guided-devbox__copy" id="guidedDevCopy">Copy</button>
+          </div>
+          <pre id="guidedDevText"></pre>
+        </div>
       </div>
-      <p class="guided-email-hint" id="guidedEmailHint">We only store this preference in your browser so you stay in control.</p>
-      <div class="guided-switch">
-        <span>Ready to track live telemetry?</span>
-        <a href="equity_analyst.html#guided-helper">Jump to the equity walkthrough</a>
+      <div class="guided-summary" id="guidedSummary" hidden>
+        <p><strong>Planner ready!</strong> Launch your next market scan, then open the equity dashboard to monitor progress.</p>
+        <label for="guidedUpdates">
+          <input type="checkbox" id="guidedUpdates" />
+          Keep me updated with daily run reports via email.
+        </label>
+        <div class="guided-email-row" id="guidedEmailRow" hidden>
+          <input type="email" id="guidedEmail" placeholder="you@example.com" autocomplete="email" />
+          <button type="button" id="guidedEmailSave">Save</button>
+        </div>
+        <p class="guided-email-hint" id="guidedEmailHint">We only store this preference in your browser so you stay in control.</p>
+        <div class="guided-switch">
+          <span>Ready to track live telemetry?</span>
+          <a href="equity_analyst.html#guided-helper">Jump to the equity walkthrough</a>
+        </div>
       </div>
     </div>
-    <div class="guided-actions">
+    <div class="guided-actions" id="guidedActions" hidden>
       <button type="button" id="guidedPrev">Back</button>
       <button type="button" id="guidedNext" class="primary">Next</button>
     </div>
@@ -3090,9 +3225,18 @@
     const emailInput = doc.getElementById('guidedEmail');
     const emailSave = doc.getElementById('guidedEmailSave');
     const emailHint = doc.getElementById('guidedEmailHint');
+    const actionsEl = doc.getElementById('guidedActions');
+    const modeSelector = doc.getElementById('guidedModeSelector');
+    const contentEl = doc.getElementById('guidedContent');
+    const assistEl = doc.getElementById('guidedAssist');
+    const assistHint = doc.getElementById('guidedAssistHint');
+    const assistFeedback = doc.getElementById('guidedAssistFeedback');
+    const devBox = doc.getElementById('guidedDevbox');
+    const devText = doc.getElementById('guidedDevText');
+    const devCopy = doc.getElementById('guidedDevCopy');
     const highlightClass = 'guided-focus';
 
-    const steps = [
+    const passiveSteps = [
       {
         title: 'Set your coverage universe',
         body: 'Adjust the <strong>Universe size</strong> and slider targets so the funnel matches your run goals. The planner saves locally so you can keep iterating.',
@@ -3130,6 +3274,100 @@
       }
     ];
 
+    const assistedSteps = [
+      {
+        title: 'Pick your run scope',
+        body: 'Choose whether to work from the global universe, a watchlist, or a custom symbol set before we size the funnel.',
+        target: '#runScopeFieldset',
+        assist: {
+          hint: 'Select the scope that matches this run. Watchlists let you focus on curated names while the global universe keeps things broad.',
+          focus: () => doc.querySelector('#runScopeFieldset input[type="radio"]:checked')
+            || doc.querySelector('#runScopeFieldset input[type="radio"]'),
+          validate: () => doc.querySelector('#runScopeFieldset input[type="radio"]:checked')
+            ? true
+            : 'Choose a coverage scope so we know which tickers to prep.'
+        }
+      },
+      {
+        title: 'Tune funnel targets',
+        body: 'Tell the planner how many names you expect to scan and what share should survive each stage.',
+        target: '#plannerConfigPanel',
+        assist: {
+          hint: 'Set the <strong>Universe size</strong>, then adjust the Stage 2 and Stage 3 sliders. These values drive downstream cost and queue estimates.',
+          focus: '#universeInput',
+          validate: () => {
+            const universe = Number(doc.getElementById('universeInput')?.value || 0);
+            return Number.isFinite(universe) && universe > 0
+              ? true
+              : 'Enter the number of tickers you plan to scan to keep projections accurate.';
+          }
+        }
+      },
+      {
+        title: 'Stage 1 — triage budget',
+        body: 'Review the model, credential, and token allowances that keep the triage worker on budget.',
+        target: '.stage-card[data-stage="1"]',
+        assist: {
+          hint: 'Pick the API credential powering Stage 1 and tweak token budgets when your filings or transcripts run long.',
+          focus: '#modelStage1'
+        }
+      },
+      {
+        title: 'Stage 2 — thematic scoring',
+        body: 'Confirm the scoring model and token plan so approvals stay aligned with your heuristics.',
+        target: '.stage-card[data-stage="2"]',
+        assist: {
+          hint: 'Use the <strong>Model</strong> and <strong>API credential</strong> selectors to assign the reasoning tier you trust for Stage 2.',
+          focus: '#modelStage2'
+        }
+      },
+      {
+        title: 'Stage 3 — deep dive output',
+        body: 'Set the long-form model and output budget before generating full analyst theses.',
+        target: '.stage-card[data-stage="3"]',
+        assist: {
+          hint: 'Verify the premium model and ensure the token caps cover the narratives you expect to ship to PMs.',
+          focus: '#modelStage3'
+        }
+      },
+      {
+        title: 'Add a spend guardrail',
+        body: 'Keep automation within budget by defining when the system should pause execution.',
+        target: '.budget-control',
+        assist: {
+          hint: 'Enter a USD amount for <strong>Budget guardrail</strong>. Workers pause automatically once spend crosses this value.',
+          focus: '#budgetInput'
+        }
+      },
+      {
+        title: 'Launch the automated run',
+        body: 'Submit your configuration to Supabase so workers spin up with the latest settings.',
+        target: '.workspace-actions',
+        assist: {
+          hint: 'Press <strong>Start automated run</strong> when you are ready. The status log below captures every request.',
+          focus: '#startRunBtn',
+          devSnippet: `await fetch('https://YOUR-PROJECT.functions.supabase.co/runs-create', {\n  method: 'POST',\n  headers: {\n    Authorization: 'Bearer <admin_token>',\n    'Content-Type': 'application/json'\n  },\n  body: JSON.stringify({ planner, budget_usd, scope })\n});`
+        }
+      }
+    ];
+
+    const modes = {
+      passive: {
+        name: 'Passive overview',
+        steps: passiveSteps,
+        summaryTitle: 'Planner walkthrough complete',
+        summaryBody: 'Great work! Launch your run from here and then keep the equity analyst dashboard open for telemetry updates.'
+      },
+      assisted: {
+        name: 'Assisted fill-out',
+        steps: assistedSteps,
+        summaryTitle: 'Planner setup locked in',
+        summaryBody: 'All core inputs are tuned. Launch a batch when you\'re ready and keep the log panel open to follow each request.'
+      }
+    };
+
+    let currentMode = null;
+    let steps = [];
     let stepIndex = 0;
     let previousTarget = null;
 
@@ -3147,6 +3385,22 @@
       }
     };
 
+    const showAssistFeedback = message => {
+      if (!assistFeedback) return;
+      if (!message) {
+        assistFeedback.textContent = '';
+        assistFeedback.hidden = true;
+        return;
+      }
+      assistFeedback.textContent = message;
+      assistFeedback.hidden = false;
+      if (assistEl) {
+        assistEl.hidden = false;
+      }
+    };
+
+    const clearAssistFeedback = () => showAssistFeedback('');
+
     const hideSummary = () => {
       summaryEl.hidden = true;
       summaryEl.setAttribute('hidden', '');
@@ -3163,7 +3417,68 @@
       }
     };
 
+    const applyAssist = step => {
+      if (!assistEl) return;
+      if (currentMode !== 'assisted') {
+        assistEl.hidden = true;
+        return;
+      }
+      const assist = step?.assist;
+      if (!assist) {
+        assistEl.hidden = true;
+        return;
+      }
+      assistEl.hidden = false;
+      if (assistHint) {
+        assistHint.innerHTML = assist.hint || '';
+      }
+      clearAssistFeedback();
+      if (devBox) {
+        if (assist.devSnippet) {
+          devBox.hidden = false;
+          devText.textContent = assist.devSnippet;
+        } else {
+          devBox.hidden = true;
+          devText.textContent = '';
+        }
+      }
+      const focusTargetEl = typeof assist.focus === 'function'
+        ? assist.focus()
+        : assist.focus
+          ? doc.querySelector(assist.focus)
+          : null;
+      if (focusTargetEl && typeof focusTargetEl.focus === 'function') {
+        try {
+          focusTargetEl.focus({ preventScroll: true });
+        } catch (error) {
+          focusTargetEl.focus();
+        }
+      }
+    };
+
+    const validateStep = step => {
+      if (currentMode !== 'assisted') return true;
+      const validator = step?.assist?.validate;
+      if (typeof validator !== 'function') {
+        clearAssistFeedback();
+        return true;
+      }
+      const result = validator();
+      if (result === true) {
+        clearAssistFeedback();
+        return true;
+      }
+      const message = typeof result === 'string'
+        ? result
+        : result && typeof result === 'object' && result.message
+          ? result.message
+          : 'Complete the guided action before moving on.';
+      showAssistFeedback(message);
+      return false;
+    };
+
     const renderStep = () => {
+      if (!Array.isArray(steps) || !steps.length) return;
       const total = steps.length;
       const step = steps[stepIndex];
       progressEl.textContent = `Step ${stepIndex + 1} of ${total}`;
@@ -3173,16 +3488,45 @@
       nextBtn.textContent = stepIndex + 1 === total ? 'Finish' : 'Next';
       prevBtn.disabled = stepIndex === 0;
       focusTarget(step.target);
+      applyAssist(step);
     };
 
     const renderSummary = () => {
       progressEl.textContent = 'Complete';
-      titleEl.textContent = 'Planner walkthrough complete';
-      bodyEl.innerHTML = 'Great work! Launch your run from here and then keep the equity analyst dashboard open for telemetry updates.';
+      const mode = modes[currentMode] || modes.passive;
+      titleEl.textContent = mode.summaryTitle;
+      bodyEl.innerHTML = mode.summaryBody;
       showSummary();
+      if (assistEl) {
+        assistEl.hidden = true;
+      }
       focusTarget(null);
       nextBtn.textContent = 'Close';
       prevBtn.disabled = false;
+    };
+
+    const resetToChooser = () => {
+      currentMode = null;
+      steps = [];
+      stepIndex = 0;
+      hideSummary();
+      focusTarget(null);
+      if (assistEl) assistEl.hidden = true;
+      if (actionsEl) actionsEl.hidden = true;
+      if (contentEl) contentEl.hidden = true;
+      if (modeSelector) modeSelector.hidden = false;
+    };
+
+    const activateMode = key => {
+      const mode = modes[key];
+      if (!mode) return;
+      currentMode = key;
+      steps = mode.steps;
+      stepIndex = 0;
+      if (modeSelector) modeSelector.hidden = true;
+      if (contentEl) contentEl.hidden = false;
+      if (actionsEl) actionsEl.hidden = false;
+      renderStep();
     };
 
     const openOverlay = () => {
@@ -3190,8 +3534,7 @@
       overlay.setAttribute('aria-hidden', 'false');
       fab.classList.add('hidden');
       body.classList.add('guided-active');
-      stepIndex = 0;
-      renderStep();
+      resetToChooser();
     };
 
     const closeOverlay = () => {
@@ -3199,8 +3542,7 @@
       overlay.setAttribute('aria-hidden', 'true');
       fab.classList.remove('hidden');
       body.classList.remove('guided-active');
-      hideSummary();
-      focusTarget(null);
+      resetToChooser();
     };
 
     fab?.addEventListener('click', openOverlay);
@@ -3215,6 +3557,14 @@
     });
 
     nextBtn?.addEventListener('click', () => {
+      if (!Array.isArray(steps) || !steps.length) {
+        resetToChooser();
+        return;
+      }
+      const step = steps[stepIndex];
+      if (!validateStep(step)) {
+        return;
+      }
       if (summaryEl.hidden) {
         if (stepIndex + 1 < steps.length) {
           stepIndex += 1;
@@ -3228,9 +3578,17 @@
     });
 
     prevBtn?.addEventListener('click', () => {
+      if (!Array.isArray(steps) || !steps.length) {
+        resetToChooser();
+        return;
+      }
       if (!summaryEl.hidden) {
         hideSummary();
         renderStep();
+        return;
+      }
+      if (stepIndex === 0) {
+        resetToChooser();
         return;
       }
       if (stepIndex > 0) {
@@ -3279,6 +3637,40 @@
         : 'We only store this preference in your browser so you stay in control.';
       emailHint.style.color = 'var(--workspace-muted)';
     });
+    modeSelector?.querySelectorAll('[data-guided-mode]')?.forEach(button => {
+      button.addEventListener('click', () => {
+        const modeKey = button.getAttribute('data-guided-mode');
+        activateMode(modeKey);
+      });
+    });
+    if (devCopy) {
+      const defaultLabel = devCopy.textContent || 'Copy';
+      let resetTimer = null;
+      devCopy.addEventListener('click', async () => {
+        const text = devText?.textContent || '';
+        if (!text.trim()) return;
+        try {
+          await navigator.clipboard?.writeText(text);
+          devCopy.textContent = 'Copied!';
+        } catch (error) {
+          devCopy.textContent = 'Press ⌘/Ctrl + C';
+          const selection = window.getSelection();
+          if (selection) {
+            const range = document.createRange();
+            range.selectNodeContents(devText);
+            selection.removeAllRanges();
+            selection.addRange(range);
+          }
+        }
+        clearTimeout(resetTimer);
+        resetTimer = setTimeout(() => {
+          devCopy.textContent = defaultLabel;
+          if (window.getSelection()?.rangeCount) {
+            window.getSelection().removeAllRanges();
+          }
+        }, 1600);
+      });
+    }
     if (window.location.hash === '#guided-helper') {
       setTimeout(() => {
         openOverlay();

--- a/tools/stock_analyzer_publisher.html
+++ b/tools/stock_analyzer_publisher.html
@@ -111,6 +111,26 @@
     .guided-email-row input{flex:1}
     .guided-email-row button{white-space:nowrap}
     .guided-hint{font-size:12px; color:var(--muted)}
+    .guided-mode-selector{display:grid; gap:12px; margin-top:4px}
+    .guided-mode-selector[hidden]{display:none!important}
+    .guided-mode-card{display:grid; gap:6px; padding:14px 16px; border-radius:16px; border:1px solid var(--border); background:var(--panel); text-align:left; cursor:pointer; transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease}
+    .guided-mode-card:hover{transform:translateY(-2px); box-shadow:0 18px 55px rgba(15,23,42,.18); border-color:var(--accent)}
+    .guided-mode-card h3{margin:0; font-size:1rem; color:var(--text)}
+    .guided-mode-card p{margin:0; font-size:.86rem; color:var(--muted); line-height:1.45}
+    @keyframes guided-wiggle{0%,100%{transform:rotate(-1.1deg) translateY(0)}50%{transform:rotate(1.1deg) translateY(-2px)}}
+    .guided-mode-card:nth-child(1){animation:guided-wiggle 2.6s ease-in-out infinite}
+    .guided-mode-card:nth-child(2){animation:guided-wiggle 2.6s ease-in-out infinite .3s}
+    .guided-content[hidden]{display:none!important}
+    .guided-assist{display:grid; gap:8px; padding:8px 0; font-size:.88rem; color:var(--muted)}
+    .guided-assist[hidden]{display:none!important}
+    .guided-assist__hint{margin:0; font-size:.88rem; line-height:1.45; color:var(--text)}
+    .guided-assist__feedback{margin:0; font-size:.76rem; color:var(--err)}
+    .guided-devbox{border:1px solid var(--border); border-radius:12px; padding:10px; background:var(--background); display:grid; gap:6px}
+    .guided-devbox[hidden]{display:none!important}
+    .guided-devbox__header{display:flex; align-items:center; justify-content:space-between; font-size:.72rem; text-transform:uppercase; letter-spacing:.08em; color:var(--muted)}
+    .guided-devbox__copy{border:none; border-radius:8px; padding:6px 10px; font-size:.72rem; font-weight:600; background:var(--accent-soft); color:var(--accent); cursor:pointer}
+    .guided-devbox__copy:focus-visible{outline:2px solid var(--accent); outline-offset:2px}
+    .guided-devbox pre{margin:0; font-family:ui-monospace,Monaco,monospace; font-size:.76rem; white-space:pre-wrap; word-break:break-word; color:var(--muted)}
     @media (max-width:768px){
       .guided-panel{left:24px; right:24px; bottom:24px; width:auto}
     }
@@ -315,19 +335,42 @@
   <div id="guided-overlay" class="guided-overlay" aria-hidden="true">
     <div class="guided-panel" role="dialog" aria-modal="true" aria-labelledby="guided-title">
       <button class="guided-close" id="guided-close" aria-label="Close guided setup">×</button>
-      <div class="guided-progress" id="guided-progress">Step 1 of 1</div>
-      <h2 id="guided-title">Guided setup</h2>
-      <div class="guided-body" id="guided-body">Follow the prompts to configure your analyst workspace.</div>
-      <div class="guided-summary" id="guided-summary" style="display:none">
-        <p><strong>You're ready to go!</strong> <span id="guided-summary-text">FutureFunds will remember your preferences for the next session.</span></p>
-        <label><input type="checkbox" id="guided-updates" /> Keep me updated with daily run reports via email.</label>
-        <div class="guided-email-row" id="guided-email-row" style="display:none">
-          <input type="email" id="guided-email" placeholder="you@example.com" />
-          <button class="btn primary" id="guided-email-save">Save</button>
-        </div>
-        <div class="guided-hint" id="guided-email-hint">We only store this preference locally so you control your notifications.</div>
+      <div class="guided-mode-selector" id="guided-mode-selector">
+        <button type="button" class="guided-mode-card" data-guided-mode="assisted">
+          <h3>Assisted fill-out</h3>
+          <p>Configure each control with inline tips and debug notes.</p>
+        </button>
+        <button type="button" class="guided-mode-card" data-guided-mode="passive">
+          <h3>Passive overview</h3>
+          <p>Skim the tour to understand the publisher before diving in.</p>
+        </button>
       </div>
-      <div class="guided-actions">
+      <div class="guided-content" id="guided-content" hidden>
+        <div class="guided-progress" id="guided-progress">Step 1 of 1</div>
+        <h2 id="guided-title">Guided setup</h2>
+        <div class="guided-body" id="guided-body">Follow the prompts to configure your analyst workspace.</div>
+        <div class="guided-assist" id="guided-assist" hidden>
+          <p class="guided-assist__hint" id="guided-assist-hint"></p>
+          <p class="guided-assist__feedback" id="guided-assist-feedback" hidden></p>
+          <div class="guided-devbox" id="guided-devbox" hidden>
+            <div class="guided-devbox__header">
+              <span>Developer debug</span>
+              <button type="button" class="guided-devbox__copy" id="guided-dev-copy">Copy</button>
+            </div>
+            <pre id="guided-dev-text"></pre>
+          </div>
+        </div>
+        <div class="guided-summary" id="guided-summary" style="display:none">
+          <p><strong>You're ready to go!</strong> <span id="guided-summary-text">FutureFunds will remember your preferences for the next session.</span></p>
+          <label><input type="checkbox" id="guided-updates" /> Keep me updated with daily run reports via email.</label>
+          <div class="guided-email-row" id="guided-email-row" style="display:none">
+            <input type="email" id="guided-email" placeholder="you@example.com" />
+            <button class="btn primary" id="guided-email-save">Save</button>
+          </div>
+          <div class="guided-hint" id="guided-email-hint">We only store this preference locally so you control your notifications.</div>
+        </div>
+      </div>
+      <div class="guided-actions" id="guided-actions" hidden>
         <button class="secondary" id="guided-prev">Back</button>
         <button class="primary" id="guided-next">Next</button>
       </div>
@@ -701,111 +744,347 @@ ${n ? "\n**Analyst notes to incorporate:**\n"+n+"\n" : ""}
       const emailSave=$('#guided-email-save');
       const emailHint=$('#guided-email-hint');
       const defaultHint=emailHint?.textContent||'';
+      const modeSelector=$('#guided-mode-selector');
+      const contentEl=$('#guided-content');
+      const assistEl=$('#guided-assist');
+      const assistHint=$('#guided-assist-hint');
+      const assistFeedback=$('#guided-assist-feedback');
+      const devBox=$('#guided-devbox');
+      const devText=$('#guided-dev-text');
+      const devCopy=$('#guided-dev-copy');
+      const actionsEl=$('#guided-actions');
 
-      const steps=[
-        {title:'Choose your provider', body:'Select which API provider powers your analyst. OpenRouter offers community models with free tiers when available.', selector:'#provider'},
-        {title:'Add your API key', body:'Paste your API key and press Save. Keys are only stored in this browser so you retain full control.', selector:'#api-key', canProceed:()=>{
-          const providerKey=api?.providers?.[api?.currentProvider||'']?.keyStorage;
-          const typed=$('#api-key')?.value.trim();
-          return !!typed || (providerKey && localStorage.getItem(providerKey));
-        }},
-        {title:'Pick a model', body:'Choose the model that will write your notes. Refresh the catalog, filter to free options, or star favourites for one-click reuse.', selector:'#model-select', canProceed:()=>{
-          return !!(api?.model && api.model());
-        }},
-        {title:'Describe the company', body:'Enter the ticker, company name, and exchange so we can craft a tailored analyst brief.', selector:'#sa-ticker', focus:true, canProceed:()=>{
-          const t=$('#sa-ticker')?.value.trim();
-          const c=$('#sa-company')?.value.trim();
-          return !!t && !!c;
-        }},
-        {title:'Build the prompt', body:'Click Build Prompt to assemble the Markdown instructions. Review or edit them before sending to the model.', selector:'#sa-build-prompt'},
-        {title:'Generate the writeup', body:'When ready, hit Generate. We will call the model, populate the raw Markdown, and show a live preview beside it.', selector:'#sa-generate'},
-        {title:'Publish or dry-run', body:'Connect your GitHub repo to publish instantly, or run a Dry-run to confirm the file path before committing.', selector:'#publish-btn'},
-        {title:'You’re ready to roll', body:'You can now generate analyst briefs end-to-end. Enable email updates below if you want daily run summaries.', selector:null, summary:true}
+      const highlightClass='guided-focus';
+
+      const passiveSteps=[
+        {title:'Choose your provider', body:'Select which API provider powers your analyst. OpenRouter offers community models with free tiers when available.', target:'#provider'},
+        {title:'Add your API key', body:'Paste your API key and press Save. Keys stay in this browser so you retain full control.', target:'#api-key'},
+        {title:'Pick a model', body:'Choose the model that will write your notes. Refresh the catalog, filter for free options, or star favourites for quick reuse.', target:'#model-select'},
+        {title:'Describe the company', body:'Enter the ticker, company name, and exchange so the brief is tailored to your subject.', target:'#sa-ticker'},
+        {title:'Build the prompt', body:'Click Build Prompt to assemble Markdown instructions. Edit them before sending if needed.', target:'#sa-build-prompt'},
+        {title:'Generate the writeup', body:'Press Generate to call the model, populate the Markdown, and preview the output.', target:'#sa-generate'},
+        {title:'Publish or dry-run', body:'Wire up your GitHub repo to publish instantly or run a dry-run to confirm the file path.', target:'#publish-btn'}
       ];
 
-      const actionableSteps=steps.filter(s=>!s.summary);
+      const assistedSteps=[
+        {
+          title:'Choose your provider',
+          body:'Decide which API backend powers this analyst session.',
+          target:'#provider',
+          assist:{
+            hint:'Pick the provider that matches your stored key. We remember the choice so you can swap quickly.',
+            focus:'#provider'
+          }
+        },
+        {
+          title:'Add your API key',
+          body:'Save an API key so calls authenticate without manual copy/paste.',
+          target:'#api-key',
+          assist:{
+            hint:'Paste the key and hit <strong>Save key</strong>. We keep it in localStorage only.',
+            focus:'#api-key',
+            validate:()=>{
+              const provider=api?.currentProvider || $('#provider')?.value;
+              const storage=provider && api?.providers?.[provider]?.keyStorage;
+              const typed=$('#api-key')?.value.trim();
+              return (typed || (storage && localStorage.getItem(storage))) ? true : 'Save a key before moving on so requests can authenticate.';
+            },
+            devSnippet:`const storageKey = apiManager.providers[apiManager.currentProvider].keyStorage;\nlocalStorage.setItem(storageKey, '<api_key_here>');`
+          }
+        },
+        {
+          title:'Pick a model',
+          body:'Select the model that will draft your analyst brief.',
+          target:'#model-select',
+          assist:{
+            hint:'Use the dropdown or type a model id. Refresh the catalog if you just saved a new key.',
+            focus:'#model-select',
+            validate:()=> (api?.model && api.model()) ? true : 'Choose a model so we know which weights to call.'
+          }
+        },
+        {
+          title:'Describe the company',
+          body:'Fill in ticker, company, and exchange details for context.',
+          target:'#sa-ticker',
+          assist:{
+            hint:'Set <strong>Ticker</strong> and <strong>Company</strong>. Add the exchange to keep prompts precise.',
+            focus:'#sa-ticker',
+            validate:()=>{
+              const ticker=$('#sa-ticker')?.value.trim();
+              const company=$('#sa-company')?.value.trim();
+              return ticker && company ? true : 'Add both a ticker and company name before continuing.';
+            }
+          }
+        },
+        {
+          title:'Build the prompt',
+          body:'Compose the Markdown instructions the model will follow.',
+          target:'#sa-build-prompt',
+          assist:{
+            hint:'Click <strong>Build Prompt</strong>. You can customise the Markdown before sending it downstream.',
+            focus:'#sa-build-prompt',
+            devSnippet:`const prompt = buildPrompt();\ndocument.getElementById('sa-prompt').value = prompt;`
+          }
+        },
+        {
+          title:'Generate the writeup',
+          body:'Call the model and review the generated analysis.',
+          target:'#sa-generate',
+          assist:{
+            hint:'Hit <strong>Generate</strong>. We stream the result into Markdown and the live preview.',
+            focus:'#sa-generate',
+            devSnippet:`const result = await api.callAPI(prompt);\ndocument.getElementById('sa-output').textContent = result;`
+          }
+        },
+        {
+          title:'Publish or dry-run',
+          body:'Push the brief to GitHub or test the workflow locally.',
+          target:'#publish-btn',
+          assist:{
+            hint:'Fill in owner, repo, branch, and token, then choose Publish or Dry-run.',
+            focus:'#publish-btn',
+            devSnippet:`await githubPutFile(owner, repo, filename, token, branch, content, commitMessage);`
+          }
+        }
+      ];
+
+      const modes={
+        passive:{
+          steps:passiveSteps,
+          summaryTitle:'Guided setup complete',
+          summaryBody:'You can now generate analyst briefs end-to-end. Enable email updates below if you want daily run summaries.'
+        },
+        assisted:{
+          steps:assistedSteps,
+          summaryTitle:'Workflow configured',
+          summaryBody:'Inputs are set and you\'ve seen every control. Run a dry-run or publish to GitHub when you\'re ready.'
+        }
+      };
+
+      let currentMode=null;
+      let steps=[];
       let index=0;
       let active=false;
       let highlightEl=null;
+      let showingSummary=false;
 
-      function removeHighlight(){
-        if(highlightEl){ highlightEl.classList.remove('guided-focus'); highlightEl=null; }
-      }
+      const removeHighlight=()=>{
+        if(highlightEl){ highlightEl.classList.remove(highlightClass); highlightEl=null; }
+      };
 
-      function ensureVisible(el){
+      const ensureVisible=el=>{
         if(!el) return;
         const rect=el.getBoundingClientRect();
         if(rect.top<72 || rect.bottom>window.innerHeight-72){
           el.scrollIntoView({behavior:'smooth', block:'center'});
         }
-      }
+      };
 
-      function applyStep(){
-        const step=steps[index];
-        const actionIndex=steps.slice(0,index+1).filter(s=>!s.summary).length;
-        if(step.summary){
-          progressEl.textContent='Complete';
-        }else{
-          progressEl.textContent=`Step ${actionIndex} of ${actionableSteps.length}`;
+      const showAssistFeedback=message=>{
+        if(!assistFeedback) return;
+        if(!message){
+          assistFeedback.textContent='';
+          assistFeedback.hidden=true;
+          return;
         }
-        titleEl.textContent=step.title;
-        bodyEl.textContent=step.body;
-        summaryEl.style.display=step.summary?'flex':'none';
-        if(step.summary && summaryText){ summaryText.textContent=step.body; }
-        bodyEl.style.display=step.summary?'none':'block';
-        nextBtn.textContent=step.summary?'Finish':'Next';
-        prevBtn.style.visibility=index===0?'hidden':'visible';
+        assistFeedback.textContent=message;
+        assistFeedback.hidden=false;
+        if(assistEl) assistEl.hidden=false;
+      };
 
+      const clearAssistFeedback=()=>showAssistFeedback('');
+
+      const hideSummary=()=>{
+        if(summaryEl){ summaryEl.style.display='none'; }
+        showingSummary=false;
+        if(bodyEl){ bodyEl.style.display='block'; }
+      };
+
+      const showSummary=()=>{
+        if(summaryEl){ summaryEl.style.display='flex'; }
+        showingSummary=true;
+        if(bodyEl){ bodyEl.style.display='none'; }
+      };
+
+      const applyAssist=step=>{
+        if(!assistEl) return;
+        if(currentMode!=='assisted'){
+          assistEl.hidden=true;
+          return;
+        }
+        const assist=step?.assist;
+        if(!assist){
+          assistEl.hidden=true;
+          return;
+        }
+        assistEl.hidden=false;
+        if(assistHint) assistHint.innerHTML=assist.hint||'';
+        clearAssistFeedback();
+        if(devBox){
+          if(assist.devSnippet){
+            devBox.hidden=false;
+            devText.textContent=assist.devSnippet;
+          }else{
+            devBox.hidden=true;
+            devText.textContent='';
+          }
+        }
+        const focusEl=typeof assist.focus==='function' ? assist.focus() : assist.focus ? document.querySelector(assist.focus) : null;
+        if(focusEl && typeof focusEl.focus==='function'){
+          try{ focusEl.focus({preventScroll:true}); }catch{ focusEl.focus(); }
+        }
+      };
+
+      const validateStep=step=>{
+        if(currentMode!=='assisted') return true;
+        const validator=step?.assist?.validate;
+        if(typeof validator!=='function'){
+          clearAssistFeedback();
+          return true;
+        }
+        const result=validator();
+        if(result===true){
+          clearAssistFeedback();
+          return true;
+        }
+        const message=typeof result==='string' ? result : result && typeof result==='object' && result.message ? result.message : 'Complete this step before moving on.';
+        showAssistFeedback(message);
+        return false;
+      };
+
+      const renderStep=()=>{
+        if(!Array.isArray(steps)||!steps.length) return;
+        const total=steps.length;
+        const step=steps[index];
+        hideSummary();
+        progressEl.textContent=`Step ${index+1} of ${total}`;
+        titleEl.textContent=step.title;
+        if(bodyEl) bodyEl.textContent=step.body;
+        nextBtn.textContent=index+1===total?'Finish':'Next';
+        prevBtn.style.visibility=index===0?'hidden':'visible';
         removeHighlight();
-        if(step.selector){
-          const target=document.querySelector(step.selector);
+        if(step.target){
+          const target=document.querySelector(step.target);
           if(target){
             highlightEl=target;
-            target.classList.add('guided-focus');
-            if(step.focus && typeof target.focus==='function'){ target.focus({preventScroll:true}); }
+            target.classList.add(highlightClass);
             ensureVisible(target);
           }
         }
-        updateControls();
-      }
+        applyAssist(step);
+      };
 
-      function open(){
-        active=true; index=0; overlay.classList.add('active'); overlay.setAttribute('aria-hidden','false');
+      const renderSummary=()=>{
+        const mode=modes[currentMode]||modes.passive;
+        progressEl.textContent='Complete';
+        titleEl.textContent=mode.summaryTitle;
+        if(summaryText){ summaryText.textContent=mode.summaryBody; }
+        showSummary();
+        if(assistEl) assistEl.hidden=true;
+        nextBtn.textContent='Close';
+        prevBtn.style.visibility='visible';
+        removeHighlight();
+      };
+
+      const resetToChooser=()=>{
+        currentMode=null;
+        steps=[];
+        index=0;
+        hideSummary();
+        removeHighlight();
+        clearAssistFeedback();
+        if(assistEl) assistEl.hidden=true;
+        if(actionsEl) actionsEl.hidden=true;
+        if(contentEl) contentEl.hidden=true;
+        if(modeSelector) modeSelector.hidden=false;
+        showingSummary=false;
+      };
+
+      const activateMode=key=>{
+        const mode=modes[key];
+        if(!mode) return;
+        currentMode=key;
+        steps=mode.steps;
+        index=0;
+        if(modeSelector) modeSelector.hidden=true;
+        if(contentEl) contentEl.hidden=false;
+        if(actionsEl) actionsEl.hidden=false;
+        renderStep();
+      };
+
+      const open=()=>{
+        active=true;
+        overlay.classList.add('active');
+        overlay.setAttribute('aria-hidden','false');
         document.body.classList.add('guided-active');
-        if(pref.enabled){
-          emailHint.textContent=`Daily reports will go to ${pref.email||'your saved address'}.`;
-        }else{
-          emailHint.textContent=defaultHint;
-        }
-        applyStep();
+        if(emailHint) emailHint.textContent=pref.enabled ? `Daily reports will go to ${pref.email||'your saved address'}.` : defaultHint;
+        resetToChooser();
         syncFab();
-      }
+      };
 
-      function close(){
-        active=false; overlay.classList.remove('active'); overlay.setAttribute('aria-hidden','true');
-        document.body.classList.remove('guided-active'); removeHighlight();
+      const close=()=>{
+        active=false;
+        overlay.classList.remove('active');
+        overlay.setAttribute('aria-hidden','true');
+        document.body.classList.remove('guided-active');
+        resetToChooser();
         syncFab();
-      }
-
-      function updateControls(){
-        if(!active) return;
-        const step=steps[index];
-        const canProceed = step.summary ? true : (typeof step.canProceed==='function' ? step.canProceed() : true);
-        nextBtn.disabled=!canProceed;
-      }
+      };
 
       launchers.forEach(btn=>btn.addEventListener('click',open));
-      closeBtn.addEventListener('click',close);
+      closeBtn?.addEventListener('click',close);
       overlay.addEventListener('click',e=>{ if(e.target===overlay) close(); });
-      prevBtn.addEventListener('click',()=>{ if(index>0){ index--; applyStep(); }});
-      nextBtn.addEventListener('click',()=>{
-        const step=steps[index];
-        if(step.summary){ close(); return; }
-        if(index<steps.length-1){ index++; applyStep(); }
-      });
       document.addEventListener('keydown',e=>{ if(active && e.key==='Escape'){ close(); }});
-      document.addEventListener('input',()=>updateControls(), true);
-      document.addEventListener('change',()=>updateControls(), true);
+
+      prevBtn?.addEventListener('click',()=>{
+        if(!Array.isArray(steps)||!steps.length){ resetToChooser(); return; }
+        if(showingSummary){ hideSummary(); renderStep(); return; }
+        if(index===0){ resetToChooser(); return; }
+        if(index>0){ index--; renderStep(); }
+      });
+
+      nextBtn?.addEventListener('click',()=>{
+        if(!Array.isArray(steps)||!steps.length){ resetToChooser(); return; }
+        if(showingSummary){ close(); return; }
+        const step=steps[index];
+        if(!validateStep(step)) return;
+        if(index+1<steps.length){ index++; renderStep(); }
+        else{ renderSummary(); }
+      });
+
+      modeSelector?.querySelectorAll('[data-guided-mode]')?.forEach(button=>{
+        button.addEventListener('click',()=>{
+          const modeKey=button.getAttribute('data-guided-mode');
+          activateMode(modeKey);
+        });
+      });
+
+      if(devCopy){
+        const defaultLabel=devCopy.textContent||'Copy';
+        let resetTimer=null;
+        devCopy.addEventListener('click',async()=>{
+          const text=devText?.textContent||'';
+          if(!text.trim()) return;
+          try{
+            await navigator.clipboard?.writeText(text);
+            devCopy.textContent='Copied!';
+          }catch(err){
+            devCopy.textContent='Press ⌘/Ctrl + C';
+            const selection=window.getSelection();
+            if(selection){
+              const range=document.createRange();
+              range.selectNodeContents(devText);
+              selection.removeAllRanges();
+              selection.addRange(range);
+            }
+          }
+          clearTimeout(resetTimer);
+          resetTimer=setTimeout(()=>{
+            devCopy.textContent=defaultLabel;
+            if(window.getSelection()?.rangeCount){ window.getSelection().removeAllRanges(); }
+          },1600);
+        });
+      }
 
       const prefRaw=localStorage.getItem('ff-guided-updates');
       let pref={enabled:false,email:''};
@@ -814,12 +1093,14 @@ ${n ? "\n**Analyst notes to incorporate:**\n"+n+"\n" : ""}
         updatesChk.checked=true;
         emailRow.style.display='flex';
         emailInput.value=pref.email||'';
+      }else{
+        emailRow.style.display='none';
       }
 
-      function savePref(newPref){
+      const savePref=newPref=>{
         pref={...pref,...newPref};
         localStorage.setItem('ff-guided-updates', JSON.stringify(pref));
-      }
+      };
 
       updatesChk.addEventListener('change',()=>{
         if(updatesChk.checked){
@@ -842,10 +1123,10 @@ ${n ? "\n**Analyst notes to incorporate:**\n"+n+"\n" : ""}
         emailHint.textContent=`Saved! We will send a digest to ${email}.`;
       });
 
-      function syncFab(){
+      const syncFab=()=>{
         if(!floating) return;
         floating.classList.toggle('hidden', active || overlay.classList.contains('active'));
-      }
+      };
 
       syncFab();
     }


### PR DESCRIPTION
## Summary
- add an animated mode chooser and assisted guidance UI to the planner, equity dashboard, and stock analyzer publisher helpers
- implement assisted walkthrough steps with field validation, focused inputs, and copyable developer debug snippets
- update guided scripts to support mode switching, clipboard integration, and persistent email preferences

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4f06e42e0832d96af63f2a80c7a02