### PR TITLE
Fix gating overlay blocking planner interactions

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1497,10 +1497,17 @@ body.theme-light table.grid pre{
   background: linear-gradient(180deg, rgba(246,247,251,0) 50%, rgba(246,247,251,.75));
   backdrop-filter: blur(2px);
   border-radius: inherit;
-  pointer-events: all;
+  pointer-events: none;
+  z-index: 1;
+}
+[data-gated].is-gated > :not(.gate-cta){
+  pointer-events: none;
+  user-select: none;
 }
 [data-gated].is-gated .gate-cta{
   display:flex;
+  z-index: 2;
+  pointer-events: auto;
 }
 .gate-cta{
   position:absolute; inset:auto 0 0 0;


### PR DESCRIPTION
## Summary
- ensure the planner gating overlay no longer captures every click
- keep the membership call-to-action clickable while the planner remains locked for non-members

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e52933ca34832d8361f57b18ea0495