### PR TITLE
Make site header sticky

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -50,8 +50,13 @@ a:hover{text-decoration:underline}
   justify-content:space-between;
   padding:1rem 2rem;
   border-bottom:1px solid #1a2147;
-  position:relative;
-  z-index:40;
+  position:sticky;
+  top:0;
+  width:100%;
+  background:rgba(11,16,32,.92);
+  background:color-mix(in srgb, var(--card) 88%, #050a1a 12%);
+  backdrop-filter:blur(10px);
+  z-index:60;
 }
 .site-footer{
   margin-top:auto;


### PR DESCRIPTION
## Summary
- keep the site header fixed to the top of the viewport with a sticky position
- add a subtle background and blur so content remains readable while scrolling

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e508f73710832da8974e5407ac118a